### PR TITLE
fix(jax): wrap array-valued params so ReducedSet/mode models run on jax

### DIFF
--- a/tvbo/classes/experiment.py
+++ b/tvbo/classes/experiment.py
@@ -1384,6 +1384,12 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         )
         # Expand coupling parameters with shape annotations like "(N, N)" or "(N,)"
         self._expand_coupling_parameter_shapes(parameters)
+        # Wrap array-valued (per-mode) parameters as ndarrays so the JAX backend
+        # receives jnp arrays. Bare Python lists would survive convert_dtype's
+        # tree_map (which descends into the list and only converts the scalar
+        # elements, leaving a list[Array]) and then break `scalar * param`
+        # arithmetic in the generated dfun. Mirrors render_jax_default (tvboptim).
+        self._arrayify_parameter_values(parameters)
 
         state = SimulationState(
             initial_conditions=(initial_conditions if initial_conditions is not None else self.collect_initial_conditions()),
@@ -1434,6 +1440,32 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
                 # Expand scalar to N-vector
                 if np.isscalar(current_value) or (hasattr(current_value, "shape") and current_value.shape == ()):
                     coupling_params[param_name] = np.full((N,), float(current_value))
+
+    def _arrayify_parameter_values(self, parameters: Bunch) -> None:
+        """Convert list/tuple-valued parameters in the collection to ``np.array``.
+
+        Array-valued constants (e.g. the Stefanescu-Jirsa per-mode coupling
+        vectors/matrices) arrive as nested Python lists from the metadata. The
+        JAX backend evaluates the dfun with these values as ``_p`` leaves, and
+        ``scalar * list`` raises ``TypeError`` under JAX. Wrapping them as
+        ndarrays makes ``SimulationState.convert_dtype`` emit real ``jnp`` arrays
+        (an ndarray is a single pytree leaf, whereas a list is traversed
+        element-wise). Recurses through the nested ``dynamics``/``coupling``
+        Bunches; scalars and existing arrays are left untouched.
+        """
+        from tvbo.utils import is_array_valued
+
+        def _walk(container):
+            for key, value in list(container.items()):
+                if isinstance(value, dict):
+                    _walk(value)
+                elif is_array_valued(value) and not isinstance(value, np.ndarray):
+                    try:
+                        container[key] = np.asarray(value)
+                    except (TypeError, ValueError):
+                        pass
+
+        _walk(parameters)
 
     def execute(self, format="tvb", **kwargs):
         # Ensure coupling resolution / delay flags are normalized before any


### PR DESCRIPTION
## Why

The JAX backend passed array-valued (per-mode) model parameters to the generated `dfun` as Python **lists**, so `param * ArrayImpl` raised `TypeError: unsupported operand type(s) for *: 'list' and 'ArrayImpl'` for the multi-mode models. `SimulationState.convert_dtype`'s `tree_map` descends into the list and converts only the *scalar elements*, leaving a `list[Array]` — which JAX arithmetic then rejects.

This is a **pre-existing `dev` bug** (surfaced by CI as `test_run_jax[ReducedSetHindmarshRose]`; reproduces on plain `dev`).

## Fix

`_arrayify_parameter_values()` in `experiment.py` — at parameter-collection time, wraps list/tuple-valued params (via `is_array_valued`) as `np.array`, so `convert_dtype` emits real `jnp` arrays (a single pytree leaf). Recurses through nested `dynamics`/`coupling`; scalars and existing arrays are untouched. Mirrors tvboptim's `render_jax_default`, kept in the Python layer per the resolve-in-Python convention. **One file, +32 lines.**

## Verified (`test_run_jax`)

| | |
|---|---|
| `ReducedSetHindmarshRose` (the CI failure) | ✅ now passes |
| `ReducedSetFitzHughNagumo`, `StefanescuJirsa2D`, `StefanescuJirsa3D` | ✅ pass |
| 15 non-mode models (Generic2dOscillator, Jansen1995, ReducedWongWang, Kuramoto, Linear, …) | ✅ unaffected |

## Out of scope
`EpileptorCodim3SlowMod` still fails on jax — but with a **separate, pre-existing** error (`Cannot concatenate arrays with different numbers of dimensions`, a shape-broadcast issue in that model), which reproduces identically on `dev` and is unrelated to this change.

---
**Draft** until CI is green. Independent of PRs #44/#45.
