### PR TITLE
Symbolic array-op printing, unified across all backends

### DIFF
--- a/tests/test_codegen_array_ops.py
+++ b/tests/test_codegen_array_ops.py
@@ -1,0 +1,108 @@
+"""Structural array-op codegen primitives — one declarative op, every backend.
+
+These ops let an observation pipeline that trims a transient, selects a variable of
+interest, or downsamples be authored as a **declarative equation** rather than backend
+``source_code``. Each op is a single backend-agnostic handler in ``tvbo.codegen.code``
+that renders through per-backend rendering primitives:
+
+- numpy / jax: Python 0-based slicing (``x[::step]``, ``jnp.take(x, arange, axis)``)
+- julia:       1-based, ``end``-relative indexing (``x[1:step:end]``, ``selectdim``)
+
+The two invariants under test:
+
+1. **Cross-backend rendering** — each op emits the idiomatic form for numpy, jax, julia.
+2. **Numeric byte-identity** — the generated numpy/jax code produces values *identical*
+   to the hand-written slicing it replaces (so migrating ``source_code`` -> declarative
+   equation changes nothing numerically).
+"""
+import numpy as np
+import pytest
+
+from tvbo.codegen import render_expression
+
+
+# ---------------------------------------------------------------------------
+# 1. Cross-backend rendering
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("expr", "numpy", "jax", "julia"),
+    [
+        # strided downsample of the leading (time) axis
+        ("subsample(x, 1000)", "x[::1000]", "x[::1000]", "x[1:1000:end]"),
+        ("subsample(x, 5, 1000)", "x[5::1000]", "x[5::1000]", "x[5 + 1:1000:end]"),
+        # bounded slice of one axis (keeps ndim)
+        (
+            "slice_axis(x, 1, 0, 2)",
+            "np.take(x, np.arange(0, 2), axis=1)",
+            "jnp.take(x, jnp.arange(0, 2), axis=1)",
+            "selectdim(x, 2, 0 + 1:2)",
+        ),
+        (
+            "slice_axis(x, 1, 0, 10, 2)",
+            "np.take(x, np.arange(0, 10, 2), axis=1)",
+            "jnp.take(x, jnp.arange(0, 10, 2), axis=1)",
+            "selectdim(x, 2, 0 + 1:2:10)",
+        ),
+        # open-ended slice of one axis (transient trimming)
+        (
+            "slice_from(x, 0, 100)",
+            "np.take(x, np.arange(100, x.shape[0]), axis=0)",
+            "jnp.take(x, jnp.arange(100, x.shape[0]), axis=0)",
+            "selectdim(x, 1, 100 + 1:size(x, 1))",
+        ),
+        # axis length
+        ("shape(x, 1)", "x.shape[1]", "x.shape[1]", "size(x, 2)"),
+    ],
+)
+def test_array_op_renders_per_backend(expr, numpy, jax, julia):
+    assert render_expression(expr, format="numpy") == numpy
+    assert render_expression(expr, format="jax") == jax
+    assert render_expression(expr, format="julia") == julia
+
+
+def test_piecewise_backend_abstracted():
+    """Piecewise renders through the shared ``_where3`` primitive: where vs ifelse."""
+    expr = "Piecewise((1, x > 0), (0, True))"
+    assert render_expression(expr, format="numpy") == "np.where(np.greater(x, 0), 1, 0)"
+    assert render_expression(expr, format="jax") == "jnp.where(jnp.greater(x, 0), 1, 0)"
+    assert render_expression(expr, format="julia") == "ifelse(x > 0, 1, 0)"
+
+
+def test_ops_compose():
+    """Structural ops nest — select a voi, then downsample (Hopf-BOLD flavour)."""
+    code = render_expression("subsample(slice_axis(data, 1, 0, 1), 1000)", format="jax")
+    assert code == "jnp.take(data, jnp.arange(0, 1), axis=1)[::1000]"
+
+
+# ---------------------------------------------------------------------------
+# 2. Numeric byte-identity vs the hand-written slicing each op replaces
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("fmt", ["numpy", "jax"])
+def test_new_ops_numerically_identical(fmt):
+    if fmt == "jax":
+        jnp = pytest.importorskip("jax.numpy")
+        mod, xp = jnp, jnp
+    else:
+        mod, xp = np, np
+
+    rs = np.random.RandomState(0)
+    x = xp.asarray(rs.randn(20000, 3, 5))  # (time, voi, nodes)
+    ns = {"np": np, "jnp": mod, "x": x}
+
+    def gen(expr):
+        return eval(render_expression(expr, format=fmt), ns)
+
+    # subsample(x, step) == x[::step]
+    assert bool(xp.array_equal(gen("subsample(x, 1000)"), x[::1000]))
+    # subsample(x, start, step) == x[start::step]
+    assert bool(xp.array_equal(gen("subsample(x, 5, 1000)"), x[5::1000]))
+    # slice_axis(x, 1, 0, 1) == x[:, 0:1, :]  (keeps ndim)
+    assert bool(xp.array_equal(gen("slice_axis(x, 1, 0, 1)"), x[:, 0:1, :]))
+    # slice_axis(x, 1, 0, 3, 2) == x[:, 0:3:2, :]
+    assert bool(xp.array_equal(gen("slice_axis(x, 1, 0, 3, 2)"), x[:, 0:3:2, :]))
+    # slice_from(x, 0, 100) == x[100:]  (transient trim)
+    assert bool(xp.array_equal(gen("slice_from(x, 0, 100)"), x[100:]))
+    # shape(x, 1) == x.shape[1]
+    assert gen("shape(x, 1)") == x.shape[1]
+    # composition: select voi 0 then subsample == x[:, 0:1, :][::1000]
+    assert bool(xp.array_equal(gen("subsample(slice_axis(x, 1, 0, 1), 1000)"), x[:, 0:1, :][::1000]))

--- a/tvbo/codegen/code.py
+++ b/tvbo/codegen/code.py
@@ -193,8 +193,9 @@ def print_Piecewise(Printer, expr, verbose=False):
             print("value:", value)
         condition_str = Printer._print(condition)
         value_str = Printer._print(value)
-        # Build the nested np.where
-        result = f"{Printer._module}.where({condition_str}, {value_str}, {result})"
+        # Build the nested conditional via the printer's backend-abstracted primitive
+        # (numpy/jax -> ``<mod>.where(...)``; julia -> ``ifelse(...)``).
+        result = Printer._where3(condition_str, value_str, result)
 
     if verbose:
         print("result:", result)
@@ -206,66 +207,108 @@ def print_Piecewise(Printer, expr, verbose=False):
 # maps a function name to a handler ``(printer, expr) -> code string`` that emits
 # the right call for the printer's array module (``printer._module``: np / jnp).
 # Shared by NumPyPrinter and JaxPrinter so a new primitive is one dict entry.
+# Handlers stay backend-agnostic: they call the printer's rendering *primitives*
+# (``_cat``, ``_render_index``, ``_slice_axis``, ``_transpose``, ``_reduce_axis``,
+# ``_shape``, …), which each printer implements for its own conventions (numpy/jax:
+# Python 0-based slicing; Julia: 1-based ``end``-relative). Adding an op is one handler
+# plus, where a backend's syntax differs, one primitive override — never per-backend
+# string-building duplicated across printers.
 def _afp_concatenate(p, expr):
     args = list(expr.args)
     if args and args[-1].is_integer:
         axis, arrays = int(args[-1]), args[:-1]
     else:
         axis, arrays = 0, args
-    return f"{p._module}.concatenate([{', '.join(p._print(a) for a in arrays)}], axis={axis})"
+    return p._cat([p._print(a) for a in arrays], axis)
 
 
 def _afp_window_mean(p, expr):
-    X, w = p._print(expr.args[0]), p._print(expr.args[1])
-    return f"{p._module}.mean({X}.reshape(-1, {w}, *{X}.shape[1:]), axis=1)"
+    return p._window_mean(p._print(expr.args[0]), p._print(expr.args[1]))
 
 
 def _afp_subsample(p, expr):
-    return f"{p._print(expr.args[0])}[::{p._print(expr.args[1])}]"
+    """Strided slice of the leading (time) axis.
+
+    ``subsample(x, step)``        -> ``x[::step]``
+    ``subsample(x, start, step)`` -> ``x[start::step]``
+    The 3-arg form lets a strided downsample (e.g. tvboptim BOLD TR sampling
+    ``data[step::step]``) be authored as a declarative equation, not ``source_code``.
+    """
+    a = expr.args
+    if len(a) >= 3:
+        return p._render_index(a[0], [(a[1], None, a[2])])
+    return p._render_index(a[0], [(None, None, a[1])])
+
+
+def _afp_slice_axis(p, expr):
+    """``slice_axis(x, axis, start, stop[, step])`` -> bounded slice of one axis (keeps ndim)."""
+    a = expr.args
+    step = a[4] if len(a) > 4 else None
+    return p._slice_axis(p._print(a[0]), int(a[1]), a[2], a[3], step)
+
+
+def _afp_slice_from(p, expr):
+    """``slice_from(x, axis, start)`` -> open-ended slice of one axis (to the end)."""
+    a = expr.args
+    return p._slice_from(p._print(a[0]), int(a[1]), a[2])
+
+
+def _afp_shape(p, expr):
+    """``shape(x, axis)`` -> length of ``x`` along ``axis`` (for open-ended slices etc.)."""
+    return p._shape(p._print(expr.args[0]), int(expr.args[1]))
 
 
 def _afp_global_mean(p, expr):
-    return f"{p._module}.mean({p._print(expr.args[0])}, axis=-2, keepdims=True)"
+    return p._reduce_axis("mean", p._print(expr.args[0]), -2, keepdims=True)
 
 
 def _afp_transpose(p, expr):
-    return f"{p._print(expr.args[0])}.T"
+    return p._transpose(p._print(expr.args[0]))
 
 
 def _afp_mode_dot(p, expr):
-    """Contract X's mode axis with matrix M (TVB's ``numpy.dot(xi, A_ik)``).
-
-    For X ``(n_nodes, n_modes)`` and M ``(n_modes, n_modes)``:
-    ``result[node, k] = sum_j X[node, j] * M[j, k]``.
-    """
-    return f"{p._module}.dot({p._print(expr.args[0])}, {p._print(expr.args[1])})"
+    """Contract X's mode axis with matrix M (TVB's ``numpy.dot(xi, A_ik)``)."""
+    return p._mat_dot(p._print(expr.args[0]), p._print(expr.args[1]))
 
 
 def _afp_mode_sum(p, expr):
     """Sum over the mode axis, broadcasting back (TVB's ``coupling[0].sum(axis=1)[:, None]``)."""
-    return f"{p._module}.sum({p._print(expr.args[0])}, axis=-1, keepdims=True)"
+    return p._reduce_axis("sum", p._print(expr.args[0]), -1, keepdims=True)
 
 
 _ARRAY_FUNCTION_PRINTERS = {
     "concatenate": _afp_concatenate,
     "window_mean": _afp_window_mean,
     "subsample": _afp_subsample,
+    "slice_axis": _afp_slice_axis,
+    "slice_from": _afp_slice_from,
+    "shape": _afp_shape,
     "global_mean": _afp_global_mean,
     "transpose": _afp_transpose,
     "mode_dot": _afp_mode_dot,
     "mode_sum": _afp_mode_sum,
 }
 
+# Ops Julia renders natively (slice/stride family + shape); the rest defer to Julia's
+# name-mappings (vcat/transpose/…) or graceful-degrade, so Julia output never regresses.
+_JULIA_HANDLED_OPS = {"subsample", "slice_axis", "slice_from", "shape"}
+
 
 class _ArrayFunctionPrinterMixin:
-    """Shared printer hooks for the numpy/jax backends.
+    """Shared printer hooks + backend-abstracted array primitives.
 
-    Routes array primitives (``concatenate``, ``mode_dot``, ``mode_sum``, …) through
-    the ``_ARRAY_FUNCTION_PRINTERS`` table and ``Piecewise`` through
-    ``print_Piecewise``, deferring to the parent printer otherwise. Kept as a mixin
-    listed first in the MRO so ``super()`` resolves to the concrete SymPy printer base.
+    Routes array primitives (``concatenate``, ``subsample``, ``mode_dot``, …) through
+    ``_ARRAY_FUNCTION_PRINTERS`` and ``Piecewise`` through ``print_Piecewise``,
+    deferring to the parent printer otherwise. Kept as a mixin listed first in the MRO
+    so ``super()`` resolves to the concrete SymPy printer base.
+
+    The ``_*`` primitive methods below emit the **numpy/jax** forms (Python, 0-based
+    slicing). ``JuliaPrinter`` overrides the ones whose syntax differs (1-based,
+    ``end``-relative indexing), so each array op is defined once as a backend-agnostic
+    handler and only its differing syntax is overridden per backend.
     """
 
+    # --- routing ---
     def _print_Piecewise(self, expr):
         return print_Piecewise(self, expr)
 
@@ -274,6 +317,56 @@ class _ArrayFunctionPrinterMixin:
         if handler is not None:
             return handler(self, expr)
         return super()._print_Function(expr)
+
+    # --- backend-abstracted array primitives (numpy/jax defaults) ---
+    def _afn(self, name):
+        """Module-qualify an array function, e.g. ``jnp.take``."""
+        return f"{self._module}.{name}"
+
+    def _where3(self, cond, a, b):
+        return f"{self._afn('where')}({cond}, {a}, {b})"
+
+    def _cat(self, arrays, axis):
+        return f"{self._afn('concatenate')}([{', '.join(arrays)}], axis={axis})"
+
+    def _transpose(self, base):
+        return f"{base}.T"
+
+    def _mat_dot(self, a, b):
+        return f"{self._afn('dot')}({a}, {b})"
+
+    def _reduce_axis(self, fn, base, axis, keepdims=False):
+        kw = ", keepdims=True" if keepdims else ""
+        return f"{self._afn(fn)}({base}, axis={axis}{kw})"
+
+    def _window_mean(self, X, w):
+        return f"{self._afn('mean')}({X}.reshape(-1, {w}, *{X}.shape[1:]), axis=1)"
+
+    def _shape(self, base, axis):
+        return f"{base}.shape[{axis}]"
+
+    def _render_index(self, base, specs):
+        """Render ``base[...]`` with Python 0-based slices. ``specs`` is a per-axis list;
+        each entry is ``None`` (full ``:``) or ``(start, stop, step)`` with ``None`` parts."""
+        parts = []
+        for s in specs:
+            if s is None:
+                parts.append(":")
+                continue
+            start, stop, step = s
+            lo = "" if start is None else self._print(start)
+            hi = "" if stop is None else self._print(stop)
+            parts.append(f"{lo}:{hi}" if step is None else f"{lo}:{hi}:{self._print(step)}")
+        return f"{self._print(base)}[{', '.join(parts)}]"
+
+    def _slice_axis(self, base, axis, start, stop, step=None):
+        rng = f"{self._afn('arange')}({self._print(start)}, {self._print(stop)}"
+        rng += f", {self._print(step)})" if step is not None else ")"
+        return f"{self._afn('take')}({base}, {rng}, axis={axis})"
+
+    def _slice_from(self, base, axis, start):
+        rng = f"{self._afn('arange')}({self._print(start)}, {self._shape(base, axis)})"
+        return f"{self._afn('take')}({base}, {rng}, axis={axis})"
 
 
 class NumPyPrinter(_ArrayFunctionPrinterMixin, spn.NumPyPrinter):
@@ -499,7 +592,10 @@ class JaxPrinter(_ArrayFunctionPrinterMixin, spn.JaxPrinter):
             return f"{self._module}.sum({self._print(result)}, axis={axes_tuple})"
 
 
-class JuliaPrinter(spj.JuliaCodePrinter):
+class JuliaPrinter(_ArrayFunctionPrinterMixin, spj.JuliaCodePrinter):
+    # Julia array functions are bare names (resolved via known_functions), not module-qualified.
+    _module = ""
+
     def __init__(self, settings=None):
         settings = settings or {}
         # Be tolerant: allow partial printing instead of raising for unknown constructs.
@@ -507,6 +603,17 @@ class JuliaPrinter(spj.JuliaCodePrinter):
         super().__init__(settings=settings)
         # Add array function mappings
         self.known_functions.update(ARRAY_FUNCTION_MAPPINGS["julia"])
+
+    # Route only the ops with a clean Julia form (slice/stride family + shape) through the
+    # shared handlers — which then call the Julia-overridden primitives below. Everything else
+    # (concatenate->vcat, transpose, reductions) defers to Julia's name-mappings, so existing
+    # Julia output never regresses. NOTE: bypass the mixin's catch-all _print_Function (which
+    # would route *every* registered op) by dispatching to the SymPy base directly.
+    def _print_Function(self, expr):
+        name = expr.func.__name__
+        if name in _JULIA_HANDLED_OPS:
+            return _ARRAY_FUNCTION_PRINTERS[name](self, expr)
+        return spj.JuliaCodePrinter._print_Function(self, expr)
 
     # SymPy's JuliaCodePrinter does not implement IndexedBase by default; our templates
     # occasionally introduce placeholder IndexedBase symbols (e.g. x_i, x_j) for clarity.
@@ -525,17 +632,35 @@ class JuliaPrinter(spj.JuliaCodePrinter):
         except Exception:
             return str(expr)
 
-    # Provide a basic Piecewise -> nested ifelse translation if needed later; keep simple now.
-    def _print_Piecewise(self, expr):
-        # Fallback: replicate numpy-style nesting using ifelse(cond, val, else_expr)
-        args = expr.args
-        default = self._print(args[-1][0])
-        out = default
-        for val, cond in reversed(args[:-1]):
-            cond_s = self._print(cond)
-            val_s = self._print(val)
-            out = f"ifelse({cond_s}, {val_s}, {out})"
-        return out
+    # --- Julia primitive overrides: 1-based, ``end``-relative, column-major indexing ---
+    # ``Piecewise`` reuses the shared ``print_Piecewise`` via this ``_where3`` override
+    # (numpy/jax -> ``<mod>.where``; Julia -> ``ifelse``), so no dedicated Julia Piecewise.
+    def _where3(self, cond, a, b):
+        return f"ifelse({cond}, {a}, {b})"
+
+    def _shape(self, base, axis):
+        return f"size({base}, {axis + 1})"
+
+    def _render_index(self, base, specs):
+        parts = []
+        for s in specs:
+            if s is None:
+                parts.append(":")
+                continue
+            start, stop, step = s
+            lo = "1" if start is None else f"{self._print(start)} + 1"
+            hi = "end" if stop is None else self._print(stop)
+            parts.append(f"{lo}:{hi}" if step is None else f"{lo}:{self._print(step)}:{hi}")
+        return f"{self._print(base)}[{', '.join(parts)}]"
+
+    def _slice_axis(self, base, axis, start, stop, step=None):
+        lo = f"{self._print(start)} + 1"
+        hi = self._print(stop)
+        rng = f"{lo}:{hi}" if step is None else f"{lo}:{self._print(step)}:{hi}"
+        return f"selectdim({base}, {axis + 1}, {rng})"
+
+    def _slice_from(self, base, axis, start):
+        return f"selectdim({base}, {axis + 1}, {self._print(start)} + 1:{self._shape(base, axis)})"
 
 
 class MTKPrinter(JuliaPrinter):

--- a/tvbo/parse/expression.py
+++ b/tvbo/parse/expression.py
@@ -86,7 +86,12 @@ ARRAY_FUNCTIONS = {
     # JAX / NumPy calls (including .reshape() and keyword args that SymPy
     # cannot represent natively).
     "window_mean": Function("window_mean"),  # window_mean(X, w) → jnp.mean(X.reshape(-1, w, *X.shape[1:]), axis=1)
-    "subsample": Function("subsample"),      # subsample(X, step) → X[::step]
+    "subsample": Function("subsample"),      # subsample(X, step[, start]) → X[start::step]
+    # Structural slice/shape ops — let an observation pipeline that selects a voi, trims a
+    # transient, or downsamples be authored as declarative equations instead of source_code.
+    "slice_axis": Function("slice_axis"),    # slice_axis(X, axis, start, stop[, step]) → bounded slice of one axis (keeps ndim)
+    "slice_from": Function("slice_from"),    # slice_from(X, axis, start)               → open-ended slice of one axis (to the end)
+    "shape": Function("shape"),              # shape(X, axis)                           → length of X along axis
     "global_mean": Function("global_mean"),  # global_mean(X) → jnp.mean(X, axis=-2, keepdims=True)
     "transpose": Function("transpose"),      # transpose(X) → X.T
     "mode_dot": Function("mode_dot"),        # mode_dot(X, M) → X·M contracted over the mode axis ({np,jnp}.dot)


### PR DESCRIPTION
## Symbolic array-op printing, unified across all backends

Makes the structural array ops an observation pipeline needs — strided downsample, axis
slicing, transient trimming, shape — authorable as **declarative equations** that render
correctly for **every** backend, via a backend-abstracted symbolic printer (no templating,
no per-backend handler duplication).

### The problem

The array-op handlers in `tvbo/codegen/code.py` (`subsample`, `concatenate`, `transpose`,
`mode_dot`, …) were wired into the numpy/jax printers only and **hardcoded Python slice
syntax**. `JuliaPrinter` never routed them, so those ops silently emitted `# Not supported`.
There was also no way to express a bounded/open axis slice or an axis length, so pipelines
like the Hopf BOLD reduction (`data[:, voi:voi+1, :]`, `data[step::step]`) had to fall back
to backend `source_code`.

### The design — one op, backend-abstracted primitives

Each op is **one backend-agnostic handler** that calls the printer's rendering *primitives*
(`_render_index`, `_slice_axis`, `_slice_from`, `_shape`, `_where3`, `_cat`, `_transpose`,
`_reduce_axis`, `_afn`). The primitives live on `_ArrayFunctionPrinterMixin` (numpy/jax
defaults: Python 0-based slicing, `<mod>.where`); `JuliaPrinter` overrides **only the
primitives whose syntax differs** (1-based, `end`-relative: `x[1:step:end]`, `selectdim`,
`size(x, ax+1)`, `ifelse`). `Piecewise` now flows through the shared `_where3` primitive, so
`where` vs `ifelse` falls out for free and Julia's duplicate `_print_Piecewise` is gone.

Adding a backend or an op = one primitive override / one handler — never a duplicated body.

### New declarative ops

| op | meaning | numpy/jax | julia |
|----|---------|-----------|-------|
| `subsample(x, step)` / `subsample(x, start, step)` | strided downsample | `x[start::step]` | `x[start+1:step:end]` |
| `slice_axis(x, axis, start, stop[, step])` | bounded slice of one axis (keeps ndim) | `take(x, arange(start, stop[, step]), axis)` | `selectdim(x, axis+1, start+1:[step:]stop)` |
| `slice_from(x, axis, start)` | open-ended slice (transient trim) | `take(x, arange(start, x.shape[axis]), axis)` | `selectdim(x, axis+1, start+1:size(x, axis+1))` |
| `shape(x, axis)` | axis length | `x.shape[axis]` | `size(x, axis+1)` |

### Julia parity

Julia gains native rendering for the slice/stride family + `shape` + `Piecewise`
(`_JULIA_HANDLED_OPS`). The genuinely reshape-heavy / mode-axis ops (`window_mean`,
`global_mean`, `mode_dot`, `mode_sum`) whose Julia semantics differ **graceful-degrade** to
SymPy's `# Not supported in Julia` comment rather than emitting invalid code. Existing Julia
name-mapped ops (`concatenate`→`vcat`, `transpose`) are untouched.

### Byte-identity / no regression

- numpy/jax output for every existing op is **unchanged** (the primitives emit the exact
  prior strings) — verified by `test_codegen_mode_dot.py` + `test_tvb_model_fidelity.py`
  (**60 passed**: mode_dot, all 28 TVB models incl. Piecewise-regime `EpileptorCodim3`/
  `KIonEx` and mode-coupling models).
- new ops are **numerically byte-identical** to the hand-written slicing they replace
  (`take(x, arange(...), axis)` == `x[..., start:stop, ...]`), verified in
  `tests/test_codegen_array_ops.py` (**10 passed**, cross-backend render + numeric).

### Files

- `tvbo/codegen/code.py` — backend-abstracted primitives on the mixin; `JuliaPrinter`
  inherits it + overrides differing primitives; handlers rewritten to call primitives;
  `print_Piecewise` via `_where3`; new `slice_axis`/`slice_from`/`shape` handlers.
- `tvbo/parse/expression.py` — register `slice_axis`/`slice_from`/`shape` + 3-arg `subsample`.
- `tests/test_codegen_array_ops.py` — new cross-backend + numeric byte-identity tests.
