### PR TITLE
data: migrate function arguments to keyed dict (completes keyed-access refactor)

### DIFF
--- a/tvbo/database/experiments/EI_Tuning_FIC_EIB_Optimization.yaml
+++ b/tvbo/database/experiments/EI_Tuning_FIC_EIB_Optimization.yaml
@@ -285,7 +285,7 @@ functions:
           value: 0.4
           description: "Feedback time constant (seconds)"
     arguments:
-      - name: duration
+      duration:
         value: 20000.0
         description: "HRF kernel duration in ms"
 
@@ -296,9 +296,9 @@ functions:
       TemporalAverage exactly.
     source_code: "jax.vmap(lambda _i: jnp.mean(jax.lax.dynamic_slice(data, (_i,) + (0,) * (data.ndim - 1), (period_samples,) + data.shape[1:]), axis=0))((jnp.arange(data.shape[0]) + 1)[::period_samples])[: jnp.arange((period_samples - 2) // 2, data.shape[0], period_samples).shape[0]]"
     arguments:
-      - name: data
+      data:
         description: "Input time series (time, nodes)"
-      - name: period_samples
+      period_samples:
         value: 1
         description: "Samples per window = round(downsample_period / dt)"
 
@@ -308,11 +308,11 @@ functions:
       zero-padding at the front when shorter — matches HRFBold._process_history.
     source_code: "jnp.concatenate([(jnp.vstack([jnp.zeros((kernel_samples - history.shape[0],) + history.shape[1:], history.dtype), history]) if history.shape[0] < kernel_samples else history[-kernel_samples:]), data], axis=0)"
     arguments:
-      - name: data
+      data:
         description: "Downsampled input time series"
-      - name: history
+      history:
         description: "Downsampled transient history data"
-      - name: kernel_samples
+      kernel_samples:
         value: 5000
         description: "Kernel support = ceil(kernel_duration / downsample_period)"
 
@@ -331,7 +331,7 @@ functions:
           value: 0.02
           description: "Resting blood volume fraction"
     arguments:
-      - name: data
+      data:
         description: "Input neural activity data"
 
   subsample_bold:
@@ -340,11 +340,10 @@ functions:
       first full TR (index 0, the zero-padded warm-up, is skipped), uncapped.
     source_code: "data[s::s]"
     arguments:
-      - name: data
+      data:
         description: "Input time series (T x n)"
-      - name: s
+      s:
         value: 180
-        description: "Subsample factor = round(TR / downsample_period) = 720/4 = 180"
         description: "Subsample factor (TR/dt = 720/4 = 180)"
 
   rmse:
@@ -357,11 +356,11 @@ functions:
       rhs: sqrt(Sum((a[i,j] - b[i,j])**2, (j, 0, m-1)) / m)
       description: "RMSE_i = sqrt(1/m * sum_j((a_ij - b_ij)^2))"
     arguments:
-      - name: a
+      a:
         description: "First matrix (n x m)"
-      - name: b
+      b:
         description: "Second matrix (n x m)"
-      - name: m
+      m:
         description: "Number of columns (for normalization)"
 
   correlation:
@@ -372,11 +371,11 @@ functions:
       rhs: Sum((x[t] - mean(x))*(y[t] - mean(y)), (t, 0, T-1)) / (sqrt(Sum((x[t] - mean(x))**2, (t, 0, T-1))) * sqrt(Sum((y[t] - mean(y))**2, (t, 0, T-1))))
       description: "ρ = Σ_t(x_t - x̄)(y_t - ȳ) / (σ_x * σ_y)"
     arguments:
-      - name: x
+      x:
         description: "First vector (length T)"
-      - name: y
+      y:
         description: "Second vector (length T)"
-      - name: T
+      T:
         description: "Vector length"
 
   fc_corr:
@@ -384,13 +383,12 @@ functions:
       Correlation between two FC matrices (flattened).
       Measures similarity between predicted and target functional connectivity.
     equation:
-      rhs: Sum((A[i,j] - mean(A))*(B[i,j] - mean(B)), (i, 0, N_nodes-1), (j, 0, N_nodes-1)) / (sqrt(Sum((A[i,j] - mean(A))**2, (i, 0, N_nodes-1), (j, 0, N_nodes-1))) * sqrt(Sum((B[i,j] - mean(B))**2,
-        (i, 0, N_nodes-1), (j, 0, N_nodes-1))))
+      rhs: Sum((A[i,j] - mean(A))*(B[i,j] - mean(B)), (i, 0, N_nodes-1), (j, 0, N_nodes-1)) / (sqrt(Sum((A[i,j] - mean(A))**2, (i, 0, N_nodes-1), (j, 0, N_nodes-1))) * sqrt(Sum((B[i,j] - mean(B))**2, (i, 0, N_nodes-1), (j, 0, N_nodes-1))))
       description: "ρ(A, B) = correlation between flattened matrices"
     arguments:
-      - name: A
+      A:
         description: "First FC matrix (N_nodes x N_nodes)"
-      - name: B
+      B:
         description: "Second FC matrix (N_nodes x N_nodes)"
 
   fc_rmse:
@@ -401,9 +399,9 @@ functions:
       rhs: sqrt(Sum((A[i,j] - B[i,j])**2, (i, 0, N_nodes-1), (j, 0, N_nodes-1)) / (N_nodes*N_nodes))
       description: "RMSE(A, B) = sqrt(mean((A - B)^2))"
     arguments:
-      - name: A
+      A:
         description: "First FC matrix (N_nodes x N_nodes)"
-      - name: B
+      B:
         description: "Second FC matrix (N_nodes x N_nodes)"
 
   compute_fc:
@@ -415,13 +413,13 @@ functions:
       rhs: Sum((X[t,i] - mean_i)*(X[t,j] - mean_j), (t, 0, T-1)) / (sqrt(Sum((X[t,i] - mean_i)**2, (t, 0, T-1))) * sqrt(Sum((X[t,j] - mean_j)**2, (t, 0, T-1))))
       description: "FC[i,j] = ρ(X[:,i], X[:,j]) with FC[i,i] = 0"
     arguments:
-      - name: X
+      X:
         description: "Time series matrix (T x n) - time by nodes"
-      - name: T
+      T:
         description: "Number of time points"
-      - name: mean_i
+      mean_i:
         description: "Mean of time series at node i: (1/T)*Σ_t X[t,i]"
-      - name: mean_j
+      mean_j:
         description: "Mean of time series at node j: (1/T)*Σ_t X[t,j]"
 
   mean_activity:
@@ -432,9 +430,9 @@ functions:
       rhs: Sum(X[t,i], (t, 0, T-1)) / T
       description: "mean_i = (1/T) * Σ_t X[t,i]"
     arguments:
-      - name: X
+      X:
         description: "Time series data (T x n) for one state variable"
-      - name: T
+      T:
         description: "Number of time points"
 
   FIC_update_rule:
@@ -447,16 +445,16 @@ functions:
       rhs: J_i[k] + eta * mean_S_i[k] * (mean_S_e[k] - target)
       description: "J_i[k] += η * S_i[k] * (S_e[k] - target)"
     arguments:
-      - name: J_i
+      J_i:
         description: "Current inhibitory weights (per node)"
-      - name: mean_S_e
+      mean_S_e:
         description: "Mean excitatory activity (per node)"
-      - name: mean_S_i
+      mean_S_i:
         description: "Mean inhibitory activity (per node)"
-      - name: eta
+      eta:
         value: 0.1
         description: "FIC learning rate"
-      - name: target
+      target:
         value: 0.25
         description: "Target excitatory activity"
 
@@ -469,13 +467,13 @@ functions:
       rhs: wLRE[i,k] + eta * (fc_target[i,k] - fc[i,k]) * sqrt(Sum((fc_target[i,j] - fc[i,j])**2, (j, 0, N_nodes-1)) / N_nodes)
       description: "wLRE[i,k] += η * (T[i,k] - P[i,k]) * RMSE_i"
     arguments:
-      - name: wLRE
+      wLRE:
         description: "Current LRE weights matrix (N_nodes x N_nodes)"
-      - name: fc_target
+      fc_target:
         description: "Target FC matrix (N_nodes x N_nodes)"
-      - name: fc
+      fc:
         description: "Predicted FC matrix (N_nodes x N_nodes)"
-      - name: eta
+      eta:
         value: 0.005
         description: "EIB learning rate"
 
@@ -488,13 +486,13 @@ functions:
       rhs: wFFI[i,k] - eta * (fc_target[i,k] - fc[i,k]) * sqrt(Sum((fc_target[i,j] - fc[i,j])**2, (j, 0, N_nodes-1)) / N_nodes)
       description: "wFFI[i,k] -= η * (T[i,k] - P[i,k]) * RMSE_i"
     arguments:
-      - name: wFFI
+      wFFI:
         description: "Current FFI weights matrix (N_nodes x N_nodes)"
-      - name: fc_target
+      fc_target:
         description: "Target FC matrix (N_nodes x N_nodes)"
-      - name: fc
+      fc:
         description: "Predicted FC matrix (N_nodes x N_nodes)"
-      - name: eta
+      eta:
         value: 0.005
         description: "EIB learning rate"
 
@@ -508,13 +506,13 @@ functions:
       rhs: sqrt(Sum((fc_pred[i,j] - fc_target[i,j])**2, (i, 0, N_nodes-1), (j, 0, N_nodes-1)) / (N_nodes*N_nodes)) + Sum((mean_activity[k] - target_activity)**2, (k, 0, N_nodes-1)) / N_nodes
       description: "L = RMSE(FC) + MSE(activity deviation)"
     arguments:
-      - name: fc_pred
+      fc_pred:
         description: "Predicted FC matrix (N_nodes x N_nodes)"
-      - name: fc_target
+      fc_target:
         description: "Target empirical FC matrix (N_nodes x N_nodes)"
-      - name: mean_activity
+      mean_activity:
         description: "Mean excitatory activity per region (N_nodes,)"
-      - name: target_activity
+      target_activity:
         value: 0.25
         description: "Target excitatory activity for FIC"
 
@@ -535,26 +533,26 @@ observations:
       - output: downsampled_data
         function: temporal_average
         arguments:
-          - name: data
+          data:
             value: integration.result
-          - name: period_samples
+          period_samples:
             value: 1
       - output: downsampled_history
         function: temporal_average
         arguments:
-          - name: data
+          data:
             value: integration.transient
-          - name: period_samples
+          period_samples:
             value: 1
 
             # Prepend transient history (zero-padded to one kernel length)
       - function: prepend_history
         arguments:
-          - name: data
+          data:
             value: downsampled_data
-          - name: history
+          history:
             value: downsampled_history
-          - name: kernel_samples
+          kernel_samples:
             value: 5000
 
             # Convolve with HRF kernel
@@ -565,23 +563,23 @@ observations:
           name: fftconvolve
         apply_on_dimension: node
         arguments:
-          - name: in1
+          in1:
             value: prepend_history
-          - name: in2
+          in2:
             value: hrf_kernel
-          - name: mode
+          mode:
             value: valid
 
             # Volterra transform: k_1 * V_0 * (bold - 1.0)
       - function: volterra_transform
         arguments:
-          - name: data
+          data:
             value: bold_convolve
 
             # Subsample to BOLD TR (720ms / 4ms = 180)
       - function: subsample_bold
         arguments:
-          - name: data
+          data:
             value: volterra_transform
 
   mean_S_e:
@@ -618,9 +616,9 @@ observations:
           name: compute_fc
           module: tvboptim.observations.observation
         arguments:
-          - name: timeseries
+          timeseries:
             value: bold
-          - name: skip_t
+          skip_t:
             value: 20
             description: "Skip first 20 TRs for transient removal in post-tuning"
 
@@ -634,9 +632,9 @@ observations:
           name: compute_fc
           module: tvboptim.observations.observation
         arguments:
-          - name: timeseries
+          timeseries:
             value: bold
-          - name: skip_t
+          skip_t:
             value: 0
             description: "No skip for in-loop FC (sliding window already handles transient)"
 
@@ -650,9 +648,9 @@ observations:
           name: compute_fc
           module: tvboptim.observations.observation
         arguments:
-          - name: timeseries
+          timeseries:
             value: bold
-          - name: skip_t
+          skip_t:
             value: 30
             description: "Skip first 30 TRs as in original gradient optimization"
 
@@ -667,9 +665,9 @@ observations:
           name: fc_corr
           module: tvboptim.observations.observation
         arguments:
-          - name: A
+          A:
             value: fc
-          - name: B
+          B:
             value: fc_target
 
   fc_rmse:
@@ -683,9 +681,9 @@ observations:
           name: rmse
           module: tvboptim.observations.observation
         arguments:
-          - name: A
+          A:
             value: fc
-          - name: B
+          B:
             value: fc_target
 
 # =============================================================================
@@ -774,15 +772,15 @@ algorithms:
     functions:
       - function: fc_corr
         arguments:
-          - name: A
+          A:
             value: fc_inloop
-          - name: B
+          B:
             value: fc_target
       - function: fc_rmse
         arguments:
-          - name: A
+          A:
             value: fc_inloop
-          - name: B
+          B:
             value: fc_target
     hyperparameters:
       - name: eta
@@ -813,29 +811,29 @@ optimizations:
     loss:
       function: combined_loss
       arguments:
-        - name: fc_pred
+        fc_pred:
           value: observations.fc_gradient.data
           description: "Predicted functional connectivity from simulation (skip_t=30)"
-        - name: fc_target
+        fc_target:
           value: observations.fc_target.data
           description: "Empirical functional connectivity matrix from network observations"
-        - name: mean_activity
+        mean_activity:
           value: observations.mean_S_e_final.data
           description: "Mean excitatory activity over final 500 timesteps"
-        - name: target_activity
+        target_activity:
           value: 0.25
           description: "Target excitatory activity for FIC"
 
     free_parameters:
-          - parameter: ReducedWongWangEIB.J_i
-            heterogeneous: true
-            shape: "(n_nodes,)"
-          - parameter: ReducedWongWangEIB.wLRE
-            heterogeneous: true
-            shape: "(n_nodes, n_nodes)"
-          - parameter: ReducedWongWangEIB.wFFI
-            heterogeneous: true
-            shape: "(n_nodes, n_nodes)"
+      - parameter: ReducedWongWangEIB.J_i
+        heterogeneous: true
+        shape: "(n_nodes,)"
+      - parameter: ReducedWongWangEIB.wLRE
+        heterogeneous: true
+        shape: "(n_nodes, n_nodes)"
+      - parameter: ReducedWongWangEIB.wFFI
+        heterogeneous: true
+        shape: "(n_nodes, n_nodes)"
 
     algorithm: adamaxw
     learning_rate: 0.033
@@ -855,5 +853,4 @@ execution:
 references:
   - "Schirner, M., Deco, G., & Ritter, P. (2023). Learning how network structure shapes decision-making for bio-inspired computing. Nature Communications, 14(1), Article 1."
   - "Wong, K.-F., & Wang, X.-J. (2006). A recurrent network mechanism of time integration in perceptual decisions. J Neurosci, 26:1314-1328."
-  - "Deco, G., Ponce-Alvarez, A., Mantini, D., Romani, G.L., Hagmann, P., & Corbetta, M. (2013). Resting-state functional connectivity emerges from structurally and dynamically shaped slow linear fluctuations.
-    J Neurosci, 33(27):11239-11252."
+  - "Deco, G., Ponce-Alvarez, A., Mantini, D., Romani, G.L., Hagmann, P., & Corbetta, M. (2013). Resting-state functional connectivity emerges from structurally and dynamically shaped slow linear fluctuations. J Neurosci, 33(27):11239-11252."

--- a/tvbo/database/experiments/JR_MEG_FrequencyGradient_Optimization.yaml
+++ b/tvbo/database/experiments/JR_MEG_FrequencyGradient_Optimization.yaml
@@ -187,9 +187,9 @@ functions:
     description: "Downsample array by step factor"
     source_code: "data[::step]"
     arguments:
-      - name: data
+      data:
         description: "Input array"
-      - name: step
+      step:
         value: 10
         description: "Downsample factor (1ms * 10 = 10ms period = 100 Hz)"
 
@@ -198,9 +198,9 @@ functions:
     description: "Index into array at given position"
     source_code: "arr[idx]"
     arguments:
-      - name: arr
+      arr:
         description: "Input array"
-      - name: idx
+      idx:
         description: "Index position"
 
     # Mathematical functions (equation-based)
@@ -211,12 +211,12 @@ functions:
       rhs: "f_max - (f_max - f_min) * (d - min(d)) / (max(d) - min(d))"
       definition: "Linear mapping from distance to frequency: f_max at visual cortex, f_min at maximum distance"
     arguments:
-      - name: d
+      d:
         description: "Distance array from visual cortex for each region"
-      - name: f_min
+      f_min:
         value: 7.0
         description: "Minimum frequency at max distance [Hz]"
-      - name: f_max
+      f_max:
         value: 11.0
         description: "Maximum frequency at visual cortex [Hz]"
 
@@ -227,11 +227,11 @@ functions:
       rhs: "1 / (pi * gamma * (1 + ((x - x0) / gamma)**2))"
       definition: "Cauchy-Lorentz distribution centered at x0 with scale gamma"
     arguments:
-      - name: x
+      x:
         description: "Input values (frequency axis)"
-      - name: x0
+      x0:
         description: "Peak location for each region (target frequencies)"
-      - name: gamma
+      gamma:
         value: 1.0
         description: "Scale parameter (half-width at half-maximum)"
 
@@ -242,9 +242,9 @@ functions:
       rhs: "Sum((x[i] - mean(x)) * (y[i] - mean(y)), (i, 0, n-1)) / sqrt(Sum((x[i] - mean(x))**2, (i, 0, n-1)) * Sum((y[i] - mean(y))**2, (i, 0, n-1)))"
       definition: "Pearson product-moment correlation coefficient"
     arguments:
-      - name: x
+      x:
         description: "First array"
-      - name: y
+      y:
         description: "Second array"
 
   spectral_loss:
@@ -253,9 +253,9 @@ functions:
     equation:
       rhs: "1 - correlation(simulated, target)"
     arguments:
-      - name: simulated
+      simulated:
         description: "Simulated power spectrum for one region"
-      - name: target
+      target:
         description: "Target power spectrum for one region"
 
 # =============================================================================
@@ -273,7 +273,7 @@ observations:
     pipeline:
       - function: subsample
         arguments:
-          - name: data
+          data:
             value: integration.result
             description: "Input time series from simulation"
       - callable:
@@ -281,7 +281,7 @@ observations:
           name: transpose
         output: transposed
         arguments:
-          - name: a
+          a:
             value: subsample
             description: "Subsampled time series"
       - callable:
@@ -289,13 +289,13 @@ observations:
           name: welch
         output: frequencies, psd
         arguments:
-          - name: x
+          x:
             value: transposed
             description: "Transposed time series (nodes, time)"
-          - name: fs
+          fs:
             value: 100.0
             description: "Sampling frequency (Hz)"
-          - name: nperseg
+          nperseg:
             value: 256
             description: "Segment length for Welch"
 
@@ -313,10 +313,10 @@ observations:
           name: mean
         output: avg_psd
         arguments:
-          - name: a
+          a:
             value: simulated_psd.psd
             description: "Power spectrum from simulated_psd observation"
-          - name: axis
+          axis:
             value: 0
             description: "Average over regions dimension"
 
@@ -332,10 +332,10 @@ observations:
           name: argmax
         output: peak_indices
         arguments:
-          - name: a
+          a:
             value: simulated_psd.psd
             description: "PSD array (regions, 1, frequencies)"
-          - name: axis
+          axis:
             value: -1
             description: "Find max along frequency axis"
       - callable:
@@ -343,15 +343,15 @@ observations:
           name: squeeze
         output: peak_indices_squeezed
         arguments:
-          - name: a
+          a:
             value: peak_indices
       - function: index_at
         output: peak_frequencies
         arguments:
-          - name: arr
+          arr:
             value: simulated_psd.frequencies
             description: "Frequency array from PSD"
-          - name: idx
+          idx:
             value: peak_indices_squeezed
             description: "Indices of peak frequencies per region"
 
@@ -368,15 +368,15 @@ observations:
           name: argmax
         output: peak_idx
         arguments:
-          - name: a
+          a:
             value: avg_spectrum
             description: "Average power spectrum (output of jnp.mean)"
       - function: index_at
         arguments:
-          - name: arr
+          arr:
             value: simulated_psd.frequencies
             description: "Frequency array from PSD"
-          - name: idx
+          idx:
             value: peak_idx
             description: "Index of peak frequency"
 
@@ -407,10 +407,10 @@ optimizations:
         over: node
         type: mean
       arguments:
-        - name: simulated
+        simulated:
           value: observations.simulated_psd.psd
           description: "Simulated power spectrum from observation (n_regions, n_freqs)"
-        - name: target
+        target:
           description: "Target power spectrum (passed to optimizer at runtime)"
 
       # Optimizer configuration

--- a/tvbo/database/experiments/RWW_BOLD_FC_Optimization.yaml
+++ b/tvbo/database/experiments/RWW_BOLD_FC_Optimization.yaml
@@ -138,9 +138,9 @@ functions:
       clamped dynamic slice, and the output is trimmed to the centered-index count.
     source_code: "jax.vmap(lambda _i: jnp.mean(jax.lax.dynamic_slice(data, (_i,) + (0,) * (data.ndim - 1), (period_samples,) + data.shape[1:]), axis=0))((jnp.arange(data.shape[0]) + 1)[::period_samples])[: jnp.arange((period_samples - 2) // 2, data.shape[0], period_samples).shape[0]]"
     arguments:
-      - name: data
+      data:
         description: "Input time series (time, nodes)"
-      - name: period_samples
+      period_samples:
         value: 1
         description: "Samples per averaging window = round(downsample_period / dt)"
 
@@ -160,7 +160,7 @@ functions:
           value: 0.4
           description: "Feedback time constant (seconds)"
     arguments:
-      - name: duration
+      duration:
         value: 20000.0
         description: "HRF kernel duration in ms"
 
@@ -172,11 +172,11 @@ functions:
       tvboptim HRFBold._process_history so a 'valid' convolution loses no samples.
     source_code: "jnp.concatenate([(jnp.vstack([jnp.zeros((kernel_samples - history.shape[0],) + history.shape[1:], history.dtype), history]) if history.shape[0] < kernel_samples else history[-kernel_samples:]), data], axis=0)"
     arguments:
-      - name: data
+      data:
         description: "Input time series (time, nodes)"
-      - name: history
+      history:
         description: "Downsampled transient history data"
-      - name: kernel_samples
+      kernel_samples:
         value: 5000
         description: "Kernel support = ceil(kernel_duration / downsample_period)"
 
@@ -192,7 +192,7 @@ functions:
           value: 0.02
           description: "Resting blood volume fraction"
     arguments:
-      - name: data
+      data:
         description: "Input data from previous step"
 
   subsample_bold:
@@ -204,9 +204,9 @@ functions:
       downsampling.
     source_code: "data[step::step]"
     arguments:
-      - name: data
+      data:
         description: "Input time series"
-      - name: step
+      step:
         value: 250
         description: "Subsample factor = round(TR / downsample_period) = 1000/4 = 250"
 
@@ -215,9 +215,9 @@ functions:
     equation:
       rhs: "sqrt(mean((x - y)**2))"
     arguments:
-      - name: x
+      x:
         description: "First array (simulated)"
-      - name: y
+      y:
         description: "Second array (target)"
 
   fc_corr:
@@ -245,26 +245,26 @@ observations:
       - output: downsampled_data
         function: temporal_average
         arguments:
-          - name: data
+          data:
             value: integration.result
-          - name: period_samples
+          period_samples:
             value: 1
 
       - output: downsampled_history
         function: temporal_average
         arguments:
-          - name: data
+          data:
             value: integration.transient
-          - name: period_samples
+          period_samples:
             value: 1
 
       - function: prepend_history
         arguments:
-          - name: data
+          data:
             value: downsampled_data
-          - name: history
+          history:
             value: downsampled_history
-          - name: kernel_samples
+          kernel_samples:
             value: 5000
 
       - output: bold_convolve
@@ -273,21 +273,21 @@ observations:
           name: fftconvolve
         apply_on_dimension: node
         arguments:
-          - name: in1
+          in1:
             value: prepend_history
-          - name: in2
+          in2:
             value: hrf_kernel
-          - name: mode
+          mode:
             value: valid
 
       - function: volterra_transform
         arguments:
-          - name: data
+          data:
             value: bold_convolve
 
       - function: subsample_bold
         arguments:
-          - name: data
+          data:
             value: volterra_transform
 
   # === Derived observations (computed from other observations) ===
@@ -301,9 +301,9 @@ observations:
           name: compute_fc
           module: tvboptim.observations.observation
         arguments:
-          - name: timeseries
+          timeseries:
             value: bold
-          - name: skip_t
+          skip_t:
             value: 20
             description: "Skip first 20 TRs to avoid transient effects"
 
@@ -321,10 +321,10 @@ optimizations:
     loss:
       function: rmse
       arguments:
-        - name: simulated_fc
+        simulated_fc:
           value: observations.fc.data
           description: "Simulated functional connectivity matrix from fc observation"
-        - name: empirical_fc
+        empirical_fc:
           value: observations.empirical_fc.data
           description: "Empirical functional connectivity matrix (target, passed at runtime)"
 
@@ -389,9 +389,9 @@ explorations:
     observable:
       function: rmse
       arguments:
-        - name: simulated_fc
+        simulated_fc:
           value: fc.data
-        - name: empirical_fc
+        empirical_fc:
           value: empirical_fc.data
           description: "Target FC (passed at runtime)"
 

--- a/tvbo/database/experiments/TBPTT_JansenRit_FC_Optimization.yaml
+++ b/tvbo/database/experiments/TBPTT_JansenRit_FC_Optimization.yaml
@@ -134,23 +134,20 @@ functions:
         tau_s: {value: 0.8}
         tau_f: {value: 0.4}
     arguments:
-      - {name: duration, value: 20000.0}
-
+      duration: {value: 20000.0}
   temporal_average:
     description: "Centered window-average downsample (reproduces HRFBold TemporalAverage)"
     source_code: "jax.vmap(lambda _i: jnp.mean(jax.lax.dynamic_slice(data, (_i,) + (0,) * (data.ndim - 1), (period_samples,) + data.shape[1:]), axis=0))((jnp.arange(data.shape[0]) + 1)[::period_samples])[: jnp.arange((period_samples - 2) // 2, data.shape[0], period_samples).shape[0]]"
     arguments:
-      - {name: data}
-      - {name: period_samples, value: 4}   # round(downsample_period 4 / dt 1)
-
+      data: {}
+      period_samples: {value: 4}
   prepend_history:
     description: "Zero-pad transient history to one kernel length and prepend"
     source_code: "jnp.concatenate([(jnp.vstack([jnp.zeros((kernel_samples - history.shape[0],) + history.shape[1:], history.dtype), history]) if history.shape[0] < kernel_samples else history[-kernel_samples:]), data], axis=0)"
     arguments:
-      - {name: data}
-      - {name: history}
-      - {name: kernel_samples, value: 5000}   # ceil(20000 / 4)
-
+      data: {}
+      history: {}
+      kernel_samples: {value: 5000}
   volterra_transform:
     description: "Volterra BOLD nonlinearity"
     equation:
@@ -159,26 +156,20 @@ functions:
         k_1: {value: 5.6}
         V_0: {value: 0.02}
     arguments:
-      - {name: data}
-
+      data: {}
   subsample_bold:
     description: "Sample at end of each BOLD TR (anchored, uncapped)"
     source_code: "data[step::step]"
     arguments:
-      - {name: data}
-      - {name: step, value: 180}   # round(TR 720 / downsample_period 4)
-
+      data: {}
+      step: {value: 180}
   rmse:
     description: "Root mean squared error"
     equation:
       rhs: "sqrt(mean((x - y)**2))"
     arguments:
-      - {name: x}
-      - {name: y}
-
-# =============================================================================
-# OBSERVATIONS
-# =============================================================================
+      x: {}
+      y: {}
 observations:
   empirical_fc:
     label: "Empirical Functional Connectivity"
@@ -193,41 +184,39 @@ observations:
       - output: downsampled_data
         function: temporal_average
         arguments:
-          - {name: data, value: integration.result}
-          - {name: period_samples, value: 4}
+          data: {value: integration.result}
+          period_samples: {value: 4}
       - output: downsampled_history
         function: temporal_average
         arguments:
-          - {name: data, value: integration.transient}
-          - {name: period_samples, value: 4}
+          data: {value: integration.transient}
+          period_samples: {value: 4}
       - function: prepend_history
         arguments:
-          - {name: data, value: downsampled_data}
-          - {name: history, value: downsampled_history}
-          - {name: kernel_samples, value: 5000}
+          data: {value: downsampled_data}
+          history: {value: downsampled_history}
+          kernel_samples: {value: 5000}
       - output: bold_convolve
         callable: {module: jax.scipy.signal, name: fftconvolve}
         apply_on_dimension: node
         arguments:
-          - {name: in1, value: prepend_history}
-          - {name: in2, value: hrf_kernel}
-          - {name: mode, value: valid}
+          in1: {value: prepend_history}
+          in2: {value: hrf_kernel}
+          mode: {value: valid}
       - function: volterra_transform
         arguments:
-          - {name: data, value: bold_convolve}
+          data: {value: bold_convolve}
       - function: subsample_bold
         arguments:
-          - {name: data, value: volterra_transform}
-
+          data: {value: volterra_transform}
   fc:
     label: "Simulated Functional Connectivity"
     source: [bold]
     pipeline:
       - callable: {name: compute_fc, module: tvboptim.observations.observation}
         arguments:
-          - {name: timeseries, value: bold}
-          - {name: skip_t, value: 25}
-
+          timeseries: {value: bold}
+          skip_t: {value: 25}
   loss:
     label: "FC-RMSE loss"
     description: "RMSE between simulated and empirical FC (the optimization/diagnostic objective)"
@@ -235,9 +224,8 @@ observations:
     pipeline:
       - function: rmse
         arguments:
-          - {name: x, value: fc}
-          - {name: y, value: empirical_fc}
-
+          x: {value: fc}
+          y: {value: empirical_fc}
   lyapunov:
     label: "Top Lyapunov exponent"
     description: "Largest Lyapunov exponent on a short segment (marks the chaos onset)"
@@ -290,8 +278,8 @@ optimizations:
     loss:
       function: rmse
       arguments:
-        - {name: x, value: observations.fc.data}
-        - {name: y, value: observations.empirical_fc.data}
+        x: {value: observations.fc.data}
+        y: {value: observations.empirical_fc.data}
     stages:
       - name: fit
         label: "Fit G"
@@ -318,9 +306,8 @@ explorations:
     observable:
       function: rmse
       arguments:
-        - {name: x, value: fc.data}
-        - {name: y, value: empirical_fc.data}
-
+        x: {value: fc.data}
+        y: {value: empirical_fc.data}
   motivation_sweep:
     label: "Diagnostics vs G (the motivation sweep)"
     description: >

--- a/tvbo/database/models/Jansen1995.yaml
+++ b/tvbo/database/models/Jansen1995.yaml
@@ -14,12 +14,12 @@ parameters:
   C:
     value: 135
     explored_values:
-    - 68
-    - 128
-    - 135
-    - 270
-    - 675
-    - 1350
+      - 68
+      - 128
+      - 135
+      - 270
+      - 675
+      - 1350
   a:
     value: 0.1
     unit: per_ms
@@ -62,7 +62,7 @@ functions:
   Sigm:
     definition: "JR sigmoid transformation"
     arguments:
-    - name: v
+      v: {}
     equation:
       rhs: 2*e0 / (1 + exp(r*(v0 - v)))
 coupling_inputs:

--- a/tvbo/database/models/JansenRit1995.yaml
+++ b/tvbo/database/models/JansenRit1995.yaml
@@ -112,7 +112,7 @@ functions:
   Sigm:
     definition: "Sigmoid potential-to-firing-rate transformation (Eq. 3)"
     arguments:
-    - name: v
+      v: {}
     equation:
       rhs: 2*e0 / (1 + exp(r*(v0 - v)))
 

--- a/tvbo/database/models/ReducedWongWangFunc.yml
+++ b/tvbo/database/models/ReducedWongWangFunc.yml
@@ -74,7 +74,7 @@ functions:
   H:
     definition: Sigmoid input-output function of the synaptic input current that computes the averaged firing rate of the neurons population (Deco et al., 2013).
     arguments:
-    - name: x
+      x: {}
     equation:
       rhs: (a*x - b)/(1 - exp(-d*(a*x - b)))
 derived_variables:

--- a/tvbo/database/models/ReducedWongWangTvboptim.yaml
+++ b/tvbo/database/models/ReducedWongWangTvboptim.yaml
@@ -18,8 +18,8 @@ description: >-
   global coupling strength G (a coupling parameter) scales the structural connectivity
   weights that modulate inter-regional communication.
 references:
-- Wong2006
-- Deco2013
+  - Wong2006
+  - Deco2013
 parameters:
   a:
     definition: Input gain parameter of the sigmoid transfer function H(x).
@@ -125,7 +125,7 @@ functions:
       Sigmoid transfer function mapping total synaptic input current to the
       average population firing rate (Deco et al., 2013).
     arguments:
-    - name: x
+      x: {}
     equation:
       rhs: (a*x - b)/(1 - exp(-d*(a*x - b)))
 coupling_inputs:

--- a/tvbo/database/models/ZerlautAdaptationSecondOrder.yaml
+++ b/tvbo/database/models/ZerlautAdaptationSecondOrder.yaml
@@ -16,8 +16,8 @@ description: >-
   stencil (df = 1e-7) used in the original TVB implementation, so the drift is
   reproduced bit-for-bit.
 references:
-- Zerlaut2018
-- DiVolo2018
+  - Zerlaut2018
+  - DiVolo2018
 parameters:
   g_L:
     definition: Leak conductance.
@@ -446,12 +446,12 @@ functions:
       given pre-synaptic excitatory/inhibitory rates (fe, fi), external drives
       (fe_ext, fi_ext), adaptation W and leak reversal E_leak.
     arguments:
-    - name: fe
-    - name: fi
-    - name: fe_ext
-    - name: fi_ext
-    - name: W
-    - name: E_leak
+      fe: {}
+      fi: {}
+      fe_ext: {}
+      fi_ext: {}
+      W: {}
+      E_leak: {}
     equation:
       lhs: muV
       rhs: >-
@@ -467,12 +467,12 @@ functions:
       Standard deviation of the membrane-potential fluctuations (Eqn 8 in
       di Volo 2018).
     arguments:
-    - name: fe
-    - name: fi
-    - name: fe_ext
-    - name: fi_ext
-    - name: W
-    - name: E_leak
+      fe: {}
+      fi: {}
+      fe_ext: {}
+      fi_ext: {}
+      W: {}
+      E_leak: {}
     equation:
       lhs: sigmaV
       rhs: >-
@@ -492,12 +492,12 @@ functions:
       Autocorrelation time of the membrane-potential fluctuations (Eqn 9 in
       di Volo 2018).
     arguments:
-    - name: fe
-    - name: fi
-    - name: fe_ext
-    - name: fi_ext
-    - name: W
-    - name: E_leak
+      fe: {}
+      fi: {}
+      fe_ext: {}
+      fi_ext: {}
+      W: {}
+      E_leak: {}
     equation:
       lhs: T_V
       rhs: >-
@@ -516,11 +516,11 @@ functions:
       semi-analytic firing-rate output given the fluctuation regime and the
       excitatory phenomenological voltage threshold.
     arguments:
-    - name: fe
-    - name: fi
-    - name: fe_ext
-    - name: fi_ext
-    - name: W
+      fe: {}
+      fi: {}
+      fe_ext: {}
+      fi_ext: {}
+      W: {}
     equation:
       lhs: TF_e
       rhs: >-
@@ -545,11 +545,11 @@ functions:
       semi-analytic firing-rate output given the fluctuation regime and the
       inhibitory phenomenological voltage threshold.
     arguments:
-    - name: fe
-    - name: fi
-    - name: fe_ext
-    - name: fi_ext
-    - name: W
+      fe: {}
+      fi: {}
+      fe_ext: {}
+      fi_ext: {}
+      W: {}
     equation:
       lhs: TF_i
       rhs: >-

--- a/tvbo/database/observation_models/FC.yaml
+++ b/tvbo/database/observation_models/FC.yaml
@@ -38,17 +38,17 @@ pipeline:
       equation:
           rhs: "bandpass(X, low_freq, high_freq, fs)"
       arguments:
-          - name: low_freq
-            value: 0.01
-            unit: Hz
-            description: "Low frequency cutoff"
-          - name: high_freq
-            value: 0.1
-            unit: Hz
-            description: "High frequency cutoff"
-          - name: order
-            value: 2
-            description: "Filter order"
+          low_freq:
+              value: 0.01
+              unit: Hz
+              description: "Low frequency cutoff"
+          high_freq:
+              value: 0.1
+              unit: Hz
+              description: "High frequency cutoff"
+          order:
+              value: 2
+              description: "Filter order"
       apply_on_dimension: time
 
     # Function 2: Z-score normalization per region
@@ -61,9 +61,9 @@ pipeline:
       equation:
           rhs: "(X - mean(X)) / std(X)"
       arguments:
-          - name: axis
-            value: 0
-            description: "Normalize along time axis"
+          axis:
+              value: 0
+              description: "Normalize along time axis"
       apply_on_dimension: time
 
     # Function 3: Compute Pearson correlation matrix
@@ -76,9 +76,9 @@ pipeline:
       equation:
           rhs: "corrcoef(transpose(X))"
       arguments:
-          - name: rowvar
-            value: false
-            description: "Each column represents a variable (region)"
+          rowvar:
+              value: false
+              description: "Each column represents a variable (region)"
 
     # Function 4: Fisher z-transformation (optional)
     - name: fisher_z_transform
@@ -94,6 +94,6 @@ pipeline:
                   value: 0.999
                   description: "Clip correlations to avoid infinity at r=±1"
       arguments:
-          - name: apply
-            value: true
-            description: "Whether to apply Fisher z-transformation"
+          apply:
+              value: true
+              description: "Whether to apply Fisher z-transformation"

--- a/tvbo/database/observation_models/afferent_coupling_temporal_average.yaml
+++ b/tvbo/database/observation_models/afferent_coupling_temporal_average.yaml
@@ -19,6 +19,6 @@ pipeline:
       equation:
           rhs: "window_mean(X, window_size)"
       arguments:
-          - name: window_size
-            description: "Number of integration steps per averaging window = period / dt"
+          window_size:
+              description: "Number of integration steps per averaging window = period / dt"
       apply_on_dimension: time

--- a/tvbo/database/observation_models/bold_double_exponential.yaml
+++ b/tvbo/database/observation_models/bold_double_exponential.yaml
@@ -28,8 +28,8 @@ pipeline:
       equation:
           rhs: "window_mean(X, stepsize)"
       arguments:
-          - name: stepsize
-            value: 1
+          stepsize:
+              value: 1
       apply_on_dimension: time
 
     - name: hemodynamic_response
@@ -53,12 +53,12 @@ pipeline:
                   value: 9.5
                   unit: s
       arguments:
-          - name: duration
-            value: 20
-            unit: s
-          - name: stock_dt
-            value: 0.004
-            unit: s
+          duration:
+              value: 20
+              unit: s
+          stock_dt:
+              value: 0.004
+              unit: s
 
     - name: convolve
       input: temporal_average_interim
@@ -67,10 +67,10 @@ pipeline:
           module: scipy.signal
           name: fftconvolve
       arguments:
-          - name: in2
-            value: hrf_kernel
-          - name: mode
-            value: same
+          in2:
+              value: hrf_kernel
+          mode:
+              value: same
 
     - name: subsample_to_period
       input: convolve
@@ -78,6 +78,6 @@ pipeline:
       equation:
           rhs: "subsample(X, stepsize)"
       arguments:
-          - name: stepsize
-            description: "TR / dt"
+          stepsize:
+              description: "TR / dt"
       apply_on_dimension: time

--- a/tvbo/database/observation_models/bold_gamma.yaml
+++ b/tvbo/database/observation_models/bold_gamma.yaml
@@ -28,8 +28,8 @@ pipeline:
       equation:
           rhs: "window_mean(X, stepsize)"
       arguments:
-          - name: stepsize
-            value: 1
+          stepsize:
+              value: 1
       apply_on_dimension: time
 
     - name: hemodynamic_response
@@ -48,12 +48,12 @@ pipeline:
               var:
                   value: 1.5
       arguments:
-          - name: duration
-            value: 20
-            unit: s
-          - name: stock_dt
-            value: 0.004
-            unit: s
+          duration:
+              value: 20
+              unit: s
+          stock_dt:
+              value: 0.004
+              unit: s
 
     - name: convolve
       input: temporal_average_interim
@@ -62,10 +62,10 @@ pipeline:
           module: scipy.signal
           name: fftconvolve
       arguments:
-          - name: in2
-            value: hrf_kernel
-          - name: mode
-            value: same
+          in2:
+              value: hrf_kernel
+          mode:
+              value: same
 
     - name: subsample_to_period
       input: convolve
@@ -73,6 +73,6 @@ pipeline:
       equation:
           rhs: "subsample(X, stepsize)"
       arguments:
-          - name: stepsize
-            description: "TR / dt"
+          stepsize:
+              description: "TR / dt"
       apply_on_dimension: time

--- a/tvbo/database/observation_models/bold_mixture_of_gammas.yaml
+++ b/tvbo/database/observation_models/bold_mixture_of_gammas.yaml
@@ -29,8 +29,8 @@ pipeline:
       equation:
           rhs: "window_mean(X, stepsize)"
       arguments:
-          - name: stepsize
-            value: 1
+          stepsize:
+              value: 1
       apply_on_dimension: time
 
     - name: hemodynamic_response
@@ -59,12 +59,12 @@ pipeline:
               d2:
                   value: 16.0
       arguments:
-          - name: duration
-            value: 20
-            unit: s
-          - name: stock_dt
-            value: 0.004
-            unit: s
+          duration:
+              value: 20
+              unit: s
+          stock_dt:
+              value: 0.004
+              unit: s
 
     - name: convolve
       input: temporal_average_interim
@@ -73,10 +73,10 @@ pipeline:
           module: scipy.signal
           name: fftconvolve
       arguments:
-          - name: in2
-            value: hrf_kernel
-          - name: mode
-            value: same
+          in2:
+              value: hrf_kernel
+          mode:
+              value: same
 
     - name: subsample_to_period
       input: convolve
@@ -84,6 +84,6 @@ pipeline:
       equation:
           rhs: "subsample(X, stepsize)"
       arguments:
-          - name: stepsize
-            description: "TR / dt"
+          stepsize:
+              description: "TR / dt"
       apply_on_dimension: time

--- a/tvbo/database/observation_models/bold_region_roi.yaml
+++ b/tvbo/database/observation_models/bold_region_roi.yaml
@@ -31,8 +31,8 @@ pipeline:
       equation:
           rhs: "window_mean(X, window)"
       arguments:
-          - name: window
-            value: 1
+          window:
+              value: 1
       apply_on_dimension: time
 
     - name: hemodynamic_response
@@ -52,12 +52,12 @@ pipeline:
                   value: 0.4
                   unit: s
       arguments:
-          - name: duration
-            value: 20
-            unit: s
-          - name: stock_dt
-            value: 0.004
-            unit: s
+          duration:
+              value: 20
+              unit: s
+          stock_dt:
+              value: 0.004
+              unit: s
 
     - name: convolve
       input: temporal_average_interim
@@ -66,10 +66,10 @@ pipeline:
           module: scipy.signal
           name: fftconvolve
       arguments:
-          - name: in2
-            value: hrf_kernel
-          - name: mode
-            value: same
+          in2:
+              value: hrf_kernel
+          mode:
+              value: same
 
     - name: subsample_to_period
       input: convolve
@@ -77,8 +77,8 @@ pipeline:
       equation:
           rhs: "subsample(X, step)"
       arguments:
-          - name: step
-            description: "Subsample factor"
+          step:
+              description: "Subsample factor"
       apply_on_dimension: time
 
     - name: volterra_transform
@@ -101,6 +101,6 @@ pipeline:
       equation:
           rhs: "spatial_mean @ X"
       arguments:
-          - name: spatial_mean
-            description: "Region averaging matrix (n_regions, n_sources)"
+          spatial_mean:
+              description: "Region averaging matrix (n_regions, n_sources)"
       apply_on_dimension: node

--- a/tvbo/database/observation_models/bold_tvb.yaml
+++ b/tvbo/database/observation_models/bold_tvb.yaml
@@ -31,9 +31,9 @@ pipeline:
       equation:
           rhs: "window_mean(X, stepsize)"
       arguments:
-          - name: stepsize
-            value: 1
-            description: "Interim averaging window (1 = no averaging)"
+          stepsize:
+              value: 1
+              description: "Interim averaging window (1 = no averaging)"
       apply_on_dimension: time
 
     - name: hemodynamic_response
@@ -53,12 +53,12 @@ pipeline:
                   value: 0.8
                   unit: s
       arguments:
-          - name: duration
-            value: 20
-            unit: s
-          - name: stock_dt
-            value: 0.004
-            unit: s
+          duration:
+              value: 20
+              unit: s
+          stock_dt:
+              value: 0.004
+              unit: s
 
     - name: convolve
       input: temporal_average_interim
@@ -67,10 +67,10 @@ pipeline:
           module: scipy.signal
           name: fftconvolve
       arguments:
-          - name: in2
-            value: hrf_kernel
-          - name: mode
-            value: same
+          in2:
+              value: hrf_kernel
+          mode:
+              value: same
 
     - name: subsample_to_period
       input: convolve
@@ -78,9 +78,9 @@ pipeline:
       equation:
           rhs: "subsample(X, stepsize)"
       arguments:
-          - name: stepsize
-            value: 180
-            description: "TR / dt"
+          stepsize:
+              value: 180
+              description: "TR / dt"
       apply_on_dimension: time
 
     - name: volterra_transform

--- a/tvbo/database/observation_models/eeg.yaml
+++ b/tvbo/database/observation_models/eeg.yaml
@@ -57,20 +57,20 @@ pipeline:
                   value: 1.0
                   unit: S_per_m
       arguments:
-          - name: Q
-            description: "Source dipole moment orientations (n_sources, 3)"
-          - name: a
-            description: "Source-to-sensor vectors: r_sensor - r_source (n_sources, 3)"
+          Q:
+              description: "Source dipole moment orientations (n_sources, 3)"
+          a:
+              description: "Source-to-sensor vectors: r_sensor - r_source (n_sources, 3)"
 
     - name: lead_field_projection
       output: projected
       equation:
           rhs: "gain @ sum(X, axis=-1) / period_steps"
       arguments:
-          - name: gain
-            description: "Lead field matrix (n_sensors, n_sources)"
-          - name: period_steps
-            description: "Number of integration steps per sampling period"
+          gain:
+              description: "Lead field matrix (n_sensors, n_sources)"
+          period_steps:
+              description: "Number of integration steps per sampling period"
       apply_on_dimension: node
 
     - name: rereference

--- a/tvbo/database/observation_models/ieeg.yaml
+++ b/tvbo/database/observation_models/ieeg.yaml
@@ -46,20 +46,20 @@ pipeline:
                   value: 1.0
                   unit: S_per_m
       arguments:
-          - name: Q
-            description: "Source dipole orientations (n_sources, 3)"
-          - name: a
-            description: "Source-to-electrode vectors (n_sources, 3)"
+          Q:
+              description: "Source dipole orientations (n_sources, 3)"
+          a:
+              description: "Source-to-electrode vectors (n_sources, 3)"
 
     - name: lead_field_projection
       output: projected
       equation:
           rhs: "gain @ sum(X, axis=-1) / period_steps"
       arguments:
-          - name: gain
-            description: "Lead field matrix (n_sensors, n_sources)"
-          - name: period_steps
-            description: "Number of integration steps per sampling period"
+          gain:
+              description: "Lead field matrix (n_sensors, n_sources)"
+          period_steps:
+              description: "Number of integration steps per sampling period"
       apply_on_dimension: node
 
     - name: add_noise
@@ -68,5 +68,5 @@ pipeline:
       equation:
           rhs: "X + noise"
       arguments:
-          - name: noise
-            description: "Observation noise (n_sensors, 1)"
+          noise:
+              description: "Observation noise (n_sensors, 1)"

--- a/tvbo/database/observation_models/meg.yaml
+++ b/tvbo/database/observation_models/meg.yaml
@@ -42,22 +42,22 @@ pipeline:
                   value: 1.25663706e-6
                   unit: H_per_m
       arguments:
-          - name: Q
-            description: "Source dipole orientations (n_sources, 3)"
-          - name: r_0
-            description: "Source dipole positions (n_sources, 3)"
-          - name: r_s
-            description: "Sensor positions (n_sensors, 3)"
+          Q:
+              description: "Source dipole orientations (n_sources, 3)"
+          r_0:
+              description: "Source dipole positions (n_sources, 3)"
+          r_s:
+              description: "Sensor positions (n_sensors, 3)"
 
     - name: lead_field_projection
       output: projected
       equation:
           rhs: "gain @ sum(X, axis=-1) / period_steps"
       arguments:
-          - name: gain
-            description: "Lead field matrix (n_sensors, n_sources)"
-          - name: period_steps
-            description: "Number of integration steps per sampling period"
+          gain:
+              description: "Lead field matrix (n_sensors, n_sources)"
+          period_steps:
+              description: "Number of integration steps per sampling period"
       apply_on_dimension: node
 
     - name: add_noise
@@ -66,5 +66,5 @@ pipeline:
       equation:
           rhs: "X + noise"
       arguments:
-          - name: noise
-            description: "Observation noise (n_sensors, 1)"
+          noise:
+              description: "Observation noise (n_sensors, 1)"

--- a/tvbo/database/observation_models/spatial_average.yaml
+++ b/tvbo/database/observation_models/spatial_average.yaml
@@ -28,8 +28,8 @@ pipeline:
       equation:
           rhs: "spatial_mean @ X"
       arguments:
-          - name: spatial_mean
-            description: >-
-                Region averaging matrix (n_regions, n_nodes). M[r, j] = 1/n_r
-                if node j belongs to region r, else 0.
+          spatial_mean:
+              description: >-
+                  Region averaging matrix (n_regions, n_nodes). M[r, j] = 1/n_r
+                  if node j belongs to region r, else 0.
       apply_on_dimension: node

--- a/tvbo/database/observation_models/subsample.yaml
+++ b/tvbo/database/observation_models/subsample.yaml
@@ -18,6 +18,6 @@ pipeline:
       equation:
           rhs: "subsample(X, step)"
       arguments:
-          - name: step
-            description: "Decimation factor = period / dt"
+          step:
+              description: "Decimation factor = period / dt"
       apply_on_dimension: time

--- a/tvbo/database/observation_models/temporal_average.yaml
+++ b/tvbo/database/observation_models/temporal_average.yaml
@@ -18,6 +18,6 @@ pipeline:
       equation:
           rhs: "window_mean(X, window_size)"
       arguments:
-          - name: window_size
-            description: "Number of integration steps per averaging window = period / dt"
+          window_size:
+              description: "Number of integration steps per averaging window = period / dt"
       apply_on_dimension: time


### PR DESCRIPTION
Completes the argument-handling keyed-access refactor (0fb61d70/163b17d0): 22 DB YAMLs still used list-form function `arguments`, failing schema validation. Converts them to keyed dicts (algorithm includes/stages args left as lists), fixes a duplicate `description:` in EI_Tuning. **test_database_validation: 428 passed** (was 22 failing); all load at runtime. Greens the Schema-validation CI job on dev.