### PR TITLE
build: ship JSON Schema + slim `tvbo validate` off runtime linkml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ graphify-out
 # on merges or drifts from schema/tvbo_datamodel.yaml.
 tvbo/datamodel/schema.py
 tvbo/datamodel/pydantic.py
+tvbo/datamodel/tvbo_datamodel.schema.json
 
 # Build artifacts
 dist/

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -24,9 +24,19 @@ _NONDETERMINISTIC_PREFIX = "# Generation date:"
 
 
 def generate_datamodel(root: str | Path) -> None:
-    """Write ``tvbo/datamodel/{schema,pydantic}.py`` from ``schema/tvbo_datamodel.yaml``."""
+    """Write the generated datamodel from ``schema/tvbo_datamodel.yaml``:
+
+    * ``tvbo/datamodel/schema.py``                  — LinkML Python dataclasses,
+    * ``tvbo/datamodel/pydantic.py``                — Pydantic models,
+    * ``tvbo/datamodel/tvbo_datamodel.schema.json`` — JSON Schema for the
+      ``tvbo validate`` CLI (checked with the lightweight ``jsonschema`` lib, so
+      validation needs no runtime ``linkml``).
+    """
     # Imported lazily so this module is importable without `linkml` (the heavy,
     # build-time-only generator) — e.g. when hatchling merely inspects the hook.
+    import json
+
+    from linkml.generators.jsonschemagen import JsonSchemaGenerator
     from linkml.generators.pydanticgen import PydanticGenerator
     from linkml.generators.pythongen import PythonGenerator
 
@@ -41,6 +51,27 @@ def generate_datamodel(root: str | Path) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     _write(out_dir / "schema.py", PythonGenerator(str(schema)).serialize())
     _write(out_dir / "pydantic.py", PydanticGenerator(str(schema)).serialize())
+
+    # JSON Schema — relax `additionalProperties: false → true` everywhere so
+    # validation stays lenient, mirroring the previous
+    # `JsonschemaValidationPlugin(closed=False)`. `sort_keys` keeps it reproducible.
+    js = json.loads(JsonSchemaGenerator(str(schema)).serialize())
+    _relax_additional_properties(js)
+    (out_dir / "tvbo_datamodel.schema.json").write_text(
+        json.dumps(js, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _relax_additional_properties(node) -> None:
+    """Recursively rewrite ``additionalProperties: false`` → ``true`` (open validation)."""
+    if isinstance(node, dict):
+        if node.get("additionalProperties") is False:
+            node["additionalProperties"] = True
+        for value in node.values():
+            _relax_additional_properties(value)
+    elif isinstance(node, list):
+        for value in node:
+            _relax_additional_properties(value)
 
 
 def _write(target: Path, code: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,13 @@ dependencies = [
     "numpy>=2.0.0",
     "pandas>=2.2.3",
     "xarray>=2025.0",
-    # `linkml-runtime` is needed to *use* the generated datamodel at runtime. The
-    # heavy `linkml` generator toolkit is build-time only (see [build-system].requires);
-    # the `validate` CLI still needs it, hence the `validate` extra below.
+    # `linkml-runtime` is needed to *use* the generated datamodel at runtime; the
+    # heavy `linkml` generator toolkit is build-time only (see [build-system].requires).
     "linkml-runtime>=1.11.0",
+    # `jsonschema` backs `tvbo validate schema` (validates against the shipped JSON
+    # Schema — no runtime linkml). Also pulled transitively by linkml-runtime; declared
+    # explicitly because we import it directly.
+    "jsonschema>=4.0.0",
     "h5py>=3.12.1",
 
     # Ontologies
@@ -56,12 +59,6 @@ dependencies = [
 tvbo = "tvbo.cli:app"
 
 [project.optional-dependencies]
-# Structural YAML validation CLI (`tvbo validate schema`). It currently drives the
-# full `linkml` validator toolkit at runtime. TEMPORARY: this extra is removed once
-# `validate.py` validates against the shipped JSON Schema via the lightweight
-# `jsonschema` lib (follow-up PR), leaving `linkml` build-time only.
-validate = ["linkml>=1.11.0"]
-
 # NeuroML/LEMS support (pyNeuroML + LEMS engine)
 neuroml = ["PyLEMS>=0.6.7", "pyNeuroML>=0.7.0"]
 
@@ -161,7 +158,11 @@ include = ["tvbo/**"]
 # The generated datamodel is .gitignore'd, so hatchling's VCS-based file selection
 # would exclude it from the build. `artifacts` force-includes these build outputs
 # (produced by the hook above) into the wheel/sdist.
-artifacts = ["tvbo/datamodel/schema.py", "tvbo/datamodel/pydantic.py"]
+artifacts = [
+    "tvbo/datamodel/schema.py",
+    "tvbo/datamodel/pydantic.py",
+    "tvbo/datamodel/tvbo_datamodel.schema.json",
+]
 exclude = [
     "tvbo/database/networks/*.h5",
     "tvbo/data/tvbo_data/atlas/**/*.nii.gz",

--- a/tvbo/cli/validate.py
+++ b/tvbo/cli/validate.py
@@ -11,49 +11,57 @@ from . import _common
 app = typer.Typer(name="validate", no_args_is_help=True)
 
 
-@app.command("schema", help="LinkML structural validation of a YAML file.")
+@app.command("schema", help="Structural JSON Schema validation of a YAML file.")
 def schema(
     path: Path = typer.Argument(..., exists=True, readable=True, help="YAML file."),
     target_class: str = typer.Option(
         None, "--class",
-        help="LinkML target class (auto-detected from `class:` key when omitted).",
+        help="Target class (auto-detected from `class:` key when omitted).",
     ),
 ) -> None:
-    """Validate *path* against the LinkML schema; auto-detects target class from `class:` key."""
-    from linkml_runtime.loaders import yaml_loader
-    from linkml.validator import Validator
-    from linkml.validator.plugins import JsonschemaValidationPlugin
+    """Validate *path* against the shipped JSON Schema; auto-detects the target class.
 
-    # Locate the shipped schema
+    Uses the lightweight ``jsonschema`` library against the pre-generated
+    ``tvbo/datamodel/tvbo_datamodel.schema.json`` (produced from the LinkML schema at
+    build time), so validation needs no runtime ``linkml``. The file is parsed with
+    TVBO's loader so ``!include``/merge-key extensions and slot aliases resolve exactly
+    as they do when the model is loaded.
+    """
+    import json
+
+    import jsonschema
+
     import tvbo
-    schema_path = Path(tvbo.__file__).parent.parent / "schema" / "tvbo_datamodel.yaml"
-    if not schema_path.exists():
-        # Fall back to the installed copy under tvbo/datamodel
-        schema_path = Path(tvbo.__file__).parent / "datamodel" / "tvbo_datamodel.yaml"
-    if not schema_path.exists():
-        _common.die("Cannot locate tvbo_datamodel.yaml schema file.")
+    from tvbo.utils import yaml_loader
+
+    schema_json = Path(tvbo.__file__).parent / "datamodel" / "tvbo_datamodel.schema.json"
+    if not schema_json.exists():
+        _common.die(
+            f"Cannot locate the generated JSON Schema at {schema_json}. "
+            "Run `make gen-linkml` (or reinstall) to regenerate the datamodel."
+        )
+    full = json.loads(schema_json.read_text(encoding="utf-8"))
+    data = yaml_loader.load_as_dict(str(path))
 
     if target_class is None:
-        text = path.read_text(encoding="utf-8")
-        # Extremely lightweight detection — accept either explicit `class:`
-        # or fall back to common roots.
-        for line in text.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("class:"):
-                target_class = stripped.split(":", 1)[1].strip()
-                break
-        if target_class is None:
-            target_class = "SimulationExperiment"
+        target_class = (data.get("class") if isinstance(data, dict) else None) or "SimulationExperiment"
 
-    validator = Validator(
-        schema=str(schema_path),
-        validation_plugins=[JsonschemaValidationPlugin(closed=False)],
+    defs = full.get("$defs", {})
+    if target_class not in defs:
+        _common.die(f"Unknown target class '{target_class}' (not in the schema's $defs).")
+
+    # Validate the document as an instance of `target_class` via a $ref into $defs.
+    class_schema = {"$schema": full.get("$schema"), "$defs": defs, "$ref": f"#/$defs/{target_class}"}
+    validator_cls = jsonschema.validators.validator_for(class_schema)
+    errors = sorted(
+        validator_cls(class_schema).iter_errors(data),
+        key=lambda e: list(e.absolute_path),
     )
-    report = validator.validate_file(str(path), target_class=target_class)
-    if report.results:
-        for r in report.results:
-            typer.echo(f"  {r.severity}: {r.message}", err=True)
-        _common.die(f"{len(report.results)} validation issue(s) in {path}.")
+    if errors:
+        for e in errors:
+            loc = "/".join(str(p) for p in e.absolute_path) or "<root>"
+            typer.echo(f"  ERROR at {loc}: {e.message}", err=True)
+        _common.die(f"{len(errors)} validation issue(s) in {path}.")
     typer.echo(f"OK — {path} is a valid {target_class}.")
 
 


### PR DESCRIPTION
**Stacked on #44** (base = `chore/untrack-generated-datamodel`). Merge #44 first; GitHub will then auto-retarget this to `dev`.

## Why

#44 made `linkml` build-time only for codegen, but kept a temporary `validate` extra because `tvbo validate schema` still drove the full `linkml` validator toolkit at runtime. This removes that last runtime use, so **`linkml` is purely a build-time dependency** and `pip install tvbo` no longer pulls `sqlalchemy`, `pyshex`/`pyshexc`, `graphviz`, `sphinx-click`, `openpyxl`, …

## What

- **`hatch_build.py`** — also generates `tvbo/datamodel/tvbo_datamodel.schema.json`. Relaxes `additionalProperties: false → true` throughout so validation stays lenient, **mirroring the previous `JsonschemaValidationPlugin(closed=False)`**.
- **`tvbo/cli/validate.py`** — validates the TVBO-loaded document (so `!include`/merge-keys/aliases resolve) against the shipped JSON Schema via a `$ref` into `$defs/<target_class>`, using the lightweight **`jsonschema`** lib. No runtime `linkml`.
- **`pyproject.toml`** — drop the temporary `validate` extra; add **`jsonschema`** as an explicit runtime dep; ship the JSON Schema via `artifacts=`.
- **`.gitignore`** — untrack the generated JSON Schema.

## Verified locally

| Case | Result |
|---|---|
| valid experiment YAML | ✅ 0 errors (`OK — … is a valid SimulationExperiment`) |
| valid + unknown extra key | ✅ 0 errors — **`closed=False` parity preserved** |
| `label` set to a list (type error) | ✅ 1 error (structural errors still caught) |
| `validate.py` imports heavy `linkml`? | ✅ no |
| `uv build` | ✅ wheel ships `tvbo_datamodel.schema.json` |

**Bonus:** the old `linkml.validator` path actually **crashes** with `unhashable type: 'PresenceEnum'` after `import tvbo` (a known linkml/global-enum pollution bug) — the jsonschema-based validator sidesteps it entirely.

---

**Draft** until CI is green (same `docker.yml` wheel-build job as #44 is the authoritative check).
