### PR TITLE
fix(tvboptim): aggregation observations return raw array, not NativeSolution

### DIFF
--- a/tvbo/templates/tvboptim/tvbo-tvboptim-observation.py.mako
+++ b/tvbo/templates/tvboptim/tvbo-tvboptim-observation.py.mako
@@ -1046,13 +1046,21 @@ class ${class_name}(AbstractMonitor):
 % if tail_samples:
         ${decl_input} = ${decl_input}[-${tail_samples}:]
 % endif
+% if aggregation:
+        # Track whether a collapsing aggregation removed the time axis. A future
+        # aggregation only needs to set this flag to be handled correctly below.
+        _aggregated = False
+% endif
 % if str(aggregation) == 'mean':
         # Declarative: mean over time axis (aggregation: mean)
         ${decl_input} = jnp.mean(${decl_input}, axis=0)
+        _aggregated = True
 % elif str(aggregation) == 'last':
         ${decl_input} = ${decl_input}[-1]
+        _aggregated = True
 % elif str(aggregation) == 'first':
         ${decl_input} = ${decl_input}[0]
+        _aggregated = True
 % endif
 % endif
 
@@ -1064,6 +1072,16 @@ class ${class_name}(AbstractMonitor):
         _final = _${primary_output}
         if isinstance(_final, NativeSolution):
             return _final
+% if aggregation:
+        if _aggregated:
+            # A collapsing aggregation removed the time axis: the result is a
+            # plain per-node value (or scalar), so return it directly instead of
+            # re-wrapping it in a NativeSolution — downstream loss / algorithm
+            # arithmetic needs an array, not a solution object (else e.g.
+            # `mean_activity + target` raises "unsupported operand type(s) for
+            # +: 'float' and 'NativeSolution'").
+            return _final
+% endif
 
         _is_scalar = _final.ndim == 0 if hasattr(_final, 'ndim') else True
         if _is_scalar:


### PR DESCRIPTION
## What

The generated tvboptim monitor collapses the time axis for a `mean`/`last`/`first` aggregation (e.g. `jnp.mean(data, axis=0)`) but then **re-wrapped the reduced per-node value/scalar back into a `NativeSolution`**. Downstream loss/algorithm arithmetic then hit `float + NativeSolution` — e.g. EI_Tuning's `MSE(mean_activity, target_activity)` raising:

```
TypeError: unsupported operand type(s) for +: 'float' and 'NativeSolution'
```

tvboptim itself was fine — it received exactly what TVBO's codegen handed it.

## Fix

Once a collapsing aggregation removes the time axis the result is no longer a time-series, so the monitor now **returns the raw array**. A runtime `_aggregated` flag drives it (each collapsing aggregation sets it), so a future aggregation is handled by just setting the flag, and it stays correct if a value does not actually collapse.

Deliberately kept it **aggregation-driven** rather than a `len(_final) != len(_time)` check: a *subsampled* time-series (e.g. BOLD at TR) also has `len(_final) < len(_time)` yet is a legitimate time-series that must stay wrapped. The template-time knowledge that an aggregation collapsed the axis is the reliable discriminator.

## Coordination with #50

Complementary halves of the same class of bug:
- **This PR (producer, `observation.mako`)** — repairs the type at the source for **aggregations** (`NativeSolution` re-wrap). Fixes every consumer (loss, algorithms, records).
- **#50 (consumer, `experiment.mako`)** — unwraps `ObservationResult` from **non-aggregation derived pipelines** (e.g. Hopf's `freq_grad_corr`, which my producer fix can't see) and no-ops once aggregations return raw.

No file conflict; either merge order works.

## Regression

The previously-red `tests/test_tvboptim_experiments.py::test_experiment_runs[EI_Tuning_FIC_EIB_Optimization]` now passes (verified on a fresh `origin/dev` checkout). A combined pin that also exercises #50's derived-pipeline path (Hopf's `freq_grad_corr`) is best added alongside #50.
