### PR TITLE
fix(jax): broadcast dfun derivatives (fixes EpileptorCodim3SlowMod shape bug)

### DIFF
--- a/tvbo/templates/base/dfun.mako
+++ b/tvbo/templates/base/dfun.mako
@@ -97,7 +97,10 @@ np = np_module(fmt)
 d${sv.name}_dt = ${render(sv)}${(' + ' + stim) if stim and getattr(sv, 'stimulation_variable', False) else ''}
 % endfor
 
-derivatives = ${np}.array([${', '.join('d' + sv.name + '_dt' for sv in svars)}])
+## broadcast_arrays so state-independent derivatives (e.g. `duA_dt = cA`, a bare
+## constant/param → scalar shape) stack cleanly with state-/coupling-dependent
+## ones (broadcast to the node/mode shape). No-op when all shapes already match.
+derivatives = ${np}.array(${np}.broadcast_arrays(${', '.join('d' + sv.name + '_dt' for sv in svars)}))
 % if return_aux and dvars:
 auxiliaries = ${np}.array([${', '.join(dvars)}])
 


### PR DESCRIPTION
The jax/autodiff dfun assembled `derivatives = jnp.array([d1, d2, ...])` without broadcasting. Models with a **state-independent** derivative (EpileptorCodim3SlowMod: `duA_dt = cA`, `duB_dt = cB` — bare constants → scalar shape) mixed with state/coupling-dependent ones (broadcast to node/mode shape) failed: `Cannot concatenate arrays with different numbers of dimensions: (1,1,1) vs (1,)`. Fix: wrap the assembly in `broadcast_arrays` in `base/dfun.mako` — no-op when shapes match, broadcasts constants to the field shape otherwise. **Mirrors the tvboptim dfun** (the model already passes there). Verified: `test_run_jax[EpileptorCodim3SlowMod]` passes; Generic2dOscillator/ReducedSetHindmarshRose/Jansen1995 unaffected.