### PR TITLE
feat(resolution): field-level iri enrichment (YAML supervenes)

### DIFF
--- a/tests/test_metadata_resolution.py
+++ b/tests/test_metadata_resolution.py
@@ -1,0 +1,120 @@
+"""Uniform metadata resolution: 3 routes, YAML supervenes, field-level enrich.
+
+Covers the ``iri``-sourced-with-inline-override contract:
+- a spec referenced by ``iri`` is filled from the registry entry it points to;
+- inline metadata supervenes at the *leaf* (override only ``parameters.a.value``,
+  keep every sibling parameter and the equations from the source);
+- this holds for the top-level ``dynamics`` slot, the keyed ``network.dynamics``
+  entries, and a directly-constructed ``Dynamics`` / ``Coupling``.
+"""
+import pytest
+
+from tvbo.utils import deep_merge
+
+
+# --------------------------------------------------------------------------- #
+# deep_merge (the field-level precedence engine)
+# --------------------------------------------------------------------------- #
+def test_deep_merge_leaf_override_keeps_siblings():
+    base = {"parameters": {"a": {"value": 0, "unit": "mV"}, "b": {"value": 2}}}
+    override = {"parameters": {"a": {"value": 1}}}
+    out = deep_merge(base, override)
+    assert out["parameters"]["a"]["value"] == 1      # leaf overridden
+    assert out["parameters"]["a"]["unit"] == "mV"    # sibling field kept
+    assert out["parameters"]["b"]["value"] == 2      # sibling param kept
+
+
+def test_deep_merge_does_not_mutate_inputs():
+    base = {"x": {"y": 1}}
+    override = {"x": {"z": 2}}
+    deep_merge(base, override)
+    assert base == {"x": {"y": 1}}
+    assert override == {"x": {"z": 2}}
+
+
+# --------------------------------------------------------------------------- #
+# Dynamics
+# --------------------------------------------------------------------------- #
+def test_dynamics_iri_only_full_population():
+    from tvbo import Dynamics
+
+    d = Dynamics(iri="tvbo:Generic2dOscillator")
+    assert d.name == "Generic2dOscillator"
+    assert len(d.parameters) == 12
+    assert len(d.state_variables) == 2
+
+
+def test_dynamics_iri_with_partial_override():
+    from tvbo import Dynamics
+
+    d = Dynamics(iri="tvbo:Generic2dOscillator", parameters={"a": {"value": 7}})
+    assert d.parameters["a"].value == 7          # inline wins
+    assert d.parameters["b"].value == -10.0      # sibling from registry
+    assert len(d.parameters) == 12               # all siblings kept
+    assert len(d.state_variables) == 2           # equations from registry
+
+
+def test_dynamics_from_db_backcompat():
+    from tvbo import Dynamics
+
+    d = Dynamics.from_db("JansenRit")
+    assert d.name == "JansenRit"
+    assert len(d.parameters) >= 10
+
+
+# --------------------------------------------------------------------------- #
+# SimulationExperiment — top-level dynamics + keyed network.dynamics
+# --------------------------------------------------------------------------- #
+def _exp(**net):
+    from tvbo import SimulationExperiment
+
+    return SimulationExperiment(
+        coupling={"iri": "tvbo:Linear"},
+        integration={"method": "Heun", "noise": None},
+        **net,
+    )
+
+
+def test_experiment_top_level_dynamics_override():
+    exp = _exp(dynamics={"iri": "tvbo:Generic2dOscillator",
+                         "parameters": {"a": {"value": 1}}})
+    assert exp.dynamics.name == "Generic2dOscillator"
+    assert exp.dynamics.parameters["a"].value == 1
+    assert exp.dynamics.parameters["b"].value == -10.0
+    assert len(exp.dynamics.parameters) == 12
+
+
+def test_experiment_network_dynamics_keyed_override():
+    exp = _exp(network={"number_of_nodes": 2,
+                        "dynamics": {"g2d": {"iri": "tvbo:Generic2dOscillator",
+                                             "parameters": {"a": {"value": 1}}}}})
+    g2d = exp.network.dynamics["g2d"]
+    assert g2d.name == "g2d"                     # keyed identifier preserved
+    assert str(g2d.iri) == "tvbo:Generic2dOscillator"
+    assert g2d.parameters["a"].value == 1        # inline wins
+    assert g2d.parameters["b"].value == -10.0    # sibling from registry
+    assert len(g2d.parameters) == 12
+
+
+# --------------------------------------------------------------------------- #
+# Coupling — iri resolves by CURIE local name (regression: was defaulting)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("curie,expected", [
+    ("tvbo:Linear", "Linear"),
+    ("tvbo:Sigmoidal", "Sigmoidal"),
+    ("tvbo:KuramotoCoupling", "KuramotoCoupling"),
+])
+def test_coupling_iri_resolves_by_local_name(curie, expected):
+    from tvbo.classes.coupling import Coupling
+
+    c = Coupling(iri=curie)
+    assert c.name == expected
+    assert c.pre_expression is not None
+
+
+def test_coupling_explicit_name_preserved():
+    from tvbo.classes.coupling import Coupling
+
+    c = Coupling(name="MyCustom", iri="tvbo:Sigmoidal")
+    assert c.name == "MyCustom"                  # explicit name wins
+    assert len(c.parameters) == 5                # but params from Sigmoidal

--- a/tvbo/classes/coupling.py
+++ b/tvbo/classes/coupling.py
@@ -160,10 +160,18 @@ class Coupling(tvbo_datamodel.Coupling):
     def __init__(self, **kwargs):
         # Legacy: accept and ignore use_ontology kwarg
         kwargs.pop("use_ontology", None)
+        _explicit_name = kwargs.get("name")
         super().__init__(**kwargs)
-        # Auto-populate from ontology if iri is set and expressions are missing
+        # Auto-populate from the registry/ontology if iri is set and expressions
+        # are missing. Resolve by the iri's CURIE local name (not the default
+        # self.name), and adopt it as the name when none was given explicitly.
         if getattr(self, "iri", None) and not getattr(self, "pre_expression", None):
-            self._populate_from_ontology()
+            from tvbo.data.registry import local_name
+
+            _local = local_name(self.iri)
+            if not _explicit_name:
+                self.name = _local
+            self._populate_from_ontology(lookup_name=_local)
 
     def _populate_from_ontology(self, lookup_name=None):
         """Fill missing metadata fields from ontology/database.

--- a/tvbo/classes/dynamics.py
+++ b/tvbo/classes/dynamics.py
@@ -760,15 +760,19 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
         **kwargs,
     ):
         iri = kwargs.get("iri")
-        if iri and (name is None or name == "Dynamics") and "parameters" not in kwargs:
-            local = iri.split(":", 1)[-1] if ":" in iri else iri
+        if iri and (name is None or name == "Dynamics"):
+            from tvbo.data.registry import resolve, local_name
+            from tvbo.utils import deep_merge
+
+            local = local_name(iri)
             try:
-                from tvbo.data.registry import resolve
-                yaml_path = resolve("Dynamics", local)
-                loaded = yaml_loader.load_as_dict(str(yaml_path))
+                loaded = yaml_loader.load_as_dict(str(resolve("Dynamics", local)))
                 _resolve_dynamics_aliases(loaded)
-                for key, value in loaded.items():
-                    kwargs.setdefault(key, value)
+                # Registry entry is the base; inline kwargs override at the leaf
+                # (e.g. parameters.a.value wins, siblings kept from the entry).
+                merged = deep_merge(loaded, kwargs)
+                kwargs.clear()
+                kwargs.update(merged)
                 name = kwargs.pop("name", local)
                 _skip_ontology = True
             except (FileNotFoundError, RuntimeError):

--- a/tvbo/classes/experiment.py
+++ b/tvbo/classes/experiment.py
@@ -166,21 +166,27 @@ def _backfill_name_from_iri(d):
 
 
 def _merge_from_registry(d, category: str):
-    """If d is a dict with iri but no parameters, load the registry YAML and
-    merge (user-provided keys win). Falls back to name-only backfill if the
-    iri does not resolve to a DB entry."""
+    """Enrich an ``iri``-referenced spec from the registry, inline values winning.
+
+    If ``d`` is a dict carrying an ``iri`` CURIE, load the registry entry it
+    points to and deep-merge the inline dict on top: inline values supervene at
+    the *leaf* (e.g. ``parameters: {a: {value: 1}}`` overrides only ``a.value``
+    and keeps every other parameter from the registry entry), while the entry
+    fills everything ``d`` did not specify. Mutates ``d`` in place. Falls back to
+    a name-only backfill if the ``iri`` does not resolve to a DB entry.
+    """
     if not isinstance(d, dict) or not d.get("iri"):
         return
-    iri = d["iri"]
-    local = _iri_local(iri)
+    local = _iri_local(d["iri"])
     try:
         from tvbo.data.registry import resolve
-        from tvbo.utils import yaml_loader
+        from tvbo.utils import yaml_loader, deep_merge
 
         loaded = yaml_loader.load_as_dict(str(resolve(category, local)))
         if isinstance(loaded, dict):
-            for k, v in loaded.items():
-                d.setdefault(k, v)
+            merged = deep_merge(loaded, d)  # registry = base, inline `d` overrides
+            d.clear()
+            d.update(merged)
             return
     except (FileNotFoundError, RuntimeError, ValueError):
         pass
@@ -278,16 +284,23 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
 
             _resolve_dynamics_aliases(dyn_kw)
 
-        # Also resolve aliases in network.dynamics entries
+        # Also resolve aliases and iri-source the keyed network.dynamics entries
+        # (per-node dynamics), symmetrically with the top-level `dynamics` slot.
         net_kw = kwargs.get("network")
         if isinstance(net_kw, dict):
             net_dyn = net_kw.get("dynamics")
             if isinstance(net_dyn, dict):
                 from tvbo.classes.dynamics import _resolve_dynamics_aliases
 
-                for _dv in net_dyn.values():
+                for _key, _dv in net_dyn.items():
                     if isinstance(_dv, dict):
                         _resolve_dynamics_aliases(_dv)
+                        if _dv.get("iri"):
+                            _merge_from_registry(_dv, "Dynamics")
+                            # Keyed collection: the population key is the
+                            # identifier, so it stays the `name` (model identity
+                            # is carried on `iri`).
+                            _dv["name"] = _key
 
         # Resolve iri-only refs by loading from the registry (full population
         # for dynamics/coupling) or backfilling name (for parcellation/tractogram).

--- a/tvbo/cli/_workflow.py
+++ b/tvbo/cli/_workflow.py
@@ -280,13 +280,4 @@ def _as_plain_dict(obj) -> dict[str, Any]:
     return {}
 
 
-def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-    if not override:
-        return dict(base)
-    out = dict(base)
-    for k, v in override.items():
-        if isinstance(v, dict) and isinstance(out.get(k), dict):
-            out[k] = _deep_merge(out[k], v)
-        else:
-            out[k] = v
-    return out
+from tvbo.utils import deep_merge as _deep_merge  # noqa: E402  (shared recursive merge)

--- a/tvbo/cli/workflow.py
+++ b/tvbo/cli/workflow.py
@@ -103,16 +103,7 @@ def _build_plan(spec: str, *, engine: str, backend: str,
     return plan, exp
 
 
-def _deep_merge(a: dict, b: dict) -> dict:
-    if not b:
-        return dict(a)
-    out = dict(a)
-    for k, v in b.items():
-        if isinstance(v, dict) and isinstance(out.get(k), dict):
-            out[k] = _deep_merge(out[k], v)
-        else:
-            out[k] = v
-    return out
+from tvbo.utils import deep_merge as _deep_merge  # noqa: E402  (shared recursive merge)
 
 
 def _render_template(rel: str, **ctx) -> str:

--- a/tvbo/utils/__init__.py
+++ b/tvbo/utils/__init__.py
@@ -59,6 +59,30 @@ def is_array_valued(value) -> bool:
     return isinstance(value, (list, tuple, np.ndarray))
 
 
+def deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge ``override`` onto ``base``, returning a new dict.
+
+    Nested dicts are merged key-by-key, so an override can replace a single leaf
+    while inheriting its siblings from ``base`` — e.g. ``{parameters: {a: {value:
+    1}}}`` overrides only ``a.value`` and keeps every other parameter from
+    ``base``. Any key whose two sides are not both dicts is taken from
+    ``override``. Neither input is mutated.
+
+    This is the field-level precedence used when a spec sourced by ``iri`` is
+    refined by inline metadata: the inline value supervenes and the source
+    (registry entry / ontology default) fills the gaps.
+    """
+    out = dict(base)
+    if not override:
+        return out
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
 # Backward-compatible re-exports (moved to tvbo.plot.utils)
 def __getattr__(name):
     _plot_names = {


### PR DESCRIPTION
## What

A uniform metadata-resolution contract for `iri`-sourced specs. Three routes are supported — **from ontology**, **from YAML/metadata** (default), **from YAML enriched by ontology** — and by default **YAML supervenes**: the ontology/registry only fills what you did not specify, and enrichment is opt-in (triggered by `iri` / `use_ontology`).

This adds the missing **field-level (recursive) merge** so an inline override wins at the leaf while inheriting siblings:

```python
dynamics = {"iri": "tvbo:Generic2dOscillator", "parameters": {"a": {"value": 1}}}
# -> a.value = 1 (inline); a.domain/description + b,c,d... + equations from the registry entry
```

## Changes

- **`tvbo/utils.deep_merge`** — one shared recursive merge (consolidates the two duplicate `_deep_merge` copies in the CLI).
- **`experiment._merge_from_registry`** — deep-merge registry entry (base) with the inline dict (override) instead of shallow top-key `setdefault`, so inline `parameters` no longer drop their siblings.
- **keyed `network.dynamics`** — same iri resolution (previously got neither backfill nor enrichment); the population key stays the `name`, model identity is carried on `iri`.
- **`Dynamics.__init__`** iri path — same deep-merge (drops the coarse `"parameters" not in kwargs` guard).
- **`Coupling.__init__`** — resolve `iri` by its CURIE local name (was defaulting to `self.name` -> `Linear` for every iri; `Coupling(iri="tvbo:Sigmoidal")` wrongly populated as Linear).

## Tests

`tests/test_metadata_resolution.py` (11): `deep_merge`, all three entry points (top-level `dynamics`, keyed `network.dynamics`, direct `Dynamics`/`Coupling`), back-compat (`from_db`, iri-only), and the Coupling-iri regression. Also green: 22-model network run + 112 experiment/dynamics/model-loading basics.

## Follow-up (tracked)

The structural dedup — collapsing the per-class `from_db`/`from_file`/`list_db` boilerplate into a single `MetadataResolvable` mixin — is a separate, non-behavioral refactor left for a follow-up.
