### PR TITLE
Ingest NeuroML-core into the ontology + emit custom conductance-based synapses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE_TAG=latest
 IMAGE_FULL=$(IMAGE_NAME):$(IMAGE_TAG)
 TARBALL_PATH=/Users/leonmartin_bih/projects/TVB-O/tvbo-container/tvbo.tar.gz
 
-.PHONY: help build save run docs-quarto docs-jupyter docs-to-py docs-rm-py docs-test docs-pytest docs-pytest-all docs-test-all docs-preview docs-render docs-clean docs-publish docs-publish-changed pypi-release release gen-linkml gen-openminds gen-owl gen-shacl gen-all all check-runtime-onto
+.PHONY: help build save run docs-quarto docs-jupyter docs-to-py docs-rm-py docs-test docs-pytest docs-pytest-all docs-test-all docs-preview docs-render docs-clean docs-publish docs-publish-changed pypi-release release gen-linkml gen-openminds gen-owl gen-shacl gen-neuroml gen-all all check-runtime-onto
 
 help: ## Show this help
 	@echo "TVBO Makefile"
@@ -76,6 +76,9 @@ ABOX_OUT = ontology/tvb-o-data.ttl
 BIOLOGY_OUT = ontology/tvb-o-biology.ttl
 AXIOMS_TTL = ontology/tvb-o-axioms.ttl
 BIFURCATION_TTL = ontology/tvb-o-bifurcation.ttl
+NEUROML_TTL = ontology/tvb-o-neuroml.ttl
+NEUROML_MAPPINGS = ontology/tvb-o-neuroml-mappings.ttl
+NEUROML_CONTRACTS = tvbo/data/ontology/neuroml_contracts.json
 CLINICAL_TTL = ontology/tvb-o-clinical.ttl
 CLINICAL_NMM = ontology/tvb-o-clinical-nmm.ttl
 MERGED_OUT = ontology/tvbo.owl
@@ -113,12 +116,22 @@ gen-abox: gen-studies
 	@python scripts/ontology/gen_abox.py -o $(ABOX_OUT) --bio-output $(BIOLOGY_OUT)
 	@echo "✓ A-box written to $(ABOX_OUT) (+ biology grounding to $(BIOLOGY_OUT))"
 
+# Ingest the NeuroML2 core LEMS ComponentTypes into a mergeable ontology module
+# plus the accumulated contract index the NeuroML adapter loads. Needs the
+# neuroml extra (jNeuroML jar + pylems); the committed outputs are consumed by
+# gen-merged without regenerating, so a merge does not require the jar.
+gen-neuroml:
+	@echo "Ingesting NeuroML-core ComponentTypes into the ontology..."
+	@mkdir -p ontology
+	@python scripts/ontology/gen_neuroml.py -o $(NEUROML_TTL) --contracts $(NEUROML_CONTRACTS)
+	@echo "✓ NeuroML module written to $(NEUROML_TTL) (+ contract index $(NEUROML_CONTRACTS))"
+
 crosswalk:
 	@echo "Refreshing crosswalk + boundary-matrix from schema/api/odoo..."
 	@python scripts/ontology/backfill_crosswalk.py
 	@echo "✓ dev/OntologicalRestructuring/{crosswalk,boundary-matrix}.md updated"
 
-gen-all: gen-linkml gen-openminds gen-owl gen-shacl gen-abox gen-merged
+gen-all: gen-linkml gen-openminds gen-owl gen-shacl gen-abox gen-neuroml gen-merged
 	@echo "✓ All schemas generated"
 
 gen-merged: gen-owl gen-abox
@@ -128,6 +141,8 @@ gen-merged: gen-owl gen-abox
 		--input $(OWL_OUT) \
 		--input $(AXIOMS_TTL) \
 		--input $(BIFURCATION_TTL) \
+		--input $(NEUROML_TTL) \
+		--input $(NEUROML_MAPPINGS) \
 		--input $(ABOX_OUT) \
 		--input $(BIOLOGY_OUT) \
 		--input $(CLINICAL_TTL) \

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -18,6 +18,8 @@ modules (OWL statements LinkML cannot express).
 | `tvb-o-biology.ttl` | generated — `make gen-abox` (`--bio-output`) | Biological grounding for the A-box. |
 | `tvb-o-axioms.ttl` | hand-authored | OWL axioms LinkML cannot capture: subclass hierarchies, equivalences, disjointness. Layered on `tvb-o-struct.owl`. |
 | `tvb-o-bifurcation.ttl` | hand-authored | Axiomatised bifurcation / special-point taxonomy, defined by codimension, eigenvalue signature, and branch geometry (single source of truth for the backend label maps). |
+| `tvb-o-neuroml.ttl` | generated — `make gen-neuroml` from the jNeuroML core types | The NeuroML2 core LEMS `ComponentType` hierarchy as OWL classes (`extends`→`subClassOf`), each `skos:exactMatch`-linked to its canonical NeuroML IRI. The reference from `tvbo.owl` to NeuroML-core, beside the GO link. Companion `tvbo/data/ontology/neuroml_contracts.json` (the accumulated contract index) is emitted in the same pass and loaded by the NeuroML adapter. |
+| `tvb-o-neuroml-mappings.ttl` | hand-authored | tvbo-core ↔ NeuroML/LEMS alignment: meta-model correspondences (`Dynamics`↔`ComponentType`, `StateVariable`/`Parameter`/`DerivedVariable`/`Event`↔LEMS peers) and role correspondences (synapse/cell/population/input branches), via SKOS mapping relations. |
 | `tvb-o-clinical.ttl` | generated from a PubMed + full-text survey (2026) | Clinical-applications addon: published TVB studies → clinical domains (ICD-11, MeSH) → the neural-mass model each uses. |
 | `tvb-o-clinical-nmm.ttl` | hand-authored | `tvbc:NeuralMassModel ⊑ tvbo:Dynamics` plus clinical-NMM links. |
 | `tvbo.owl` | generated — `make gen-merged` | Merge of every module above. The complete ontology; also copied to `tvbo/data/ontology/tvbo.owl`, which the runtime loads. |
@@ -39,10 +41,11 @@ modules (OWL statements LinkML cannot express).
 ## Generation
 
 ```bash
-make gen-owl     # → tvb-o-struct.owl   (T-box from the schema)
-make gen-shacl   # → tvb-o.shacl.ttl    (SHACL shapes from the schema)
-make gen-abox    # → tvb-o-data.ttl + tvb-o-biology.ttl (A-box from YAML)
-make gen-merged  # → tvbo.owl           (merge + reason; also packaged for runtime)
+make gen-owl      # → tvb-o-struct.owl   (T-box from the schema)
+make gen-shacl    # → tvb-o.shacl.ttl    (SHACL shapes from the schema)
+make gen-abox     # → tvb-o-data.ttl + tvb-o-biology.ttl (A-box from YAML)
+make gen-neuroml  # → tvb-o-neuroml.ttl + neuroml_contracts.json (NeuroML-core; needs the neuroml extra)
+make gen-merged   # → tvbo.owl           (merge + reason; also packaged for runtime)
 ```
 
 The generated outputs are checked in so external consumers need no LinkML or

--- a/ontology/tvb-o-neuroml-mappings.ttl
+++ b/ontology/tvb-o-neuroml-mappings.ttl
@@ -1,0 +1,76 @@
+@prefix tvbo:     <https://w3id.org/tvbo/> .
+@prefix nml:      <https://w3id.org/tvbo/neuroml/> .
+@prefix lems:     <http://www.neuroml.org/lems/0.7.6#> .
+@prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:  <http://purl.org/dc/terms/> .
+
+#
+# ═════════════════════════════════════════════════════════════════
+# TVB-O ↔ NeuroML / LEMS alignment (mergeable module).
+# ═════════════════════════════════════════════════════════════════
+#
+# Records the semantic overlaps between tvbo-core and the NeuroML/LEMS core,
+# merged into `tvbo.owl` alongside `tvb-o-neuroml.ttl` (the ingested NeuroML
+# class hierarchy). Two kinds of link:
+#
+#   1. Meta-model correspondence — tvbo's modelling primitives against the LEMS
+#      meta-model elements they mirror (a tvbo Dynamics is the analog of a LEMS
+#      ComponentType, its StateVariable/Parameter/DerivedVariable/Event of the
+#      LEMS peers of the same name).
+#   2. Role correspondence — the NeuroML branch a tvbo Dynamics is emitted into
+#      when it plays a given role (synapse, cell, population, input current).
+#
+# SKOS mapping relations (not owl:equivalentClass) are used deliberately: these
+# concepts correspond closely across the two schemes without being logically
+# identical (tvbo:Dynamics is broader than any single LEMS ComponentType), so
+# skos:closeMatch / skos:relatedMatch state the correspondence at the right
+# strength and keep the ELK merge free of spurious class-equivalence
+# entailments. This mirrors the tvbo↔GO cross-reference precedent.
+#
+
+<https://w3id.org/tvbo/neuroml/mappings> a owl:Ontology ;
+    dcterms:title       "TVB-O ↔ NeuroML/LEMS alignment"@en ;
+    dcterms:description  "Semantic overlaps between tvbo-core and the NeuroML/LEMS core: meta-model correspondences (Dynamics↔ComponentType, StateVariable/Parameter/DerivedVariable/Event↔LEMS peers) and role correspondences (synapse/cell/population/input branches)."@en ;
+    dcterms:license      <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:seeAlso         <https://w3id.org/tvbo/neuroml> ;
+    rdfs:seeAlso         <http://www.neuroml.org/lems/0.7.6> .
+
+#
+# ── 1. Meta-model correspondence: tvbo-core ↔ LEMS meta-model ──────
+#
+# A tvbo Dynamics declares the same kinds of internal elements a LEMS
+# ComponentType does; each maps to its LEMS peer of the same role.
+#
+
+tvbo:Dynamics         skos:closeMatch lems:ComponentType .
+tvbo:StateVariable    skos:closeMatch lems:StateVariable .
+tvbo:Parameter        skos:closeMatch lems:Parameter .
+tvbo:DerivedVariable  skos:closeMatch lems:DerivedVariable .
+tvbo:Event            skos:closeMatch lems:EventPort .
+
+# A tvbo CouplingInput is a quantity a Dynamics draws from its network context,
+# the role a LEMS Requirement plays for a ComponentType.
+tvbo:CouplingInput    skos:relatedMatch lems:Requirement .
+
+#
+# ── 2. Role correspondence: tvbo:Dynamics ↔ NeuroML branch roots ──
+#
+# The same tvbo:Dynamics is emitted into a different NeuroML branch depending on
+# the role it plays. These links name the emission target per role; they are
+# associative (relatedMatch), not subsumption, because the tvbo class is the
+# role-neutral Dynamics.
+#
+
+nml:baseCell         skos:relatedMatch tvbo:Dynamics ;
+    rdfs:comment "A tvbo:Dynamics acting as a neuron is emitted as a descendant of baseCell."@en .
+
+nml:baseSynapse      skos:relatedMatch tvbo:Dynamics ;
+    rdfs:comment "A tvbo:Dynamics acting as a synapse is emitted as a descendant of baseSynapse."@en .
+
+nml:basePointCurrent skos:relatedMatch tvbo:Dynamics ;
+    rdfs:comment "A tvbo:Dynamics acting as an input current is emitted as a descendant of basePointCurrent."@en .
+
+nml:basePopulation   skos:relatedMatch tvbo:Node ;
+    rdfs:comment "A NeuroML population corresponds to a tvbo network node (a group of cells of one type)."@en .

--- a/ontology/tvb-o-neuroml.ttl
+++ b/ontology/tvb-o-neuroml.ttl
@@ -1,0 +1,2037 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix neuroml2: <http://www.neuroml.org/schema/neuroml2#> .
+@prefix nml: <https://w3id.org/tvbo/neuroml/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tvbo: <https://w3id.org/tvbo/> .
+
+nml:Display a owl:Class ;
+    rdfs:label "Display"@en ;
+    dcterms:description "Details of a display to generate (usually a set of traces given by _Line_s in a newly opened window) on completion of the simulation."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:Display ;
+    nml:hasParameter "timeScale",
+        "xmax",
+        "xmin",
+        "ymax",
+        "ymin" .
+
+nml:EIF_cond_alpha_isfa_ista a owl:Class ;
+    rdfs:label "EIF_cond_alpha_isfa_ista"@en ;
+    dcterms:description "Adaptive exponential integrate and fire neuron according to Brette R and Gerstner W (2005) with alpha-function-shaped post-synaptic conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCondCell ;
+    skos:exactMatch neuroml2:EIF_cond_alpha_isfa_ista ;
+    nml:exposes "w" ;
+    nml:hasParameter "a",
+        "b",
+        "delta_T",
+        "i_offset",
+        "tau_refrac",
+        "tau_w",
+        "v_rest",
+        "v_spike" .
+
+nml:EIF_cond_exp_isfa_ista a owl:Class ;
+    rdfs:label "EIF_cond_exp_isfa_ista"@en ;
+    dcterms:description "Adaptive exponential integrate and fire neuron according to Brette R and Gerstner W (2005) with exponentially-decaying post-synaptic conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCondCell ;
+    skos:exactMatch neuroml2:EIF_cond_exp_isfa_ista ;
+    nml:exposes "w" ;
+    nml:hasParameter "a",
+        "b",
+        "delta_T",
+        "i_offset",
+        "tau_refrac",
+        "tau_w",
+        "v_rest",
+        "v_spike" .
+
+nml:EventOutputFile a owl:Class ;
+    rdfs:label "EventOutputFile"@en ;
+    dcterms:description "A file in which to save event information (e.g. spikes from cells in a population) in a specified _format"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:EventOutputFile .
+
+nml:EventSelection a owl:Class ;
+    rdfs:label "EventSelection"@en ;
+    dcterms:description "A specific source of events with an associated _id, which will be recorded inside the file specified in the parent _EventOutputFile_. The attribute _select should point to a cell inside a _population_ (e.g. hhpop[0], see https://docs.neuroml.org/Userdocs/Paths.html), and the _eventPort specifies the port for the emitted events, which usually has id: spike. Note: the _id used on this element (and appearing in the file alongside the event time) can be different from the id/index of the cell in the population."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:EventSelection .
+
+nml:HHExpLinearRate a owl:Class ;
+    rdfs:label "HHExpLinearRate"@en ;
+    dcterms:description "Exponential linear form for rate equation. Linear for large positive _v, exponentially decays for large negative _v."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseHHRate ;
+    skos:exactMatch neuroml2:HHExpLinearRate .
+
+nml:HHExpLinearVariable a owl:Class ;
+    rdfs:label "HHExpLinearVariable"@en ;
+    dcterms:description "Exponential linear form for variable equation. Linear for large positive _v, exponentially decays for large negative _v."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseHHVariable ;
+    skos:exactMatch neuroml2:HHExpLinearVariable .
+
+nml:HHExpRate a owl:Class ;
+    rdfs:label "HHExpRate"@en ;
+    dcterms:description "Exponential form for rate equation (Q: Should these be renamed hhExpRate, etc?)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseHHRate ;
+    skos:exactMatch neuroml2:HHExpRate .
+
+nml:HHExpVariable a owl:Class ;
+    rdfs:label "HHExpVariable"@en ;
+    dcterms:description "Exponential form for variable equation"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseHHVariable ;
+    skos:exactMatch neuroml2:HHExpVariable .
+
+nml:HHSigmoidRate a owl:Class ;
+    rdfs:label "HHSigmoidRate"@en ;
+    dcterms:description "Sigmoidal form for rate equation"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseHHRate ;
+    skos:exactMatch neuroml2:HHSigmoidRate .
+
+nml:HHSigmoidVariable a owl:Class ;
+    rdfs:label "HHSigmoidVariable"@en ;
+    dcterms:description "Sigmoidal form for variable equation"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseHHVariable ;
+    skos:exactMatch neuroml2:HHSigmoidVariable .
+
+nml:HH_cond_exp a owl:Class ;
+    rdfs:label "HH_cond_exp"@en ;
+    dcterms:description "Single-compartment Hodgkin-Huxley-type neuron with transient sodium and delayed-rectifier potassium currents using the ion channel models from Traub."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNCell ;
+    skos:exactMatch neuroml2:HH_cond_exp ;
+    nml:exposes "h",
+        "m",
+        "n" ;
+    nml:hasParameter "e_rev_E",
+        "e_rev_I",
+        "e_rev_K",
+        "e_rev_Na",
+        "e_rev_leak",
+        "g_leak",
+        "gbar_K",
+        "gbar_Na",
+        "v_offset" .
+
+nml:IF_cond_alpha a owl:Class ;
+    rdfs:label "IF_cond_alpha"@en ;
+    dcterms:description "Leaky integrate and fire model with fixed threshold and alpha-function-shaped post-synaptic conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCondCell ;
+    skos:exactMatch neuroml2:IF_cond_alpha .
+
+nml:IF_cond_exp a owl:Class ;
+    rdfs:label "IF_cond_exp"@en ;
+    dcterms:description "Leaky integrate and fire model with fixed threshold and exponentially-decaying post-synaptic conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCondCell ;
+    skos:exactMatch neuroml2:IF_cond_exp .
+
+nml:IF_curr_alpha a owl:Class ;
+    rdfs:label "IF_curr_alpha"@en ;
+    dcterms:description "Leaky integrate and fire model with fixed threshold and alpha-function-shaped post-synaptic current"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCell ;
+    skos:exactMatch neuroml2:IF_curr_alpha .
+
+nml:IF_curr_exp a owl:Class ;
+    rdfs:label "IF_curr_exp"@en ;
+    dcterms:description "Leaky integrate and fire model with fixed threshold and decaying-exponential post-synaptic current"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCell ;
+    skos:exactMatch neuroml2:IF_curr_exp .
+
+nml:Line a owl:Class ;
+    rdfs:label "Line"@en ;
+    dcterms:description "Specification of a single time varying _quantity to plot on the _Display_. Note that all quantities are handled internally in LEMS in SI units, and so a _scale should be used if it is to be displayed in other units."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:Line ;
+    nml:hasParameter "scale",
+        "timeScale" .
+
+nml:Meta a owl:Class ;
+    rdfs:label "Meta"@en ;
+    dcterms:description "Metadata to add to simulation"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:Meta .
+
+nml:OutputColumn a owl:Class ;
+    rdfs:label "OutputColumn"@en ;
+    dcterms:description "Specification of a single time varying _quantity to record during the simulation. Note that all quantities are handled internally in LEMS in SI units, and so the value for the quantity in the file (as well as time) will be in SI units."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:OutputColumn .
+
+nml:OutputFile a owl:Class ;
+    rdfs:label "OutputFile"@en ;
+    dcterms:description "A file in which to save recorded values from the simulation"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:OutputFile .
+
+nml:Simulation a owl:Class ;
+    rdfs:label "Simulation"@en ;
+    dcterms:description "The main element in a LEMS Simulation file. Defines the _length of simulation, the timestep (dt) _step and an optional _seed to use for stochastic elements, as well as _Display_s, _OutputFile_s and _EventOutputFile_s to record. Specifies a _target component to run, usually the id of a _network_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:Simulation ;
+    nml:hasParameter "length",
+        "step" .
+
+nml:SpikeSourcePoisson a owl:Class ;
+    rdfs:label "SpikeSourcePoisson"@en ;
+    dcterms:description "Spike source, generating spikes according to a Poisson process."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikeSource ;
+    skos:exactMatch neuroml2:SpikeSourcePoisson ;
+    nml:eventPort "in" ;
+    nml:exposes "isi",
+        "tnextIdeal",
+        "tnextUsed" ;
+    nml:hasParameter "duration",
+        "rate",
+        "start" .
+
+nml:adExIaFCell a owl:Class ;
+    rdfs:label "adExIaFCell"@en ;
+    dcterms:description "Model based on Brette R and Gerstner W (2005) Adaptive Exponential Integrate-and-Fire Model as an Effective Description of Neuronal Activity. J Neurophysiol 94:3637-3642"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotCap ;
+    skos:exactMatch neuroml2:adExIaFCell ;
+    nml:exposes "w" ;
+    nml:hasParameter "EL",
+        "VT",
+        "a",
+        "b",
+        "delT",
+        "gL",
+        "refract",
+        "reset",
+        "tauw",
+        "thresh" .
+
+nml:alphaCondSynapse a owl:Class ;
+    rdfs:label "alphaCondSynapse"@en ;
+    dcterms:description "Alpha synapse: rise time and decay time are both tau_syn. Conductance based synapse."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePynnSynapse ;
+    skos:exactMatch neuroml2:alphaCondSynapse ;
+    nml:exposes "A",
+        "g" ;
+    nml:hasParameter "e_rev" .
+
+nml:alphaCurrSynapse a owl:Class ;
+    rdfs:label "alphaCurrSynapse"@en ;
+    dcterms:description "Alpha synapse: rise time and decay time are both tau_syn. Current based synapse."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePynnSynapse ;
+    skos:exactMatch neuroml2:alphaCurrSynapse ;
+    nml:exposes "A" .
+
+nml:alphaCurrentSynapse a owl:Class ;
+    rdfs:label "alphaCurrentSynapse"@en ;
+    dcterms:description "Alpha current synapse: rise time and decay time are both _tau."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCurrentBasedSynapse ;
+    skos:exactMatch neuroml2:alphaCurrentSynapse ;
+    nml:hasParameter "ibase",
+        "tau" .
+
+nml:alphaSynapse a owl:Class ;
+    rdfs:label "alphaSynapse"@en ;
+    dcterms:description "Ohmic synapse model where rise time and decay time are both _tau. Max conductance reached during this time (assuming zero conductance before) is _gbase * _weight."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseConductanceBasedSynapse ;
+    skos:exactMatch neuroml2:alphaSynapse ;
+    nml:hasParameter "tau" .
+
+nml:baseConductanceScalingCaDependent a owl:Class ;
+    rdfs:label "baseConductanceScalingCaDependent"@en ;
+    dcterms:description "Base ComponentType for a scaling to apply to a gate's conductance which depends on Ca concentration. Usually a generic expression of _caConc (so no standard, non-base form here)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseConductanceScaling ;
+    skos:exactMatch neuroml2:baseConductanceScalingCaDependent ;
+    nml:requires "caConc" .
+
+nml:baseSynapseDL a owl:Class ;
+    rdfs:label "baseSynapseDL"@en ;
+    dcterms:description "Base type for all synapses, i.e. ComponentTypes which produce a dimensionless current and change Dynamics in response to an incoming event. cno_0000009"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrentDL ;
+    skos:exactMatch neuroml2:baseSynapseDL .
+
+nml:baseVoltageConcDepRate a owl:Class ;
+    rdfs:label "baseVoltageConcDepRate"@en ;
+    dcterms:description "Base ComponentType for voltage and concentration dependent rate. Produces a time varying rate _r which depends on _v and _caConc."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepRate ;
+    skos:exactMatch neuroml2:baseVoltageConcDepRate ;
+    nml:requires "caConc" .
+
+nml:baseVoltageConcDepTime a owl:Class ;
+    rdfs:label "baseVoltageConcDepTime"@en ;
+    dcterms:description "Base type for voltage and calcium concentration dependent ComponentType producing value _t with dimension time (e.g. for time course of rate variable)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepTime ;
+    skos:exactMatch neuroml2:baseVoltageConcDepTime ;
+    nml:requires "caConc" .
+
+nml:baseVoltageConcDepVariable a owl:Class ;
+    rdfs:label "baseVoltageConcDepVariable"@en ;
+    dcterms:description "Base ComponentType for voltage and calcium concentration dependent variable _x, which depends on _v and _caConc."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepVariable ;
+    skos:exactMatch neuroml2:baseVoltageConcDepVariable ;
+    nml:requires "caConc" .
+
+nml:biophysicalProperties a owl:Class ;
+    rdfs:label "biophysicalProperties"@en ;
+    dcterms:description "The biophysical properties of the _cell_, including the _membraneProperties_ and the _intracellularProperties_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:biophysicalProperties ;
+    nml:exposes "totSpecCap" .
+
+nml:biophysicalProperties2CaPools a owl:Class ;
+    rdfs:label "biophysicalProperties2CaPools"@en ;
+    dcterms:description "The biophysical properties of the _cell_, including the _membraneProperties2CaPools_ and the _intracellularProperties2CaPools_ for a cell with two Ca pools"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:biophysicalProperties2CaPools ;
+    nml:exposes "totSpecCap" .
+
+nml:blockingPlasticSynapse a owl:Class ;
+    rdfs:label "blockingPlasticSynapse"@en ;
+    dcterms:description "Biexponential synapse that allows for     optional block and plasticity     mechanisms, which can be expressed as     child elements."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:expTwoSynapse ;
+    skos:exactMatch neuroml2:blockingPlasticSynapse ;
+    nml:eventPort "relay" .
+
+nml:cell2CaPools a owl:Class ;
+    rdfs:label "cell2CaPools"@en ;
+    dcterms:description "Variant of cell with two independent Ca2+ pools. Cell with _segment_s specified in a _morphology_ element along with details on its _biophysicalProperties_. NOTE: this can only be correctly simulated using jLEMS when there is a single segment in the cell, and _v of this cell represents the membrane potential in that isopotential segment."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:cell ;
+    skos:exactMatch neuroml2:cell2CaPools ;
+    nml:exposes "caConc2",
+        "caConcExt2",
+        "iCa2" .
+
+nml:channelDensityGHK a owl:Class ;
+    rdfs:label "channelDensityGHK"@en ;
+    dcterms:description "Specifies a time varying conductance density, _gDensity, which is distributed on an area of the cell, producing a current density _iDensity and whose reversal potential is calculated from the Goldman Hodgkin Katz equation. Hard coded for Ca only! See https://github.com/OpenSourceBrain/ghk-nernst."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensity ;
+    skos:exactMatch neuroml2:channelDensityGHK ;
+    nml:hasParameter "permeability" ;
+    nml:requires "caConc",
+        "caConcExt",
+        "temperature" .
+
+nml:channelDensityGHK2 a owl:Class ;
+    rdfs:label "channelDensityGHK2"@en ;
+    dcterms:description "Time varying conductance density, _gDensity, which is distributed on an area of the cell, producing a current density _iDensity. Modified version of Jaffe et al. 1994 (used also in Lawrence et al. 2006). See https://github.com/OpenSourceBrain/ghk-nernst."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensityCond ;
+    skos:exactMatch neuroml2:channelDensityGHK2 ;
+    nml:requires "caConc",
+        "caConcExt",
+        "temperature" .
+
+nml:channelDensityNernst a owl:Class ;
+    rdfs:label "channelDensityNernst"@en ;
+    dcterms:description "Specifies a time varying conductance density, _gDensity, which is distributed on an area of the _cell, producing a current density _iDensity and whose reversal potential is calculated from the Nernst equation. Hard coded for Ca only! See https://github.com/OpenSourceBrain/ghk-nernst."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensityCond ;
+    skos:exactMatch neuroml2:channelDensityNernst ;
+    nml:exposes "erev" ;
+    nml:requires "caConc",
+        "caConcExt",
+        "temperature" .
+
+nml:channelDensityNernstCa2 a owl:Class ;
+    rdfs:label "channelDensityNernstCa2"@en ;
+    dcterms:description "This component is similar to the original component type _channelDensityNernst_ but it is changed in order to have a reversal potential that depends on a second independent Ca++ pool (ca2). See https://github.com/OpenSourceBrain/ghk-nernst."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensityCond ;
+    skos:exactMatch neuroml2:channelDensityNernstCa2 ;
+    nml:exposes "erev" ;
+    nml:requires "caConc2",
+        "caConcExt2",
+        "temperature" .
+
+nml:channelDensityNonUniform a owl:Class ;
+    rdfs:label "channelDensityNonUniform"@en ;
+    dcterms:description "Specifies a time varying ohmic conductance density, which is distributed on a region of the _cell. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensity ;
+    skos:exactMatch neuroml2:channelDensityNonUniform ;
+    nml:hasParameter "erev" .
+
+nml:channelDensityNonUniformGHK a owl:Class ;
+    rdfs:label "channelDensityNonUniformGHK"@en ;
+    dcterms:description "Specifies a time varying conductance density, which is distributed on a region of the _cell, and whose current is calculated from the Goldman-Hodgkin-Katz equation. Hard coded for Ca only!. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensity ;
+    skos:exactMatch neuroml2:channelDensityNonUniformGHK .
+
+nml:channelDensityNonUniformNernst a owl:Class ;
+    rdfs:label "channelDensityNonUniformNernst"@en ;
+    dcterms:description "Specifies a time varying conductance density, which is distributed on a region of the _cell, and whose reversal potential is calculated from the Nernst equation. Hard coded for Ca only!. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensity ;
+    skos:exactMatch neuroml2:channelDensityNonUniformNernst .
+
+nml:channelDensityVShift a owl:Class ;
+    rdfs:label "channelDensityVShift"@en ;
+    dcterms:description "Same as _channelDensity_, but with a _vShift parameter to change voltage activation of gates. The exact usage of _vShift in expressions for rates is determined by the individual gates."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:channelDensity ;
+    skos:exactMatch neuroml2:channelDensityVShift ;
+    nml:hasParameter "vShift" .
+
+nml:channelPopulation a owl:Class ;
+    rdfs:label "channelPopulation"@en ;
+    dcterms:description "Population of a _number of ohmic ion channels. These each produce a conductance _channelg across a reversal potential _erev, giving a total current _i. Note that active membrane currents are more frequently specified as a density over an area of the _cell_ using _channelDensity_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelPopulation ;
+    skos:exactMatch neuroml2:channelPopulation ;
+    nml:hasParameter "erev",
+        "number" .
+
+nml:channelPopulationNernst a owl:Class ;
+    rdfs:label "channelPopulationNernst"@en ;
+    dcterms:description "Population of a _number of channels with a time varying reversal potential _erev determined by Nernst equation. Note: hard coded for Ca only!"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelPopulation ;
+    skos:exactMatch neuroml2:channelPopulationNernst ;
+    nml:exposes "erev" ;
+    nml:hasParameter "number" ;
+    nml:requires "caConc",
+        "caConcExt",
+        "temperature" .
+
+nml:closedState a owl:Class ;
+    rdfs:label "closedState"@en ;
+    dcterms:description "A _KSState_ with _relativeConductance of 0"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:KSState ;
+    skos:exactMatch neuroml2:closedState ;
+    nml:hasParameter "relativeConductance" .
+
+nml:compoundInput a owl:Class ;
+    rdfs:label "compoundInput"@en ;
+    dcterms:description "Generates a current which is the sum of all its child _basePointCurrent_ element, e.g. can be a combination of _pulseGenerator_, _sineGenerator_ elements producing a single _i. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrent ;
+    skos:exactMatch neuroml2:compoundInput ;
+    nml:eventPort "in" .
+
+nml:compoundInputDL a owl:Class ;
+    rdfs:label "compoundInputDL"@en ;
+    dcterms:description "Generates a current which is the sum of all its child _basePointCurrentDL_ elements, e.g. can be a combination of _pulseGeneratorDL_, _sineGeneratorDL_ elements producing a single _i. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrentDL ;
+    skos:exactMatch neuroml2:compoundInputDL ;
+    nml:eventPort "in" .
+
+nml:connectionWD a owl:Class ;
+    rdfs:label "connectionWD"@en ;
+    dcterms:description "Event connection between named components, which gets processed via a new instance of a synapse component which is created on the target component, includes setting of _weight and _delay for the synaptic connection"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:connection ;
+    skos:exactMatch neuroml2:connectionWD ;
+    nml:hasParameter "delay",
+        "weight" .
+
+nml:continuousConnection a owl:Class ;
+    rdfs:label "continuousConnection"@en ;
+    dcterms:description "An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Can be used for analog synapses."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:continuousConnection .
+
+nml:continuousConnectionInstanceW a owl:Class ;
+    rdfs:label "continuousConnectionInstanceW"@en ;
+    dcterms:description "An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Can be used for analog synapses. Includes setting of _weight for the connection"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:continuousConnectionInstance ;
+    skos:exactMatch neuroml2:continuousConnectionInstanceW ;
+    nml:hasParameter "weight" .
+
+nml:continuousProjection a owl:Class ;
+    rdfs:label "continuousProjection"@en ;
+    dcterms:description "A projection between _presynapticPopulation and _postsynapticPopulation through components _preComponent at the start and _postComponent at the end of a _continuousConnection_ or _continuousConnectionInstance_. Can be used for analog synapses."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:continuousProjection .
+
+nml:decayingPoolConcentrationModel a owl:Class ;
+    rdfs:label "decayingPoolConcentrationModel"@en ;
+    dcterms:description "Model of an intracellular buffering mechanism for _ion (currently hard Coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course _decayConstant. The ion is assumed to occupy a shell inside the membrane of thickness _shellThickness."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:concentrationModel ;
+    skos:exactMatch neuroml2:decayingPoolConcentrationModel ;
+    nml:hasParameter "decayConstant",
+        "restingConc",
+        "shellThickness" ;
+    nml:requires "iCa" .
+
+nml:distal a owl:Class ;
+    rdfs:label "distal"@en ;
+    dcterms:description "Point on a _segment_ furthest from the soma. Should always be present in the description of a _segment_, unlike _proximal_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:point3DWithDiam ;
+    skos:exactMatch neuroml2:distal .
+
+nml:distalDetails a owl:Class ;
+    rdfs:label "distalDetails"@en ;
+    dcterms:description "What to do at the distal point when creating an inhomogeneous parameter"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:distalDetails .
+
+nml:doubleSynapse a owl:Class ;
+    rdfs:label "doubleSynapse"@en ;
+    dcterms:description "Synapse consisting of two independent synaptic mechanisms (e.g. AMPA-R and NMDA-R), which can be easily colocated in connections"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepSynapse ;
+    skos:exactMatch neuroml2:doubleSynapse ;
+    nml:eventPort "relay" .
+
+nml:electricalConnection a owl:Class ;
+    rdfs:label "electricalConnection"@en ;
+    dcterms:description "To enable connections between populations through gap junctions."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:electricalConnection .
+
+nml:electricalConnectionInstanceW a owl:Class ;
+    rdfs:label "electricalConnectionInstanceW"@en ;
+    dcterms:description "To enable connections between populations through gap junctions. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Includes setting of _weight for the connection"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:electricalConnectionInstance ;
+    skos:exactMatch neuroml2:electricalConnectionInstanceW ;
+    nml:hasParameter "weight" .
+
+nml:electricalProjection a owl:Class ;
+    rdfs:label "electricalProjection"@en ;
+    dcterms:description "A projection between _presynapticPopulation to another _postsynapticPopulation through gap junctions."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:electricalProjection .
+
+nml:eventPort a owl:AnnotationProperty ;
+    rdfs:label "event port"@en ;
+    rdfs:comment "An event port declared by this NeuroML ComponentType."@en .
+
+nml:expCondSynapse a owl:Class ;
+    rdfs:label "expCondSynapse"@en ;
+    dcterms:description "Conductance based synapse with instantaneous rise and single exponential decay (with time constant tau_syn)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePynnSynapse ;
+    skos:exactMatch neuroml2:expCondSynapse ;
+    nml:exposes "g" ;
+    nml:hasParameter "e_rev" .
+
+nml:expCurrSynapse a owl:Class ;
+    rdfs:label "expCurrSynapse"@en ;
+    dcterms:description "Current based synapse with instantaneous rise and single exponential decay (with time constant tau_syn)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePynnSynapse ;
+    skos:exactMatch neuroml2:expCurrSynapse .
+
+nml:expOneSynapse a owl:Class ;
+    rdfs:label "expOneSynapse"@en ;
+    dcterms:description "Ohmic synapse model whose conductance rises instantaneously by (_gbase * _weight) on receiving an event, and which decays exponentially to zero with time course _tauDecay"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseConductanceBasedSynapse ;
+    skos:exactMatch neuroml2:expOneSynapse ;
+    nml:hasParameter "tauDecay" .
+
+nml:expThreeSynapse a owl:Class ;
+    rdfs:label "expThreeSynapse"@en ;
+    dcterms:description "Ohmic synapse similar to expTwoSynapse but consisting of two components that can differ in decay times and max conductances but share the same rise time."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseConductanceBasedSynapseTwo ;
+    skos:exactMatch neuroml2:expThreeSynapse ;
+    nml:hasParameter "tauDecay1",
+        "tauDecay2",
+        "tauRise" .
+
+nml:explicitInput a owl:Class ;
+    rdfs:label "explicitInput"@en ;
+    dcterms:description "An explicit input (anything which extends _basePointCurrent_) to a target cell in a population"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:explicitInput .
+
+nml:exposes a owl:AnnotationProperty ;
+    rdfs:label "exposes"@en ;
+    rdfs:comment "A quantity this NeuroML ComponentType exposes."@en .
+
+nml:fitzHughNagumo1969Cell a owl:Class ;
+    rdfs:label "fitzHughNagumo1969Cell"@en ;
+    dcterms:description "The Fitzhugh Nagumo model is a two-dimensional simplification of the Hodgkin-Huxley model of spike generation in squid giant axons.  This system was suggested by FitzHugh (FitzHugh R. [1961]: Impulses and physiological states in theoretical models of nerve membrane.  Biophysical J.  1:445-466), who called it \" Bonhoeffer-van der Pol model \", and the equivalent circuit by Nagumo et al.  (Nagumo J., Arimoto S., and Yoshizawa S. [1962] An active pulse transmission line simulating nerve axon. Proc IRE. 50:2061-2070.1962). This version corresponds to the one described in FitzHugh R.[1969]: Mathematical models of excitation and propagation in nerve.  Chapter 1 (pp. 1-85 in H.P. Schwan, ed. Biological Engineering, McGraw-Hill Book Co., N.Y.)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotDL ;
+    skos:exactMatch neuroml2:fitzHughNagumo1969Cell ;
+    nml:exposes "F",
+        "W" ;
+    nml:hasParameter "I",
+        "V0",
+        "W0",
+        "a",
+        "b",
+        "phi" .
+
+nml:fitzHughNagumoCell a owl:Class ;
+    rdfs:label "fitzHughNagumoCell"@en ;
+    dcterms:description "Simple dimensionless model of spiking cell from FitzHugh and Nagumo. Superseded by _fitzHughNagumo1969Cell (See https://github.com/NeuroML/NeuroML2/issues/42)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotDL ;
+    skos:exactMatch neuroml2:fitzHughNagumoCell ;
+    nml:exposes "W" ;
+    nml:hasParameter "I" .
+
+nml:fixedFactorConcentrationModel a owl:Class ;
+    rdfs:label "fixedFactorConcentrationModel"@en ;
+    dcterms:description "Model of buffering of concentration of an ion (currently hard coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course _decayConstant. A fixed factor _rho is used to scale the incoming current *independently of the size of the compartment* to produce a concentration change."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:concentrationModel ;
+    skos:exactMatch neuroml2:fixedFactorConcentrationModel ;
+    nml:hasParameter "decayConstant",
+        "restingConc",
+        "rho" ;
+    nml:requires "iCa",
+        "surfaceArea" .
+
+nml:fixedFactorConcentrationModelTraub a owl:Class ;
+    rdfs:label "fixedFactorConcentrationModelTraub"@en ;
+    dcterms:description "Model of buffering of concentration of an ion (currently hard coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course 1 / _beta. A fixed factor _phi is used to scale the incoming current *independently of the size of the compartment* to produce a concentration change. Not recommended for use in models other than Traub et al. 2005!"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:concentrationModel ;
+    skos:exactMatch neuroml2:fixedFactorConcentrationModelTraub ;
+    nml:hasParameter "beta",
+        "phi",
+        "restingConc" ;
+    nml:requires "iCa",
+        "surfaceArea" .
+
+nml:fixedTimeCourse a owl:Class ;
+    rdfs:label "fixedTimeCourse"@en ;
+    dcterms:description "Time course of a fixed magnitude _tau which can be used for the time course in _gateHHtauInf_, _gateHHratesTau_ or _gateHHratesTauInf_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepTime ;
+    skos:exactMatch neuroml2:fixedTimeCourse ;
+    nml:hasParameter "tau" .
+
+nml:foaf_account a owl:Class ;
+    rdfs:label "foaf_account"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_account .
+
+nml:foaf_fundedBy a owl:Class ;
+    rdfs:label "foaf_fundedBy"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_fundedBy .
+
+nml:foaf_homepage a owl:Class ;
+    rdfs:label "foaf_homepage"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_homepage .
+
+nml:foaf_mbox a owl:Class ;
+    rdfs:label "foaf_mbox"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_mbox .
+
+nml:foaf_name a owl:Class ;
+    rdfs:label "foaf_name"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_name .
+
+nml:foaf_publications a owl:Class ;
+    rdfs:label "foaf_publications"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_publications .
+
+nml:foaf_thumbnail a owl:Class ;
+    rdfs:label "foaf_thumbnail"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_thumbnail .
+
+nml:foaf_weblog a owl:Class ;
+    rdfs:label "foaf_weblog"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:foaf_weblog .
+
+nml:forwardTransition a owl:Class ;
+    rdfs:label "forwardTransition"@en ;
+    dcterms:description "A forward only _KSTransition_ for a _gateKS_ which specifies a _rate (type _baseHHRate_) which follows one of the standard Hodgkin Huxley forms (e.g. _HHExpRate_, _HHSigmoidRate_, _HHExpLinearRate_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:KSTransition ;
+    skos:exactMatch neuroml2:forwardTransition .
+
+nml:from a owl:Class ;
+    rdfs:label "from"@en ;
+    dcterms:description "In a _path_ or _subTree_, specifies which _segment (inclusive) from which to calculate the _segmentGroup_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:from .
+
+nml:gapJunction a owl:Class ;
+    rdfs:label "gapJunction"@en ;
+    dcterms:description "Gap junction/single electrical connection"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSynapse ;
+    skos:exactMatch neuroml2:gapJunction ;
+    nml:exposes "i" ;
+    nml:hasParameter "conductance" ;
+    nml:requires "v" .
+
+nml:gateFractional a owl:Class ;
+    rdfs:label "gateFractional"@en ;
+    dcterms:description "Gate composed of subgates contributing with fractional conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateFractional ;
+    nml:exposes "rateScale" .
+
+nml:gateHHInstantaneous a owl:Class ;
+    rdfs:label "gateHHInstantaneous"@en ;
+    dcterms:description "Gate which follows the general Hodgkin Huxley formalism but is instantaneous, so tau = 0 and gate follows exactly inf value"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateHHInstantaneous ;
+    nml:exposes "inf",
+        "tau" .
+
+nml:gateHHrates a owl:Class ;
+    rdfs:label "gateHHrates"@en ;
+    dcterms:description "Gate which follows the general Hodgkin Huxley formalism"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateHHrates ;
+    nml:exposes "alpha",
+        "beta",
+        "inf",
+        "rateScale",
+        "tau" .
+
+nml:gateHHratesInf a owl:Class ;
+    rdfs:label "gateHHratesInf"@en ;
+    dcterms:description "Gate which follows the general Hodgkin Huxley formalism"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateHHratesInf ;
+    nml:exposes "alpha",
+        "beta",
+        "inf",
+        "rateScale",
+        "tau" .
+
+nml:gateHHratesTau a owl:Class ;
+    rdfs:label "gateHHratesTau"@en ;
+    dcterms:description "Gate which follows the general Hodgkin Huxley formalism"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateHHratesTau ;
+    nml:exposes "alpha",
+        "beta",
+        "inf",
+        "rateScale",
+        "tau" .
+
+nml:gateHHratesTauInf a owl:Class ;
+    rdfs:label "gateHHratesTauInf"@en ;
+    dcterms:description "Gate which follows the general Hodgkin Huxley formalism"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateHHratesTauInf ;
+    nml:exposes "alpha",
+        "beta",
+        "inf",
+        "rateScale",
+        "tau" .
+
+nml:gateHHtauInf a owl:Class ;
+    rdfs:label "gateHHtauInf"@en ;
+    dcterms:description "Gate which follows the general Hodgkin Huxley formalism"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:gate ;
+    skos:exactMatch neuroml2:gateHHtauInf ;
+    nml:exposes "inf",
+        "rateScale",
+        "tau" .
+
+nml:gateKS a owl:Class ;
+    rdfs:label "gateKS"@en ;
+    dcterms:description "A gate which consists of multiple _KSState_s and _KSTransition_s giving the rates of transition between them"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseGate ;
+    skos:exactMatch neuroml2:gateKS ;
+    nml:exposes "rateScale" .
+
+nml:gradedSynapse a owl:Class ;
+    rdfs:label "gradedSynapse"@en ;
+    dcterms:description "Graded/analog synapse. Based on synapse in Methods of http://www.nature.com/neuro/journal/v7/n12/abs/nn1352.html"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseGradedSynapse ;
+    skos:exactMatch neuroml2:gradedSynapse ;
+    nml:exposes "i",
+        "inf",
+        "tau" ;
+    nml:hasParameter "Vth",
+        "conductance",
+        "delta",
+        "erev",
+        "k" ;
+    nml:requires "v" .
+
+nml:hasParameter a owl:AnnotationProperty ;
+    rdfs:label "has parameter"@en ;
+    rdfs:comment "A parameter declared by this NeuroML ComponentType."@en .
+
+nml:hindmarshRose1984Cell a owl:Class ;
+    rdfs:label "hindmarshRose1984Cell"@en ;
+    dcterms:description "         The Hindmarsh Rose model is a simplified point cell model which         captures complex firing patterns of single neurons, such as         periodic and chaotic bursting. It has a fast spiking subsystem,         which is a generalization of the FitzHugh-Nagumo system, coupled         to a slower subsystem which allows the model to fire bursts. The         dynamical variables x,y,z correspond to the membrane potential, a         recovery variable, and a slower adaptation current, respectively.          See Hindmarsh J. L., and Rose R. M. (1984) A model of neuronal         bursting using three coupled first order differential equations.         Proc. R. Soc. London, Ser. B 221:87–102.         "@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotCap ;
+    skos:exactMatch neuroml2:hindmarshRose1984Cell ;
+    nml:exposes "chi",
+        "phi",
+        "rho",
+        "spiking",
+        "x",
+        "y",
+        "z" ;
+    nml:hasParameter "a",
+        "b",
+        "c",
+        "d",
+        "r",
+        "s",
+        "v_scaling",
+        "x0",
+        "x1",
+        "y0",
+        "z0" .
+
+nml:iafRefCell a owl:Class ;
+    rdfs:label "iafRefCell"@en ;
+    dcterms:description "Integrate and fire cell  with capacitance _C, _leakConductance, _leakReversal and refractory period _refract"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:iafCell ;
+    skos:exactMatch neuroml2:iafRefCell ;
+    nml:hasParameter "refract" .
+
+nml:iafTauRefCell a owl:Class ;
+    rdfs:label "iafTauRefCell"@en ;
+    dcterms:description "Integrate and fire cell which returns to its leak reversal potential of _leakReversal with a time course _tau. It has a refractory period of _refract after spiking"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:iafTauCell ;
+    skos:exactMatch neuroml2:iafTauRefCell ;
+    nml:hasParameter "refract" .
+
+nml:include a owl:Class ;
+    rdfs:label "include"@en ;
+    dcterms:description "Include all members of another _segmentGroup_ in this group"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:include .
+
+nml:inhomogeneousParameter a owl:Class ;
+    rdfs:label "inhomogeneousParameter"@en ;
+    dcterms:description "An inhomogeneous parameter specified across the _segmentGroup_ (see _variableParameter_ for usage)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:inhomogeneousParameter .
+
+nml:inhomogeneousValue a owl:Class ;
+    rdfs:label "inhomogeneousValue"@en ;
+    dcterms:description "Specifies the _value of an _inhomogeneousParameter. For usage see _variableParameter_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:inhomogeneousValue .
+
+nml:initMembPotential a owl:Class ;
+    rdfs:label "initMembPotential"@en ;
+    dcterms:description "Explicitly set initial membrane potential for the cell"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:initMembPotential ;
+    nml:hasParameter "value" .
+
+nml:inputList a owl:Class ;
+    rdfs:label "inputList"@en ;
+    dcterms:description "An explicit list of _input_s to a _population."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:inputList .
+
+nml:inputW a owl:Class ;
+    rdfs:label "inputW"@en ;
+    dcterms:description "Specifies input lists. Can set _weight to scale individual inputs."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:input ;
+    skos:exactMatch neuroml2:inputW ;
+    nml:hasParameter "weight" .
+
+nml:instance a owl:Class ;
+    rdfs:label "instance"@en ;
+    dcterms:description "Specifies a single instance of a component in a _population_ (placed at _location_)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:instance .
+
+nml:intracellularProperties2CaPools a owl:Class ;
+    rdfs:label "intracellularProperties2CaPools"@en ;
+    dcterms:description "Variant of intracellularProperties with 2 independent Ca pools"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:intracellularProperties ;
+    skos:exactMatch neuroml2:intracellularProperties2CaPools ;
+    nml:exposes "caConc",
+        "caConc2",
+        "caConcExt",
+        "caConcExt2" .
+
+nml:ionChannelKS a owl:Class ;
+    rdfs:label "ionChannelKS"@en ;
+    dcterms:description "A kinetic scheme based ion channel with multiple _gateKS_s, each of which consists of multiple _KSState_s and _KSTransition_s giving the rates of transition between them"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseIonChannel ;
+    skos:exactMatch neuroml2:ionChannelKS .
+
+nml:ionChannelPassive a owl:Class ;
+    rdfs:label "ionChannelPassive"@en ;
+    dcterms:description "Simple passive ion channel where the constant conductance through the channel is equal to _conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:ionChannel ;
+    skos:exactMatch neuroml2:ionChannelPassive .
+
+nml:ionChannelVShift a owl:Class ;
+    rdfs:label "ionChannelVShift"@en ;
+    dcterms:description "Same as _ionChannel_, but with a _vShift parameter to change voltage activation of gates. The exact usage of _vShift in expressions for rates is determined by the individual gates."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:ionChannel ;
+    skos:exactMatch neuroml2:ionChannelVShift ;
+    nml:hasParameter "vShift" .
+
+nml:izhikevich2007Cell a owl:Class ;
+    rdfs:label "izhikevich2007Cell"@en ;
+    dcterms:description "Cell based on the modified Izhikevich model in Izhikevich 2007, Dynamical systems in neuroscience, MIT Press"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotCap ;
+    skos:exactMatch neuroml2:izhikevich2007Cell ;
+    nml:exposes "u" ;
+    nml:hasParameter "a",
+        "b",
+        "c",
+        "d",
+        "k",
+        "v0",
+        "vpeak",
+        "vr",
+        "vt" .
+
+nml:izhikevichCell a owl:Class ;
+    rdfs:label "izhikevichCell"@en ;
+    dcterms:description "Cell based on the 2003 model of Izhikevich, see http://izhikevich.org/publications/spikes.htm"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPot ;
+    skos:exactMatch neuroml2:izhikevichCell ;
+    nml:exposes "U" ;
+    nml:hasParameter "a",
+        "b",
+        "c",
+        "d",
+        "thresh",
+        "v0" .
+
+nml:linearGradedSynapse a owl:Class ;
+    rdfs:label "linearGradedSynapse"@en ;
+    dcterms:description "Behaves just like a one way gap junction."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseGradedSynapse ;
+    skos:exactMatch neuroml2:linearGradedSynapse ;
+    nml:exposes "i" ;
+    nml:hasParameter "conductance" ;
+    nml:requires "v" .
+
+nml:location a owl:Class ;
+    rdfs:label "location"@en ;
+    dcterms:description "Specifies the (x,y,z) location of a single _instance_ of a component in a _population_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:location ;
+    nml:hasParameter "x",
+        "y",
+        "z" .
+
+nml:member a owl:Class ;
+    rdfs:label "member"@en ;
+    dcterms:description "A single identified _segment which is part of the _segmentGroup_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:member .
+
+nml:membraneProperties2CaPools a owl:Class ;
+    rdfs:label "membraneProperties2CaPools"@en ;
+    dcterms:description "Variant of membraneProperties with 2 independent Ca pools"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:membraneProperties ;
+    skos:exactMatch neuroml2:membraneProperties2CaPools ;
+    nml:exposes "iCa",
+        "iCa2",
+        "totChanCurrent",
+        "totSpecCap" ;
+    nml:requires "surfaceArea" .
+
+nml:morphology a owl:Class ;
+    rdfs:label "morphology"@en ;
+    dcterms:description "The collection of _segment_s which specify the 3D structure of the cell, along with a number of _segmentGroup_s"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:morphology .
+
+nml:networkWithTemperature a owl:Class ;
+    rdfs:label "networkWithTemperature"@en ;
+    dcterms:description "Same as _network_, but with an explicit _temperature for temperature dependent elements (e.g. ion channels)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:network ;
+    skos:exactMatch neuroml2:networkWithTemperature ;
+    nml:hasParameter "temperature" .
+
+nml:openState a owl:Class ;
+    rdfs:label "openState"@en ;
+    dcterms:description "A _KSState_ with _relativeConductance of 1"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:KSState ;
+    skos:exactMatch neuroml2:openState ;
+    nml:hasParameter "relativeConductance" .
+
+nml:orcid_id a owl:Class ;
+    rdfs:label "orcid_id"@en ;
+    dcterms:description "https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:orcid_id .
+
+nml:parent a owl:Class ;
+    rdfs:label "parent"@en ;
+    dcterms:description "Specifies the _segment_ which is this segment's parent. The _fractionAlong specifies where it is connected, usually 1 (the default value), meaning the _distal_ point of the parent, or 0, meaning the _proximal_ point. If it is between these, a linear interpolation between the 2 points should be used."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:parent .
+
+nml:path a owl:Class ;
+    rdfs:label "path"@en ;
+    dcterms:description "Include all the _segment_s between those specified by _from_ and _to_, inclusive"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:path .
+
+nml:pinskyRinzelCA3Cell a owl:Class ;
+    rdfs:label "pinskyRinzelCA3Cell"@en ;
+    dcterms:description "Reduced CA3 cell model from Pinsky, P.F., Rinzel, J. Intrinsic and network rhythmogenesis in a reduced traub model for CA3 neurons. J Comput Neurosci 1, 39-60 (1994). See https://github.com/OpenSourceBrain/PinskyRinzelModel"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPot ;
+    skos:exactMatch neuroml2:pinskyRinzelCA3Cell ;
+    nml:exposes "Cad",
+        "ICad",
+        "Si",
+        "Vd",
+        "Vs",
+        "Wi",
+        "cd",
+        "hs",
+        "ns",
+        "qd",
+        "sd" ;
+    nml:hasParameter "alphac",
+        "betac",
+        "cm",
+        "eCa",
+        "eK",
+        "eL",
+        "eNa",
+        "gAmpa",
+        "gCa",
+        "gKC",
+        "gKahp",
+        "gKdr",
+        "gLd",
+        "gLs",
+        "gNa",
+        "gNmda",
+        "gc",
+        "iDend",
+        "iSoma",
+        "pp",
+        "qd0" .
+
+nml:pointCellCondBased a owl:Class ;
+    rdfs:label "pointCellCondBased"@en ;
+    dcterms:description "Simple model of a conductance based cell, with no separate _morphology_ element, just an absolute capacitance _C, and a set of channel _populations. Note: use of _cell_ is generally preferable (and more widely supported), even for a single compartment cell."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotCap ;
+    skos:exactMatch neuroml2:pointCellCondBased ;
+    nml:hasParameter "thresh",
+        "v0" .
+
+nml:pointCellCondBasedCa a owl:Class ;
+    rdfs:label "pointCellCondBasedCa"@en ;
+    dcterms:description "TEMPORARY: Point cell with conductances and Ca concentration info. Not yet fully tested!!! TODO: Remove in favour of _cell_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotCap ;
+    skos:exactMatch neuroml2:pointCellCondBasedCa ;
+    nml:exposes "caConc",
+        "iCa" ;
+    nml:hasParameter "thresh",
+        "v0" .
+
+nml:poissonFiringSynapse a owl:Class ;
+    rdfs:label "poissonFiringSynapse"@en ;
+    dcterms:description "Poisson spike generator firing at _averageRate, which is connected to single _synapse that is triggered every time a spike is generated, producing an input current. See also _transientPoissonFiringSynapse_."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrentSpiking ;
+    skos:exactMatch neuroml2:poissonFiringSynapse ;
+    nml:eventPort "in",
+        "spike" ;
+    nml:exposes "isi",
+        "tnextIdeal",
+        "tnextUsed",
+        "tsince" ;
+    nml:hasParameter "averageRate" .
+
+nml:population a owl:Class ;
+    rdfs:label "population"@en ;
+    dcterms:description "A population of components, with just one parameter for the _size, i.e. number of components to create. Note: quite often this is used with type=_populationList_ which means the size is determined by the number of _instance_s (with _location_s) in the list. The _size attribute is still set, and there will be a validation error if this does not match the number in the list."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePopulation ;
+    skos:exactMatch neuroml2:population ;
+    nml:hasParameter "size" .
+
+nml:populationList a owl:Class ;
+    rdfs:label "populationList"@en ;
+    dcterms:description "An explicit list of _instance_s (with _location_s) of components in the population. "@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePopulation ;
+    skos:exactMatch neuroml2:populationList .
+
+nml:projection a owl:Class ;
+    rdfs:label "projection"@en ;
+    dcterms:description "Projection from one population, _presynapticPopulation to another, _postsynapticPopulation, through _synapse. Contains lists of _connection_ or _connectionWD_ elements."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:projection .
+
+nml:proximal a owl:Class ;
+    rdfs:label "proximal"@en ;
+    dcterms:description "Point on a _segment_ closest to the soma. Note, the proximal point can be omitted, and in this case is defined as being the point _fractionAlong between the proximal and _distal_ point of the _parent_, i.e. if _fractionAlong = 1 (as it is by default) it will be the _distal on the parent, or if _fractionAlong = 0, it will be the proximal point. If between 0 and 1, it is the linear interpolation between the two points."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:point3DWithDiam ;
+    skos:exactMatch neuroml2:proximal .
+
+nml:proximalDetails a owl:Class ;
+    rdfs:label "proximalDetails"@en ;
+    dcterms:description "What to do at the proximal point when creating an inhomogeneous parameter"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:proximalDetails .
+
+nml:pulseGenerator a owl:Class ;
+    rdfs:label "pulseGenerator"@en ;
+    dcterms:description "Generates a constant current pulse of a certain _amplitude for a specified _duration after a _delay. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrent ;
+    skos:exactMatch neuroml2:pulseGenerator ;
+    nml:eventPort "in" ;
+    nml:hasParameter "amplitude",
+        "delay",
+        "duration" .
+
+nml:pulseGeneratorDL a owl:Class ;
+    rdfs:label "pulseGeneratorDL"@en ;
+    dcterms:description "Dimensionless equivalent of _pulseGenerator_. Generates a constant current pulse of a certain _amplitude for a specified _duration after a _delay. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrentDL ;
+    skos:exactMatch neuroml2:pulseGeneratorDL ;
+    nml:eventPort "in" ;
+    nml:hasParameter "amplitude",
+        "delay",
+        "duration" .
+
+nml:q10ConductanceScaling a owl:Class ;
+    rdfs:label "q10ConductanceScaling"@en ;
+    dcterms:description "A value for the conductance scaling which varies as a standard function of the difference between the current temperature, _temperature, and the temperature at which the conductance was originally determined, _experimentalTemp"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseConductanceScaling ;
+    skos:exactMatch neuroml2:q10ConductanceScaling ;
+    nml:hasParameter "experimentalTemp",
+        "q10Factor" .
+
+nml:q10ExpTemp a owl:Class ;
+    rdfs:label "q10ExpTemp"@en ;
+    dcterms:description "A value for the Q10 scaling which varies as a standard function of the difference between the current temperature, _temperature, and the temperature at which the gating variable equations were determined, _experimentalTemp"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseQ10Settings ;
+    skos:exactMatch neuroml2:q10ExpTemp ;
+    nml:hasParameter "experimentalTemp",
+        "q10Factor" .
+
+nml:q10Fixed a owl:Class ;
+    rdfs:label "q10Fixed"@en ;
+    dcterms:description "A fixed value, _fixedQ10, for the scaling of the time course of the gating variable"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseQ10Settings ;
+    skos:exactMatch neuroml2:q10Fixed ;
+    nml:hasParameter "fixedQ10" .
+
+nml:rampGenerator a owl:Class ;
+    rdfs:label "rampGenerator"@en ;
+    dcterms:description "Generates a ramping current after a time _delay, for a fixed _duration. During this time the current steadily changes from _startAmplitude to _finishAmplitude. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrent ;
+    skos:exactMatch neuroml2:rampGenerator ;
+    nml:eventPort "in" ;
+    nml:hasParameter "baselineAmplitude",
+        "delay",
+        "duration",
+        "finishAmplitude",
+        "startAmplitude" .
+
+nml:rampGeneratorDL a owl:Class ;
+    rdfs:label "rampGeneratorDL"@en ;
+    dcterms:description "Dimensionless equivalent of _rampGenerator_. Generates a ramping current after a time _delay, for a fixed _duration. During this time the dimensionless current steadily changes from _startAmplitude to _finishAmplitude. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrentDL ;
+    skos:exactMatch neuroml2:rampGeneratorDL ;
+    nml:eventPort "in" ;
+    nml:hasParameter "baselineAmplitude",
+        "delay",
+        "duration",
+        "finishAmplitude",
+        "startAmplitude" .
+
+nml:rectangularExtent a owl:Class ;
+    rdfs:label "rectangularExtent"@en ;
+    dcterms:description "For defining a 3D rectangular box"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:rectangularExtent ;
+    nml:hasParameter "xLength",
+        "xStart",
+        "yLength",
+        "yStart",
+        "zLength",
+        "zStart" .
+
+nml:region a owl:Class ;
+    rdfs:label "region"@en ;
+    dcterms:description "Initial attempt to specify 3D region for placing cells. Work in progress..."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:region .
+
+nml:requires a owl:AnnotationProperty ;
+    rdfs:label "requires"@en ;
+    rdfs:comment "A quantity this NeuroML ComponentType requires from its context."@en .
+
+nml:resistivity a owl:Class ;
+    rdfs:label "resistivity"@en ;
+    dcterms:description "The resistivity, or specific axial resistance, of the cytoplasm"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:resistivity ;
+    nml:hasParameter "value" .
+
+nml:reverseTransition a owl:Class ;
+    rdfs:label "reverseTransition"@en ;
+    dcterms:description "A reverse only _KSTransition_ for a _gateKS_ which specifies a _rate (type _baseHHRate_) which follows one of the standard Hodgkin Huxley forms (e.g. _HHExpRate_, _HHSigmoidRate_, _HHExpLinearRate_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:KSTransition ;
+    skos:exactMatch neuroml2:reverseTransition .
+
+nml:segment a owl:Class ;
+    rdfs:label "segment"@en ;
+    dcterms:description "A segment defines the smallest unit within a possibly branching structure (_morphology_), such as a dendrite or axon. Its _id should be a nonnegative integer (usually soma/root = 0). Its end points are given by the _proximal_ and _distal_ points. The _proximal_ point can be omitted, usually because it is the same as a point on the _parent_ segment, see _proximal_ for details. _parent_ specifies the parent segment. The first segment of a _cell_ (with no _parent_) usually represents the soma. The shape is normally a cylinder (radii of the _proximal_ and _distal_ equal, but positions different) or a conical frustum (radii and positions different). If the x,y,x positions of the _proximal_ and _distal_ are equal, the segment can be interpreted as a sphere, and in this case the radii of these points must be equal. NOTE: LEMS does not yet support multicompartmental modelling, so the Dynamics here is only appropriate for single compartment modelling. "@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:segment ;
+    nml:exposes "length",
+        "radDist",
+        "surfaceArea" .
+
+nml:segmentGroup a owl:Class ;
+    rdfs:label "segmentGroup"@en ;
+    dcterms:description "A method to describe a group of _segment_s in a _morphology_, e.g. soma_group, dendrite_group, axon_group. While a name is useful to describe the group, the _neuroLexId attribute can be used to explicitly specify the meaning of the group, e.g. sao1044911821 for 'Neuronal Cell Body', sao1211023249 for 'Dendrite'. The _segment_s in this group can be specified as: a list of individual _member_ segments; a _path_, all of the segments along which should be included; a _subTree_ of the _cell_ to include; other segmentGroups to _include_ (so all segments from those get included here). An _inhomogeneousParameter_ can be defined on the region of the cell specified by this group (see _variableParameter_ for usage)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:segmentGroup .
+
+nml:silentSynapse a owl:Class ;
+    rdfs:label "silentSynapse"@en ;
+    dcterms:description "Dummy synapse which emits no current. Used as presynaptic endpoint for analog synaptic connection."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseGradedSynapse ;
+    skos:exactMatch neuroml2:silentSynapse ;
+    nml:exposes "i" ;
+    nml:requires "v" .
+
+nml:sineGenerator a owl:Class ;
+    rdfs:label "sineGenerator"@en ;
+    dcterms:description "Generates a sinusoidally varying current after a time _delay, for a fixed _duration. The _period and maximum _amplitude of the current can be set as well as the _phase at which to start. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrent ;
+    skos:exactMatch neuroml2:sineGenerator ;
+    nml:eventPort "in" ;
+    nml:hasParameter "amplitude",
+        "delay",
+        "duration",
+        "period",
+        "phase" .
+
+nml:sineGeneratorDL a owl:Class ;
+    rdfs:label "sineGeneratorDL"@en ;
+    dcterms:description "Dimensionless equivalent of _sineGenerator_. Generates a sinusoidally varying current after a time _delay, for a fixed _duration. The _period and maximum _amplitude of the current can be set as well as the _phase at which to start. Scaled by _weight, if set"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrentDL ;
+    skos:exactMatch neuroml2:sineGeneratorDL ;
+    nml:eventPort "in" ;
+    nml:hasParameter "amplitude",
+        "delay",
+        "duration",
+        "period",
+        "phase" .
+
+nml:species a owl:Class ;
+    rdfs:label "species"@en ;
+    dcterms:description "Description of a chemical species identified by _ion, which has internal, _concentration, and external, _extConcentration values for its concentration"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:species ;
+    nml:exposes "concentration",
+        "extConcentration" ;
+    nml:hasParameter "initialConcentration",
+        "initialExtConcentration" .
+
+nml:specificCapacitance a owl:Class ;
+    rdfs:label "specificCapacitance"@en ;
+    dcterms:description "Capacitance per unit area"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:specificCapacitance ;
+    nml:exposes "specCap" ;
+    nml:hasParameter "value" .
+
+nml:spike a owl:Class ;
+    rdfs:label "spike"@en ;
+    dcterms:description "Emits a single spike at the specified _time"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikeSource ;
+    skos:exactMatch neuroml2:spike ;
+    nml:exposes "spiked" ;
+    nml:hasParameter "time" .
+
+nml:spikeArray a owl:Class ;
+    rdfs:label "spikeArray"@en ;
+    dcterms:description "Set of spike ComponentTypes, each emitting one spike at a certain time. Can be used to feed a predetermined spike train into a cell"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikeSource ;
+    skos:exactMatch neuroml2:spikeArray ;
+    nml:eventPort "in" .
+
+nml:spikeGenerator a owl:Class ;
+    rdfs:label "spikeGenerator"@en ;
+    dcterms:description "Simple generator of spikes at a regular interval set by _period"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikeSource ;
+    skos:exactMatch neuroml2:spikeGenerator ;
+    nml:exposes "tnext" ;
+    nml:hasParameter "period" .
+
+nml:spikeGeneratorRandom a owl:Class ;
+    rdfs:label "spikeGeneratorRandom"@en ;
+    dcterms:description "Generator of spikes with a random interspike interval of at least _minISI and at most _maxISI"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikeSource ;
+    skos:exactMatch neuroml2:spikeGeneratorRandom ;
+    nml:exposes "isi",
+        "tnext" ;
+    nml:hasParameter "maxISI",
+        "minISI" .
+
+nml:spikeGeneratorRefPoisson a owl:Class ;
+    rdfs:label "spikeGeneratorRefPoisson"@en ;
+    dcterms:description "Generator of spikes whose ISI distribution is the maximum entropy distribution over [ _minimumISI, +infinity ) with mean: 1 / _averageRate"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:spikeGeneratorPoisson ;
+    skos:exactMatch neuroml2:spikeGeneratorRefPoisson ;
+    nml:hasParameter "minimumISI" .
+
+nml:spikeThresh a owl:Class ;
+    rdfs:label "spikeThresh"@en ;
+    dcterms:description "Membrane potential at which to emit a spiking event. Note, usually the spiking event will not be emitted again until the membrane potential has fallen below this value and rises again to cross it in a positive direction"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:spikeThresh ;
+    nml:hasParameter "value" .
+
+nml:stdpSynapse a owl:Class ;
+    rdfs:label "stdpSynapse"@en ;
+    dcterms:description "Spike timing dependent plasticity mechanism,  NOTE: EXAMPLE NOT YET WORKING!!!! cno_0000034"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:expTwoSynapse ;
+    skos:exactMatch neuroml2:stdpSynapse ;
+    nml:exposes "M",
+        "P",
+        "tsince" .
+
+nml:subGate a owl:Class ;
+    rdfs:label "subGate"@en ;
+    dcterms:description "Gate composed of subgates contributing with fractional conductance"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:subGate ;
+    nml:exposes "inf",
+        "q",
+        "qfrac",
+        "tau" ;
+    nml:hasParameter "fractionalConductance" ;
+    nml:requires "rateScale" .
+
+nml:subTree a owl:Class ;
+    rdfs:label "subTree"@en ;
+    dcterms:description "Include all the _segment_s distal to that specified by _from_ in the _segmentGroup_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:subTree .
+
+nml:synapticConnectionWD a owl:Class ;
+    rdfs:label "synapticConnectionWD"@en ;
+    dcterms:description "Explicit event connection between named components, which gets processed via a new instance of a _synapse component which is created on the target component, includes setting of _weight and _delay for the synaptic connection"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:synapticConnection ;
+    skos:exactMatch neuroml2:synapticConnectionWD ;
+    nml:hasParameter "delay",
+        "weight" .
+
+nml:tauInfTransition a owl:Class ;
+    rdfs:label "tauInfTransition"@en ;
+    dcterms:description "KS Transition specified in terms of time constant _tau_ and steady state _inf_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:KSTransition ;
+    skos:exactMatch neuroml2:tauInfTransition .
+
+nml:timedSynapticInput a owl:Class ;
+    rdfs:label "timedSynapticInput"@en ;
+    dcterms:description "Spike array connected to a single _synapse, producing a current triggered by each _spike_ in the array."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrentSpiking ;
+    skos:exactMatch neuroml2:timedSynapticInput ;
+    nml:eventPort "in" ;
+    nml:exposes "tsince" .
+
+nml:to a owl:Class ;
+    rdfs:label "to"@en ;
+    dcterms:description "In a _path_, specifies which _segment (inclusive) up to which to calculate the _segmentGroup_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:to .
+
+nml:transientPoissonFiringSynapse a owl:Class ;
+    rdfs:label "transientPoissonFiringSynapse"@en ;
+    dcterms:description "Poisson spike generator firing at _averageRate after a _delay and for a _duration, connected to single _synapse that is triggered every time a spike is generated, providing an input current.                       Similar to ComponentType _poissonFiringSynapse_."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrentSpiking ;
+    skos:exactMatch neuroml2:transientPoissonFiringSynapse ;
+    nml:eventPort "in",
+        "spike" ;
+    nml:exposes "isi",
+        "tnextIdeal",
+        "tnextUsed",
+        "tsince" ;
+    nml:hasParameter "averageRate",
+        "delay",
+        "duration" .
+
+nml:tsodyksMarkramDepFacMechanism a owl:Class ;
+    rdfs:label "tsodyksMarkramDepFacMechanism"@en ;
+    dcterms:description "Full Tsodyks-Markram STP model with both depression and facilitation, as in Tsodyks, Pawelzik and Markram 1998."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePlasticityMechanism ;
+    skos:exactMatch neuroml2:tsodyksMarkramDepFacMechanism ;
+    nml:hasParameter "initReleaseProb",
+        "tauFac",
+        "tauRec" .
+
+nml:tsodyksMarkramDepMechanism a owl:Class ;
+    rdfs:label "tsodyksMarkramDepMechanism"@en ;
+    dcterms:description "Depression-only Tsodyks-Markram model, as in Tsodyks and Markram 1997."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePlasticityMechanism ;
+    skos:exactMatch neuroml2:tsodyksMarkramDepMechanism ;
+    nml:hasParameter "initReleaseProb",
+        "tauRec" .
+
+nml:vHalfTransition a owl:Class ;
+    rdfs:label "vHalfTransition"@en ;
+    dcterms:description "Transition which specifies both the forward and reverse rates of transition"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:KSTransition ;
+    skos:exactMatch neuroml2:vHalfTransition ;
+    nml:hasParameter "gamma",
+        "tau",
+        "tauMin",
+        "vHalf",
+        "z" ;
+    nml:requires "v" .
+
+nml:variableParameter a owl:Class ;
+    rdfs:label "variableParameter"@en ;
+    dcterms:description "Specifies a _parameter (e.g. condDensity) which can vary its value across a _segmentGroup. The value is calculated from _value attribute of the _inhomogeneousValue_ subelement. This element is normally a child of _channelDensityNonUniform_, _channelDensityNonUniformNernst_ or _channelDensityNonUniformGHK_ and is used to calculate the value of the conductance, etc. which will vary on different parts of the cell. The _segmentGroup specified here needs to define an _inhomogeneousParameter_ (referenced from _inhomogeneousParameter in the _inhomogeneousValue_), which calculates a _variable (e.g. p) varying across the cell (e.g. based on the path length from soma), which is then used in the _value attribute of the _inhomogeneousValue_ (so for example condDensity = f(p))"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:variableParameter .
+
+nml:voltageClamp a owl:Class ;
+    rdfs:label "voltageClamp"@en ;
+    dcterms:description "Voltage clamp. Applies a variable current _i to try to keep parent at _targetVoltage. Not yet fully tested!!! Consider using voltageClampTriple!!"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrent ;
+    skos:exactMatch neuroml2:voltageClamp ;
+    nml:eventPort "in" ;
+    nml:hasParameter "delay",
+        "duration",
+        "simpleSeriesResistance",
+        "targetVoltage" .
+
+nml:voltageClampTriple a owl:Class ;
+    rdfs:label "voltageClampTriple"@en ;
+    dcterms:description "Voltage clamp with 3 clamp levels. Applies a variable current _i (through _simpleSeriesResistance) to try to keep parent cell at _conditioningVoltage until time _delay, _testingVoltage until _delay + _duration, and _returnVoltage afterwards. Only enabled if _active = 1. "@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrent ;
+    skos:exactMatch neuroml2:voltageClampTriple ;
+    nml:eventPort "in" ;
+    nml:hasParameter "active",
+        "conditioningVoltage",
+        "delay",
+        "duration",
+        "returnVoltage",
+        "simpleSeriesResistance",
+        "testingVoltage" .
+
+nml:voltageConcDepBlockMechanism a owl:Class ;
+    rdfs:label "voltageConcDepBlockMechanism"@en ;
+    dcterms:description "Synaptic blocking mechanism which varys with membrane potential across the synapse, e.g. in NMDA receptor mediated synapses"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseBlockMechanism ;
+    skos:exactMatch neuroml2:voltageConcDepBlockMechanism ;
+    nml:hasParameter "blockConcentration",
+        "scalingConc",
+        "scalingVolt" ;
+    nml:requires "v" .
+
+nml:baseBlockMechanism a owl:Class ;
+    rdfs:label "baseBlockMechanism"@en ;
+    dcterms:description "Base of any ComponentType which produces a varying scaling (or blockage) of synaptic strength of magnitude _scaling"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseBlockMechanism ;
+    nml:exposes "blockFactor" .
+
+nml:baseCell a owl:Class ;
+    rdfs:label "baseCell"@en ;
+    dcterms:description "Base type of any cell (e.g. point neuron like _izhikevich2007Cell_, or a morphologically detailed _Cell_ with _segment_s) which can be used in a _population_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseStandalone ;
+    skos:exactMatch neuroml2:baseCell .
+
+nml:baseConductanceBasedSynapseTwo a owl:Class ;
+    rdfs:label "baseConductanceBasedSynapseTwo"@en ;
+    dcterms:description "Synapse model suited for a sum of two expTwoSynapses which exposes a conductance _g in addition to producing a current. Not necessarily ohmic!! cno_0000027"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepSynapse ;
+    skos:exactMatch neuroml2:baseConductanceBasedSynapseTwo ;
+    nml:exposes "g" ;
+    nml:hasParameter "erev",
+        "gbase1",
+        "gbase2" .
+
+nml:baseCurrentBasedSynapse a owl:Class ;
+    rdfs:label "baseCurrentBasedSynapse"@en ;
+    dcterms:description "Synapse model which produces a synaptic current."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSynapse ;
+    skos:exactMatch neuroml2:baseCurrentBasedSynapse .
+
+nml:baseIaf a owl:Class ;
+    rdfs:label "baseIaf"@en ;
+    dcterms:description "Base ComponentType for an integrate and fire cell which emits a spiking event at membrane potential _thresh and and resets to _reset"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPot ;
+    skos:exactMatch neuroml2:baseIaf ;
+    nml:hasParameter "reset",
+        "thresh" .
+
+nml:baseIafCapCell a owl:Class ;
+    rdfs:label "baseIafCapCell"@en ;
+    dcterms:description "Base Type for all Integrate and Fire cells with a capacitance _C, threshold _thresh and reset membrane potential _reset"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPotCap ;
+    skos:exactMatch neuroml2:baseIafCapCell ;
+    nml:hasParameter "reset",
+        "thresh" .
+
+nml:baseVoltageDepPointCurrentDL a owl:Class ;
+    rdfs:label "baseVoltageDepPointCurrentDL"@en ;
+    dcterms:description "Base type for all ComponentTypes which produce a dimensionless current _I and require a dimensionless membrane potential _V exposed on the parent Component"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrentDL ;
+    skos:exactMatch neuroml2:baseVoltageDepPointCurrentDL ;
+    nml:requires "V" .
+
+nml:cell a owl:Class ;
+    rdfs:label "cell"@en ;
+    dcterms:description "Cell with _segment_s specified in a _morphology_ element along with details on its _biophysicalProperties_. NOTE: this can only be correctly simulated using jLEMS when there is a single segment in the cell, and _v of this cell represents the membrane potential in that isopotential segment."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPot ;
+    skos:exactMatch neuroml2:cell ;
+    nml:exposes "caConc",
+        "caConcExt",
+        "iCa",
+        "iChannels",
+        "iSyn",
+        "spiking",
+        "surfaceArea",
+        "totSpecCap" .
+
+nml:channelDensity a owl:Class ;
+    rdfs:label "channelDensity"@en ;
+    dcterms:description "Specifies a time varying ohmic conductance density, _gDensity, which is distributed on an area of the _cell (specified in _membraneProperties_) with fixed reversal potential _erev producing a current density _iDensity"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensityCond ;
+    skos:exactMatch neuroml2:channelDensity ;
+    nml:hasParameter "erev" .
+
+nml:connection a owl:Class ;
+    rdfs:label "connection"@en ;
+    dcterms:description "Event connection directly between named components, which gets processed via a new instance of a _synapse component which is created on the target component. Normally contained inside a _projection_ element."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:connection .
+
+nml:continuousConnectionInstance a owl:Class ;
+    rdfs:label "continuousConnectionInstance"@en ;
+    dcterms:description "An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Can be used for analog synapses."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:continuousConnectionInstance .
+
+nml:electricalConnectionInstance a owl:Class ;
+    rdfs:label "electricalConnectionInstance"@en ;
+    dcterms:description "To enable connections between populations through gap junctions. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:electricalConnectionInstance .
+
+nml:explicitConnection a owl:Class ;
+    rdfs:label "explicitConnection"@en ;
+    dcterms:description "Explicit event connection between components"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:explicitConnection .
+
+nml:iafCell a owl:Class ;
+    rdfs:label "iafCell"@en ;
+    dcterms:description "Integrate and fire cell with capacitance _C, _leakConductance and _leakReversal"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseIafCapCell ;
+    skos:exactMatch neuroml2:iafCell ;
+    nml:hasParameter "leakConductance",
+        "leakReversal" .
+
+nml:iafTauCell a owl:Class ;
+    rdfs:label "iafTauCell"@en ;
+    dcterms:description "Integrate and fire cell which returns to its leak reversal potential of _leakReversal with a time constant _tau"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseIaf ;
+    skos:exactMatch neuroml2:iafTauCell ;
+    nml:hasParameter "leakReversal",
+        "tau" .
+
+nml:input a owl:Class ;
+    rdfs:label "input"@en ;
+    dcterms:description "Specifies a single input to a _target, optionally giving the _segmentId (default 0) and _fractionAlong the segment (default 0.5)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:input .
+
+nml:intracellularProperties a owl:Class ;
+    rdfs:label "intracellularProperties"@en ;
+    dcterms:description "Biophysical properties related to the intracellular space within the _cell_, such as the _resistivity_ and the list of ionic _species_ present. _caConc and _caConcExt are explicitly exposed here to facilitate accessing these values from other Components, even though _caConcExt is clearly not an intracellular property"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:intracellularProperties ;
+    nml:exposes "caConc",
+        "caConcExt" .
+
+nml:ionChannelHH a owl:Class ;
+    rdfs:label "ionChannelHH"@en ;
+    dcterms:description "Note _ionChannel_ and _ionChannelHH_ are currently functionally identical. This is needed since many existing examples use ionChannel, some use ionChannelHH. NeuroML v2beta4 should remove one of these, probably ionChannelHH."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseIonChannel ;
+    skos:exactMatch neuroml2:ionChannelHH .
+
+nml:membraneProperties a owl:Class ;
+    rdfs:label "membraneProperties"@en ;
+    dcterms:description "Properties specific to the membrane, such as the _populations of channels, _channelDensities, _specificCapacitance, etc."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:membraneProperties ;
+    nml:exposes "iCa",
+        "totChanCurrent",
+        "totSpecCap" ;
+    nml:requires "surfaceArea" .
+
+nml:network a owl:Class ;
+    rdfs:label "network"@en ;
+    dcterms:description "Network containing: _population_s (potentially of type _populationList_, and so specifying a list of cell _location_s); _projection_s (with lists of _connection_s) and/or _explicitConnection_s; and _inputList_s (with lists of _input_s) and/or _explicitInput_s. Note: often in NeuroML this will be of type _networkWithTemperature_ if there are temperature dependent elements (e.g. ion channels)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseStandalone ;
+    skos:exactMatch neuroml2:network .
+
+nml:spikeGeneratorPoisson a owl:Class ;
+    rdfs:label "spikeGeneratorPoisson"@en ;
+    dcterms:description "Generator of spikes whose ISI is distributed according to an exponential PDF with scale: 1 / _averageRate"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikeSource ;
+    skos:exactMatch neuroml2:spikeGeneratorPoisson ;
+    nml:exposes "isi",
+        "tnextIdeal",
+        "tnextUsed" ;
+    nml:hasParameter "averageRate" .
+
+nml:synapticConnection a owl:Class ;
+    rdfs:label "synapticConnection"@en ;
+    dcterms:description "Explicit event connection between named components, which gets processed via a new instance of a _synapse component which is created on the target component"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:explicitConnection ;
+    skos:exactMatch neuroml2:synapticConnection .
+
+nml:KSState a owl:Class ;
+    rdfs:label "KSState"@en ;
+    dcterms:description "One of the states in which a _gateKS_ can be. The rates of transitions between these states are given by _KSTransition_s"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:KSState ;
+    nml:exposes "occupancy",
+        "q" ;
+    nml:hasParameter "relativeConductance" .
+
+nml:baseCellMembPotDL a owl:Class ;
+    rdfs:label "baseCellMembPotDL"@en ;
+    dcterms:description "Any spiking cell which has a dimensioness membrane potential, _V (as opposed to a membrane potential units of voltage, _baseCellMembPot_)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikingCell ;
+    skos:exactMatch neuroml2:baseCellMembPotDL ;
+    nml:exposes "V" .
+
+nml:baseChannelPopulation a owl:Class ;
+    rdfs:label "baseChannelPopulation"@en ;
+    dcterms:description "Base type for any current produced by a population of channels, all of which are of type _ionChannel"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrent ;
+    skos:exactMatch neuroml2:baseChannelPopulation .
+
+nml:baseConductanceScaling a owl:Class ;
+    rdfs:label "baseConductanceScaling"@en ;
+    dcterms:description "Base ComponentType for a scaling to apply to a gate's conductance, e.g. temperature dependent scaling"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseConductanceScaling ;
+    nml:exposes "factor" ;
+    nml:requires "temperature" .
+
+nml:baseGate a owl:Class ;
+    rdfs:label "baseGate"@en ;
+    dcterms:description "Base ComponentType for a voltage and/or concentration dependent gate"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseGate ;
+    nml:exposes "fcond",
+        "q" ;
+    nml:hasParameter "instances" .
+
+nml:baseIonChannel a owl:Class ;
+    rdfs:label "baseIonChannel"@en ;
+    dcterms:description "Base for all ion channel ComponentTypes"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseIonChannel ;
+    nml:exposes "fopen",
+        "g" ;
+    nml:hasParameter "conductance" ;
+    nml:requires "v" .
+
+nml:basePlasticityMechanism a owl:Class ;
+    rdfs:label "basePlasticityMechanism"@en ;
+    dcterms:description "Base plasticity mechanism."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:basePlasticityMechanism ;
+    nml:eventPort "in" ;
+    nml:exposes "plasticityFactor" .
+
+nml:basePopulation a owl:Class ;
+    rdfs:label "basePopulation"@en ;
+    dcterms:description "A population of multiple instances of a specific _component, which anything which extends _baseCell_. "@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseStandalone ;
+    skos:exactMatch neuroml2:basePopulation .
+
+nml:basePyNNCell a owl:Class ;
+    rdfs:label "basePyNNCell"@en ;
+    dcterms:description "Base type of any PyNN standard cell model. Note: membrane potential _v has dimensions voltage, but all other parameters are dimensionless. This is to facilitate translation to and from PyNN scripts in Python, where these parameters have implicit units, see http://neuralensemble.org/trac/PyNN/wiki/StandardModels"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPot ;
+    skos:exactMatch neuroml2:basePyNNCell ;
+    nml:eventPort "spike_in_E",
+        "spike_in_I" ;
+    nml:exposes "iSyn" ;
+    nml:hasParameter "cm",
+        "i_offset",
+        "tau_syn_E",
+        "tau_syn_I",
+        "v_init" .
+
+nml:baseQ10Settings a owl:Class ;
+    rdfs:label "baseQ10Settings"@en ;
+    dcterms:description "Base ComponentType for a scaling to apply to gating variable time course, usually temperature dependent"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseQ10Settings ;
+    nml:exposes "q10" ;
+    nml:requires "temperature" .
+
+nml:baseSpikingCell a owl:Class ;
+    rdfs:label "baseSpikingCell"@en ;
+    dcterms:description "Base type of any cell which can emit _spike events."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCell ;
+    skos:exactMatch neuroml2:baseSpikingCell ;
+    nml:eventPort "spike" .
+
+nml:baseVoltageDepRate a owl:Class ;
+    rdfs:label "baseVoltageDepRate"@en ;
+    dcterms:description "Base ComponentType for voltage dependent rate. Produces a time varying rate _r which depends on _v."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseVoltageDepRate ;
+    nml:exposes "r" ;
+    nml:requires "v" .
+
+nml:baseVoltageDepTime a owl:Class ;
+    rdfs:label "baseVoltageDepTime"@en ;
+    dcterms:description "Base ComponentType for voltage dependent ComponentType producing value _t with dimension time (e.g. for time course of rate variable). Note: time course would not normally be fit to exp/sigmoid etc."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseVoltageDepTime ;
+    nml:exposes "t" ;
+    nml:requires "v" .
+
+nml:baseVoltageDepVariable a owl:Class ;
+    rdfs:label "baseVoltageDepVariable"@en ;
+    dcterms:description "Base ComponentType for voltage dependent variable  _x, which depends on _v. Can be used for inf/steady state of rate variable."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseVoltageDepVariable ;
+    nml:exposes "x" ;
+    nml:requires "v" .
+
+nml:expTwoSynapse a owl:Class ;
+    rdfs:label "expTwoSynapse"@en ;
+    dcterms:description "Ohmic synapse model whose conductance waveform on receiving an event has a rise time of _tauRise and a decay time of _tauDecay. Max conductance reached during this time (assuming zero conductance before) is _gbase * _weight."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseConductanceBasedSynapse ;
+    skos:exactMatch neuroml2:expTwoSynapse ;
+    nml:hasParameter "tauDecay",
+        "tauRise" .
+
+nml:ionChannel a owl:Class ;
+    rdfs:label "ionChannel"@en ;
+    dcterms:description "Note _ionChannel_ and _ionChannelHH_ are currently functionally identical. This is needed since many existing examples use ionChannel, some use ionChannelHH. NeuroML v2beta4 should remove one of these, probably ionChannelHH."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:ionChannelHH ;
+    skos:exactMatch neuroml2:ionChannel .
+
+nml:point3DWithDiam a owl:Class ;
+    rdfs:label "point3DWithDiam"@en ;
+    dcterms:description "Base type for ComponentTypes which specify an ( _x, _y, _z ) coordinate along with a _diameter. Note: no dimension used in the attributes for these coordinates! These are assumed to have dimension micrometer (10^-6 m). This is due to micrometers being the default option for the majority of neuronal morphology formats, and dimensions are omitted here to facilitate reading and writing of morphologies in NeuroML."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:point3DWithDiam ;
+    nml:hasParameter "diameter",
+        "x",
+        "y",
+        "z" .
+
+nml:baseConductanceBasedSynapse a owl:Class ;
+    rdfs:label "baseConductanceBasedSynapse"@en ;
+    dcterms:description "Synapse model which exposes a conductance _g in addition to producing a current. Not necessarily ohmic!! cno_0000027"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepSynapse ;
+    skos:exactMatch neuroml2:baseConductanceBasedSynapse ;
+    nml:exposes "g" ;
+    nml:hasParameter "erev",
+        "gbase" .
+
+nml:baseGradedSynapse a owl:Class ;
+    rdfs:label "baseGradedSynapse"@en ;
+    dcterms:description "Base type for graded synapses"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSynapse ;
+    skos:exactMatch neuroml2:baseGradedSynapse .
+
+nml:baseHHRate a owl:Class ;
+    rdfs:label "baseHHRate"@en ;
+    dcterms:description "Base ComponentType for rate which follow one of the typical forms for rate equations in the standard HH formalism, using the parameters _rate, _midpoint and _scale"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepRate ;
+    skos:exactMatch neuroml2:baseHHRate ;
+    nml:hasParameter "midpoint",
+        "rate",
+        "scale" .
+
+nml:baseHHVariable a owl:Class ;
+    rdfs:label "baseHHVariable"@en ;
+    dcterms:description "Base ComponentType for voltage dependent dimensionless variable which follow one of the typical forms for variable equations in the standard HH formalism, using the parameters _rate, _midpoint, _scale"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepVariable ;
+    skos:exactMatch neuroml2:baseHHVariable ;
+    nml:hasParameter "midpoint",
+        "rate",
+        "scale" .
+
+nml:basePyNNIaFCell a owl:Class ;
+    rdfs:label "basePyNNIaFCell"@en ;
+    dcterms:description "Base type of any PyNN standard integrate and fire model"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNCell ;
+    skos:exactMatch neuroml2:basePyNNIaFCell ;
+    nml:hasParameter "tau_m",
+        "tau_refrac",
+        "v_reset",
+        "v_rest",
+        "v_thresh" .
+
+nml:baseVoltageDepPointCurrentSpiking a owl:Class ;
+    rdfs:label "baseVoltageDepPointCurrentSpiking"@en ;
+    dcterms:description "Base type for all ComponentTypes which produce a current _i, require a membrane potential _v exposed on the parent and emit spikes (on a port _spike). The exposed variable _tsince can be used for plotting the time since the Component has spiked last"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepPointCurrent ;
+    skos:exactMatch neuroml2:baseVoltageDepPointCurrentSpiking ;
+    nml:eventPort "spike" ;
+    nml:exposes "tsince" .
+
+nml:concentrationModel a owl:Class ;
+    rdfs:label "concentrationModel"@en ;
+    dcterms:description "Base for any model of an _ion concentration which changes with time. Internal (_concentration) and external (_extConcentration) values for the concentration of the ion are given."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:concentrationModel ;
+    nml:exposes "concentration",
+        "extConcentration" ;
+    nml:requires "initialConcentration",
+        "initialExtConcentration",
+        "surfaceArea" .
+
+nml:KSTransition a owl:Class ;
+    rdfs:label "KSTransition"@en ;
+    dcterms:description "Specified the forward and reverse rates of transition between two _KSState_s in a _gateKS_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:KSTransition ;
+    nml:exposes "rf",
+        "rr" .
+
+nml:baseChannelDensityCond a owl:Class ;
+    rdfs:label "baseChannelDensityCond"@en ;
+    dcterms:description "Base type for distributed conductances on an area of a cell producing a (not necessarily ohmic) current"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseChannelDensity ;
+    skos:exactMatch neuroml2:baseChannelDensityCond ;
+    nml:exposes "gDensity" ;
+    nml:hasParameter "condDensity" .
+
+nml:basePyNNIaFCondCell a owl:Class ;
+    rdfs:label "basePyNNIaFCondCell"@en ;
+    dcterms:description "Base type of conductance based PyNN IaF cell models"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePyNNIaFCell ;
+    skos:exactMatch neuroml2:basePyNNIaFCondCell ;
+    nml:hasParameter "e_rev_E",
+        "e_rev_I" .
+
+nml:basePynnSynapse a owl:Class ;
+    rdfs:label "basePynnSynapse"@en ;
+    dcterms:description "Base type for all PyNN synapses. Note, the current _I produced is dimensionless, but it requires a membrane potential _v with dimension voltage"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseVoltageDepSynapse ;
+    skos:exactMatch neuroml2:basePynnSynapse ;
+    nml:hasParameter "tau_syn" .
+
+nml:baseStandalone a owl:Class ;
+    rdfs:label "baseStandalone"@en ;
+    dcterms:description "Base type of any Component which can have _Notes_, _Annotation_, or a _property_ list."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseStandalone .
+
+nml:baseSynapse a owl:Class ;
+    rdfs:label "baseSynapse"@en ;
+    dcterms:description "Base type for all synapses, i.e. ComponentTypes which produce a current (dimension current) and change Dynamics in response to an incoming event. cno_0000009"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrent ;
+    skos:exactMatch neuroml2:baseSynapse ;
+    nml:eventPort "in" .
+
+nml:baseVoltageDepPointCurrent a owl:Class ;
+    rdfs:label "baseVoltageDepPointCurrent"@en ;
+    dcterms:description "Base type for all ComponentTypes which produce a current _i (with dimension current) and require a voltage _v exposed on the parent Component, which would often be the membrane potential of a Component extending _baseCellMembPot_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:basePointCurrent ;
+    skos:exactMatch neuroml2:baseVoltageDepPointCurrent ;
+    nml:requires "v" .
+
+nml:baseVoltageDepSynapse a owl:Class ;
+    rdfs:label "baseVoltageDepSynapse"@en ;
+    dcterms:description "Base type for synapses with a dependence on membrane potential"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSynapse ;
+    skos:exactMatch neuroml2:baseVoltageDepSynapse ;
+    nml:requires "v" .
+
+nml:baseChannelDensity a owl:Class ;
+    rdfs:label "baseChannelDensity"@en ;
+    dcterms:description "Base type for a current of density _iDensity distributed on an area of a _cell_, flowing through the specified _ionChannel. Instances of this (normally _channelDensity_) are specified in the _membraneProperties_ of the _cell_."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseChannelDensity ;
+    nml:exposes "iDensity" ;
+    nml:requires "v" .
+
+nml:basePointCurrentDL a owl:Class ;
+    rdfs:label "basePointCurrentDL"@en ;
+    dcterms:description "Base type for all ComponentTypes which produce a dimensionless current _I. There are many dimensionless equivalents of all the core current producing ComponentTypes such as _pulseGenerator_ / _pulseGeneratorDL_, _sineGenerator_ / _sineGeneratorDL_ and _rampGenerator_ / _rampGeneratorDL_"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:basePointCurrentDL ;
+    nml:exposes "I" .
+
+nml:baseCellMembPot a owl:Class ;
+    rdfs:label "baseCellMembPot"@en ;
+    dcterms:description "Any spiking cell which has a membrane potential _v with units of voltage (as opposed to a dimensionless membrane potential used in _baseCellMembPotDL_)."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseSpikingCell ;
+    skos:exactMatch neuroml2:baseCellMembPot ;
+    nml:exposes "v" .
+
+nml:baseCellMembPotCap a owl:Class ;
+    rdfs:label "baseCellMembPotCap"@en ;
+    dcterms:description "Any cell with a membrane potential _v with voltage units and a membrane capacitance _C. Also defines exposed value _iSyn for current due to external synapses and _iMemb for total transmembrane current (usually channel currents plus _iSyn)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseCellMembPot ;
+    skos:exactMatch neuroml2:baseCellMembPotCap ;
+    nml:exposes "iMemb",
+        "iSyn" ;
+    nml:hasParameter "C" .
+
+nml:basePointCurrent a owl:Class ;
+    rdfs:label "basePointCurrent"@en ;
+    dcterms:description "Base type for all ComponentTypes which produce a current _i (with dimension current)"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseStandalone ;
+    skos:exactMatch neuroml2:basePointCurrent ;
+    nml:exposes "i" .
+
+nml:baseSpikeSource a owl:Class ;
+    rdfs:label "baseSpikeSource"@en ;
+    dcterms:description "Base for any ComponentType whose main purpose is to emit spikes (on a port _spike). The exposed variable _tsince can be used for plotting the time since the Component has spiked last."@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    skos:exactMatch neuroml2:baseSpikeSource ;
+    nml:eventPort "spike" ;
+    nml:exposes "tsince" .
+
+nml:gate a owl:Class ;
+    rdfs:label "gate"@en ;
+    dcterms:description "Conveniently named baseGate"@en ;
+    rdfs:isDefinedBy tvbo:neuroml ;
+    rdfs:subClassOf nml:baseGate ;
+    skos:exactMatch neuroml2:gate .
+
+tvbo:neuroml a owl:Ontology ;
+    dcterms:description "OWL rendering of the NeuroML2 core LEMS ComponentType hierarchy: one class per ComponentType, extends as rdfs:subClassOf, cross-referenced to the canonical NeuroML type via skos:exactMatch."@en ;
+    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dcterms:title "TVB-O NeuroML-core reference"@en ;
+    rdfs:seeAlso <http://www.neuroml.org/schema/neuroml2> .
+

--- a/ontology/tvbo.owl
+++ b/ontology/tvbo.owl
@@ -14,10 +14,11 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:linkml="https://w3id.org/linkml/"
      xmlns:schema="http://schema.org/"
+     xmlns:neuroml="https://w3id.org/tvbo/neuroml/"
      xmlns:clinical="https://w3id.org/tvbo/clinical/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/tvbo/tvbo.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/tvbo/struct/0.4.0"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/tvbo/2026-07-20/tvbo.owl"/>
         <terms:contributor>The Virtual Brain Ontology contributors</terms:contributor>
         <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-01</terms:created>
         <terms:description>Metadata schema for simulation studies using The Virtual Brain neuroinformatics platform or other dynamic network models of large-scale brain activity.</terms:description>
@@ -219,6 +220,12 @@
     
 
 
+    <!-- http://www.w3.org/2004/02/skos/core#closeMatch -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch"/>
+    
+
+
     <!-- http://www.w3.org/2004/02/skos/core#definition -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
@@ -252,6 +259,12 @@
     <!-- http://www.w3.org/2004/02/skos/core#prefLabel -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+    
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#relatedMatch -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#relatedMatch"/>
     
 
 
@@ -365,6 +378,42 @@
 
     <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/clinical/icd11Code">
         <rdfs:label>ICD-11 code</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/eventPort -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/eventPort">
+        <rdfs:comment xml:lang="en">An event port declared by this NeuroML ComponentType.</rdfs:comment>
+        <rdfs:label xml:lang="en">event port</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/exposes -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/exposes">
+        <rdfs:comment xml:lang="en">A quantity this NeuroML ComponentType exposes.</rdfs:comment>
+        <rdfs:label xml:lang="en">exposes</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/hasParameter -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/hasParameter">
+        <rdfs:comment xml:lang="en">A parameter declared by this NeuroML ComponentType.</rdfs:comment>
+        <rdfs:label xml:lang="en">has parameter</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/requires -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/requires">
+        <rdfs:comment xml:lang="en">A quantity this NeuroML ComponentType requires from its context.</rdfs:comment>
+        <rdfs:label xml:lang="en">requires</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -1821,6 +1870,12 @@
     
 
 
+    <!-- https://w3id.org/tvbo/outsym -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/tvbo/outsym"/>
+    
+
+
     <!-- https://w3id.org/tvbo/over -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/tvbo/over">
@@ -2280,12 +2335,6 @@
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
         <skos:notation>sweep_seeding</skos:notation>
     </owl:ObjectProperty>
-    
-
-
-    <!-- https://w3id.org/tvbo/symmetry -->
-
-    <owl:ObjectProperty rdf:about="https://w3id.org/tvbo/symmetry"/>
     
 
 
@@ -9908,6 +9957,12 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/outsym"/>
+                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/parameters"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
@@ -9933,12 +9988,6 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/regional_connectivity"/>
-                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -10010,12 +10059,6 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
-                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/delayed"/>
                 <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
             </owl:Restriction>
@@ -10064,13 +10107,13 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/outsym"/>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/sparse"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/sparse"/>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -10101,6 +10144,12 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/sparse"/>
+                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
                 <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -10687,6 +10736,7 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>DerivedVariable</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#DerivedVariable"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/DerivedVariable"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
     </owl:Class>
@@ -11844,6 +11894,7 @@
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>Dynamics</rdfs:label>
         <skos:altLabel>NeuralMassModel</skos:altLabel>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#ComponentType"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
         <skos:note>Successor class replacing deprecated NeuralMassModel.</skos:note>
@@ -12933,6 +12984,7 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>Event</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#EventPort"/>
         <skos:definition>A discrete or continuous event that modifies the system during simulation. Generalizes Stimulus: can represent external inputs (stimulus type), threshold-triggered state changes (continuous/discrete type), or time-scheduled interventions (preset_time type). Attaches to components (nodes/edges) or to the experiment level.</skos:definition>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/Event"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
@@ -19295,6 +19347,7 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>Parameter</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#Parameter"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/Parameter"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
     </owl:Class>
@@ -22130,6 +22183,7 @@ Aligns with the BIDS phenotype standard (https://bids-specification.readthedocs.
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>StateVariable</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#StateVariable"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/StateVariable"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
     </owl:Class>
@@ -27381,6 +27435,3221 @@ Aligns with the BIDS phenotype standard (https://bids-specification.readthedocs.
         <skos:definition>DBS parameters for a specific session.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo/dbs"/>
         <skos:notation>StimulationSetting</skos:notation>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Display -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Display">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Details of a display to generate (usually a set of traces given by _Line_s in a newly opened window) on completion of the simulation.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Display</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Display"/>
+        <neuroml:hasParameter>timeScale</neuroml:hasParameter>
+        <neuroml:hasParameter>xmax</neuroml:hasParameter>
+        <neuroml:hasParameter>xmin</neuroml:hasParameter>
+        <neuroml:hasParameter>ymax</neuroml:hasParameter>
+        <neuroml:hasParameter>ymin</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EIF_cond_alpha_isfa_ista -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EIF_cond_alpha_isfa_ista">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Adaptive exponential integrate and fire neuron according to Brette R and Gerstner W (2005) with alpha-function-shaped post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EIF_cond_alpha_isfa_ista</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EIF_cond_alpha_isfa_ista"/>
+        <neuroml:exposes>w</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>delta_T</neuroml:hasParameter>
+        <neuroml:hasParameter>i_offset</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_refrac</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_w</neuroml:hasParameter>
+        <neuroml:hasParameter>v_rest</neuroml:hasParameter>
+        <neuroml:hasParameter>v_spike</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EIF_cond_exp_isfa_ista -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EIF_cond_exp_isfa_ista">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Adaptive exponential integrate and fire neuron according to Brette R and Gerstner W (2005) with exponentially-decaying post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EIF_cond_exp_isfa_ista</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EIF_cond_exp_isfa_ista"/>
+        <neuroml:exposes>w</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>delta_T</neuroml:hasParameter>
+        <neuroml:hasParameter>i_offset</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_refrac</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_w</neuroml:hasParameter>
+        <neuroml:hasParameter>v_rest</neuroml:hasParameter>
+        <neuroml:hasParameter>v_spike</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EventOutputFile -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EventOutputFile">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A file in which to save event information (e.g. spikes from cells in a population) in a specified _format</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EventOutputFile</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EventOutputFile"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EventSelection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EventSelection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A specific source of events with an associated _id, which will be recorded inside the file specified in the parent _EventOutputFile_. The attribute _select should point to a cell inside a _population_ (e.g. hhpop[0], see https://docs.neuroml.org/Userdocs/Paths.html), and the _eventPort specifies the port for the emitted events, which usually has id: spike. Note: the _id used on this element (and appearing in the file alongside the event time) can be different from the id/index of the cell in the population.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EventSelection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EventSelection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpLinearRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpLinearRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHRate"/>
+        <terms:description xml:lang="en">Exponential linear form for rate equation. Linear for large positive _v, exponentially decays for large negative _v.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpLinearRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpLinearRate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpLinearVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpLinearVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHVariable"/>
+        <terms:description xml:lang="en">Exponential linear form for variable equation. Linear for large positive _v, exponentially decays for large negative _v.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpLinearVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpLinearVariable"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHRate"/>
+        <terms:description xml:lang="en">Exponential form for rate equation (Q: Should these be renamed hhExpRate, etc?)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpRate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHVariable"/>
+        <terms:description xml:lang="en">Exponential form for variable equation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpVariable"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHSigmoidRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHSigmoidRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHRate"/>
+        <terms:description xml:lang="en">Sigmoidal form for rate equation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHSigmoidRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHSigmoidRate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHSigmoidVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHSigmoidVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHVariable"/>
+        <terms:description xml:lang="en">Sigmoidal form for variable equation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHSigmoidVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHSigmoidVariable"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HH_cond_exp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HH_cond_exp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNCell"/>
+        <terms:description xml:lang="en">Single-compartment Hodgkin-Huxley-type neuron with transient sodium and delayed-rectifier potassium currents using the ion channel models from Traub.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HH_cond_exp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HH_cond_exp"/>
+        <neuroml:exposes>h</neuroml:exposes>
+        <neuroml:exposes>m</neuroml:exposes>
+        <neuroml:exposes>n</neuroml:exposes>
+        <neuroml:hasParameter>e_rev_E</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_I</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_K</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_Na</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_leak</neuroml:hasParameter>
+        <neuroml:hasParameter>g_leak</neuroml:hasParameter>
+        <neuroml:hasParameter>gbar_K</neuroml:hasParameter>
+        <neuroml:hasParameter>gbar_Na</neuroml:hasParameter>
+        <neuroml:hasParameter>v_offset</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_cond_alpha -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_cond_alpha">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and alpha-function-shaped post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_cond_alpha</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_cond_alpha"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_cond_exp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_cond_exp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and exponentially-decaying post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_cond_exp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_cond_exp"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_curr_alpha -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_curr_alpha">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and alpha-function-shaped post-synaptic current</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_curr_alpha</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_curr_alpha"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_curr_exp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_curr_exp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and decaying-exponential post-synaptic current</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_curr_exp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_curr_exp"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/KSState -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/KSState">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">One of the states in which a _gateKS_ can be. The rates of transitions between these states are given by _KSTransition_s</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">KSState</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#KSState"/>
+        <neuroml:exposes>occupancy</neuroml:exposes>
+        <neuroml:exposes>q</neuroml:exposes>
+        <neuroml:hasParameter>relativeConductance</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/KSTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/KSTransition">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specified the forward and reverse rates of transition between two _KSState_s in a _gateKS_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">KSTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#KSTransition"/>
+        <neuroml:exposes>rf</neuroml:exposes>
+        <neuroml:exposes>rr</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Line -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Line">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specification of a single time varying _quantity to plot on the _Display_. Note that all quantities are handled internally in LEMS in SI units, and so a _scale should be used if it is to be displayed in other units.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Line</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Line"/>
+        <neuroml:hasParameter>scale</neuroml:hasParameter>
+        <neuroml:hasParameter>timeScale</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Meta -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Meta">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Metadata to add to simulation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Meta</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Meta"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/OutputColumn -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/OutputColumn">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specification of a single time varying _quantity to record during the simulation. Note that all quantities are handled internally in LEMS in SI units, and so the value for the quantity in the file (as well as time) will be in SI units.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">OutputColumn</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#OutputColumn"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/OutputFile -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/OutputFile">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A file in which to save recorded values from the simulation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">OutputFile</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#OutputFile"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Simulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Simulation">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The main element in a LEMS Simulation file. Defines the _length of simulation, the timestep (dt) _step and an optional _seed to use for stochastic elements, as well as _Display_s, _OutputFile_s and _EventOutputFile_s to record. Specifies a _target component to run, usually the id of a _network_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Simulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Simulation"/>
+        <neuroml:hasParameter>length</neuroml:hasParameter>
+        <neuroml:hasParameter>step</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/SpikeSourcePoisson -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/SpikeSourcePoisson">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Spike source, generating spikes according to a Poisson process.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">SpikeSourcePoisson</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#SpikeSourcePoisson"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>rate</neuroml:hasParameter>
+        <neuroml:hasParameter>start</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/adExIaFCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/adExIaFCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Model based on Brette R and Gerstner W (2005) Adaptive Exponential Integrate-and-Fire Model as an Effective Description of Neuronal Activity. J Neurophysiol 94:3637-3642</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">adExIaFCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#adExIaFCell"/>
+        <neuroml:exposes>w</neuroml:exposes>
+        <neuroml:hasParameter>EL</neuroml:hasParameter>
+        <neuroml:hasParameter>VT</neuroml:hasParameter>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>delT</neuroml:hasParameter>
+        <neuroml:hasParameter>gL</neuroml:hasParameter>
+        <neuroml:hasParameter>refract</neuroml:hasParameter>
+        <neuroml:hasParameter>reset</neuroml:hasParameter>
+        <neuroml:hasParameter>tauw</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaCondSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaCondSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Alpha synapse: rise time and decay time are both tau_syn. Conductance based synapse.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaCondSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaCondSynapse"/>
+        <neuroml:exposes>A</neuroml:exposes>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>e_rev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaCurrSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaCurrSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Alpha synapse: rise time and decay time are both tau_syn. Current based synapse.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaCurrSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaCurrSynapse"/>
+        <neuroml:exposes>A</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaCurrentSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaCurrentSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCurrentBasedSynapse"/>
+        <terms:description xml:lang="en">Alpha current synapse: rise time and decay time are both _tau.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaCurrentSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaCurrentSynapse"/>
+        <neuroml:hasParameter>ibase</neuroml:hasParameter>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse"/>
+        <terms:description xml:lang="en">Ohmic synapse model where rise time and decay time are both _tau. Max conductance reached during this time (assuming zero conductance before) is _gbase * _weight.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaSynapse"/>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseBlockMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseBlockMechanism">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base of any ComponentType which produces a varying scaling (or blockage) of synaptic strength of magnitude _scaling</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseBlockMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseBlockMechanism"/>
+        <neuroml:exposes>blockFactor</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">Base type of any cell (e.g. point neuron like _izhikevich2007Cell_, or a morphologically detailed _Cell_ with _segment_s) which can be used in a _population_</terms:description>
+        <rdfs:comment xml:lang="en">A tvbo:Dynamics acting as a neuron is emitted as a descendant of baseCell.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCell"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCellMembPot -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCellMembPot">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikingCell"/>
+        <terms:description xml:lang="en">Any spiking cell which has a membrane potential _v with units of voltage (as opposed to a dimensionless membrane potential used in _baseCellMembPotDL_).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCellMembPot</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCellMembPot"/>
+        <neuroml:exposes>v</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCellMembPotCap -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCellMembPotCap">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Any cell with a membrane potential _v with voltage units and a membrane capacitance _C. Also defines exposed value _iSyn for current due to external synapses and _iMemb for total transmembrane current (usually channel currents plus _iSyn)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCellMembPotCap</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCellMembPotCap"/>
+        <neuroml:exposes>iMemb</neuroml:exposes>
+        <neuroml:exposes>iSyn</neuroml:exposes>
+        <neuroml:hasParameter>C</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCellMembPotDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCellMembPotDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikingCell"/>
+        <terms:description xml:lang="en">Any spiking cell which has a dimensioness membrane potential, _V (as opposed to a membrane potential units of voltage, _baseCellMembPot_).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCellMembPotDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCellMembPotDL"/>
+        <neuroml:exposes>V</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseChannelDensity -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseChannelDensity">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type for a current of density _iDensity distributed on an area of a _cell_, flowing through the specified _ionChannel. Instances of this (normally _channelDensity_) are specified in the _membraneProperties_ of the _cell_.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseChannelDensity</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseChannelDensity"/>
+        <neuroml:exposes>iDensity</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseChannelDensityCond -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseChannelDensityCond">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Base type for distributed conductances on an area of a cell producing a (not necessarily ohmic) current</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseChannelDensityCond</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseChannelDensityCond"/>
+        <neuroml:exposes>gDensity</neuroml:exposes>
+        <neuroml:hasParameter>condDensity</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseChannelPopulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseChannelPopulation">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Base type for any current produced by a population of channels, all of which are of type _ionChannel</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseChannelPopulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseChannelPopulation"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Synapse model which exposes a conductance _g in addition to producing a current. Not necessarily ohmic!! cno_0000027</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceBasedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceBasedSynapse"/>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>gbase</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapseTwo -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapseTwo">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Synapse model suited for a sum of two expTwoSynapses which exposes a conductance _g in addition to producing a current. Not necessarily ohmic!! cno_0000027</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceBasedSynapseTwo</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceBasedSynapseTwo"/>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>gbase1</neuroml:hasParameter>
+        <neuroml:hasParameter>gbase2</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceScaling -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceScaling">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for a scaling to apply to a gate&apos;s conductance, e.g. temperature dependent scaling</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceScaling</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceScaling"/>
+        <neuroml:exposes>factor</neuroml:exposes>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceScalingCaDependent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceScalingCaDependent">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceScaling"/>
+        <terms:description xml:lang="en">Base ComponentType for a scaling to apply to a gate&apos;s conductance which depends on Ca concentration. Usually a generic expression of _caConc (so no standard, non-base form here).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceScalingCaDependent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceScalingCaDependent"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCurrentBasedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCurrentBasedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Synapse model which produces a synaptic current.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCurrentBasedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCurrentBasedSynapse"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseGate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseGate">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for a voltage and/or concentration dependent gate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseGate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseGate"/>
+        <neuroml:exposes>fcond</neuroml:exposes>
+        <neuroml:exposes>q</neuroml:exposes>
+        <neuroml:hasParameter>instances</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseGradedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseGradedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Base type for graded synapses</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseGradedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseGradedSynapse"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseHHRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseHHRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepRate"/>
+        <terms:description xml:lang="en">Base ComponentType for rate which follow one of the typical forms for rate equations in the standard HH formalism, using the parameters _rate, _midpoint and _scale</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseHHRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseHHRate"/>
+        <neuroml:hasParameter>midpoint</neuroml:hasParameter>
+        <neuroml:hasParameter>rate</neuroml:hasParameter>
+        <neuroml:hasParameter>scale</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseHHVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseHHVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepVariable"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent dimensionless variable which follow one of the typical forms for variable equations in the standard HH formalism, using the parameters _rate, _midpoint, _scale</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseHHVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseHHVariable"/>
+        <neuroml:hasParameter>midpoint</neuroml:hasParameter>
+        <neuroml:hasParameter>rate</neuroml:hasParameter>
+        <neuroml:hasParameter>scale</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseIaf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseIaf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Base ComponentType for an integrate and fire cell which emits a spiking event at membrane potential _thresh and and resets to _reset</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseIaf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseIaf"/>
+        <neuroml:hasParameter>reset</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseIafCapCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseIafCapCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Base Type for all Integrate and Fire cells with a capacitance _C, threshold _thresh and reset membrane potential _reset</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseIafCapCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseIafCapCell"/>
+        <neuroml:hasParameter>reset</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseIonChannel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseIonChannel">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base for all ion channel ComponentTypes</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseIonChannel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseIonChannel"/>
+        <neuroml:exposes>fopen</neuroml:exposes>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePlasticityMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePlasticityMechanism">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base plasticity mechanism.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePlasticityMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePlasticityMechanism"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:exposes>plasticityFactor</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePointCurrent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePointCurrent">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a current _i (with dimension current)</terms:description>
+        <rdfs:comment xml:lang="en">A tvbo:Dynamics acting as an input current is emitted as a descendant of basePointCurrent.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePointCurrent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePointCurrent"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
+        <neuroml:exposes>i</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePointCurrentDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePointCurrentDL">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a dimensionless current _I. There are many dimensionless equivalents of all the core current producing ComponentTypes such as _pulseGenerator_ / _pulseGeneratorDL_, _sineGenerator_ / _sineGeneratorDL_ and _rampGenerator_ / _rampGeneratorDL_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePointCurrentDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePointCurrentDL"/>
+        <neuroml:exposes>I</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePopulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePopulation">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">A population of multiple instances of a specific _component, which anything which extends _baseCell_. </terms:description>
+        <rdfs:comment xml:lang="en">A NeuroML population corresponds to a tvbo network node (a group of cells of one type).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePopulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePopulation"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Node"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePyNNCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePyNNCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Base type of any PyNN standard cell model. Note: membrane potential _v has dimensions voltage, but all other parameters are dimensionless. This is to facilitate translation to and from PyNN scripts in Python, where these parameters have implicit units, see http://neuralensemble.org/trac/PyNN/wiki/StandardModels</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePyNNCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePyNNCell"/>
+        <neuroml:eventPort>spike_in_E</neuroml:eventPort>
+        <neuroml:eventPort>spike_in_I</neuroml:eventPort>
+        <neuroml:exposes>iSyn</neuroml:exposes>
+        <neuroml:hasParameter>cm</neuroml:hasParameter>
+        <neuroml:hasParameter>i_offset</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_syn_E</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_syn_I</neuroml:hasParameter>
+        <neuroml:hasParameter>v_init</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePyNNIaFCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePyNNIaFCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNCell"/>
+        <terms:description xml:lang="en">Base type of any PyNN standard integrate and fire model</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePyNNIaFCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePyNNIaFCell"/>
+        <neuroml:hasParameter>tau_m</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_refrac</neuroml:hasParameter>
+        <neuroml:hasParameter>v_reset</neuroml:hasParameter>
+        <neuroml:hasParameter>v_rest</neuroml:hasParameter>
+        <neuroml:hasParameter>v_thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCell"/>
+        <terms:description xml:lang="en">Base type of conductance based PyNN IaF cell models</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePyNNIaFCondCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePyNNIaFCondCell"/>
+        <neuroml:hasParameter>e_rev_E</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_I</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePynnSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePynnSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Base type for all PyNN synapses. Note, the current _I produced is dimensionless, but it requires a membrane potential _v with dimension voltage</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePynnSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePynnSynapse"/>
+        <neuroml:hasParameter>tau_syn</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseQ10Settings -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseQ10Settings">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for a scaling to apply to gating variable time course, usually temperature dependent</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseQ10Settings</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseQ10Settings"/>
+        <neuroml:exposes>q10</neuroml:exposes>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSpikeSource -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSpikeSource">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base for any ComponentType whose main purpose is to emit spikes (on a port _spike). The exposed variable _tsince can be used for plotting the time since the Component has spiked last.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSpikeSource</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSpikeSource"/>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSpikingCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSpikingCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCell"/>
+        <terms:description xml:lang="en">Base type of any cell which can emit _spike events.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSpikingCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSpikingCell"/>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseStandalone -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseStandalone">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type of any Component which can have _Notes_, _Annotation_, or a _property_ list.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseStandalone</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseStandalone"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Base type for all synapses, i.e. ComponentTypes which produce a current (dimension current) and change Dynamics in response to an incoming event. cno_0000009</terms:description>
+        <rdfs:comment xml:lang="en">A tvbo:Dynamics acting as a synapse is emitted as a descendant of baseSynapse.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSynapse"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSynapseDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSynapseDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentDL"/>
+        <terms:description xml:lang="en">Base type for all synapses, i.e. ComponentTypes which produce a dimensionless current and change Dynamics in response to an incoming event. cno_0000009</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSynapseDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSynapseDL"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageConcDepRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageConcDepRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepRate"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage and concentration dependent rate. Produces a time varying rate _r which depends on _v and _caConc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageConcDepRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageConcDepRate"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageConcDepTime -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageConcDepTime">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepTime"/>
+        <terms:description xml:lang="en">Base type for voltage and calcium concentration dependent ComponentType producing value _t with dimension time (e.g. for time course of rate variable).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageConcDepTime</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageConcDepTime"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageConcDepVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageConcDepVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepVariable"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage and calcium concentration dependent variable _x, which depends on _v and _caConc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageConcDepVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageConcDepVariable"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a current _i (with dimension current) and require a voltage _v exposed on the parent Component, which would often be the membrane potential of a Component extending _baseCellMembPot_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepPointCurrent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepPointCurrent"/>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a dimensionless current _I and require a dimensionless membrane potential _V exposed on the parent Component</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepPointCurrentDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepPointCurrentDL"/>
+        <neuroml:requires>V</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a current _i, require a membrane potential _v exposed on the parent and emit spikes (on a port _spike). The exposed variable _tsince can be used for plotting the time since the Component has spiked last</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepPointCurrentSpiking</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepPointCurrentSpiking"/>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepRate">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent rate. Produces a time varying rate _r which depends on _v.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepRate"/>
+        <neuroml:exposes>r</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Base type for synapses with a dependence on membrane potential</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepSynapse"/>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepTime -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepTime">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent ComponentType producing value _t with dimension time (e.g. for time course of rate variable). Note: time course would not normally be fit to exp/sigmoid etc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepTime</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepTime"/>
+        <neuroml:exposes>t</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepVariable">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent variable  _x, which depends on _v. Can be used for inf/steady state of rate variable.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepVariable"/>
+        <neuroml:exposes>x</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/biophysicalProperties -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/biophysicalProperties">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The biophysical properties of the _cell_, including the _membraneProperties_ and the _intracellularProperties_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">biophysicalProperties</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#biophysicalProperties"/>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/biophysicalProperties2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/biophysicalProperties2CaPools">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The biophysical properties of the _cell_, including the _membraneProperties2CaPools_ and the _intracellularProperties2CaPools_ for a cell with two Ca pools</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">biophysicalProperties2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#biophysicalProperties2CaPools"/>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/blockingPlasticSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/blockingPlasticSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/expTwoSynapse"/>
+        <terms:description xml:lang="en">Biexponential synapse that allows for     optional block and plasticity     mechanisms, which can be expressed as     child elements.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">blockingPlasticSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#blockingPlasticSynapse"/>
+        <neuroml:eventPort>relay</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Cell with _segment_s specified in a _morphology_ element along with details on its _biophysicalProperties_. NOTE: this can only be correctly simulated using jLEMS when there is a single segment in the cell, and _v of this cell represents the membrane potential in that isopotential segment.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#cell"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>caConcExt</neuroml:exposes>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:exposes>iChannels</neuroml:exposes>
+        <neuroml:exposes>iSyn</neuroml:exposes>
+        <neuroml:exposes>spiking</neuroml:exposes>
+        <neuroml:exposes>surfaceArea</neuroml:exposes>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/cell2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/cell2CaPools">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/cell"/>
+        <terms:description xml:lang="en">Variant of cell with two independent Ca2+ pools. Cell with _segment_s specified in a _morphology_ element along with details on its _biophysicalProperties_. NOTE: this can only be correctly simulated using jLEMS when there is a single segment in the cell, and _v of this cell represents the membrane potential in that isopotential segment.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">cell2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#cell2CaPools"/>
+        <neuroml:exposes>caConc2</neuroml:exposes>
+        <neuroml:exposes>caConcExt2</neuroml:exposes>
+        <neuroml:exposes>iCa2</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensity -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensity">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">Specifies a time varying ohmic conductance density, _gDensity, which is distributed on an area of the _cell (specified in _membraneProperties_) with fixed reversal potential _erev producing a current density _iDensity</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensity</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensity"/>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityGHK -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityGHK">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, _gDensity, which is distributed on an area of the cell, producing a current density _iDensity and whose reversal potential is calculated from the Goldman Hodgkin Katz equation. Hard coded for Ca only! See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityGHK</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityGHK"/>
+        <neuroml:hasParameter>permeability</neuroml:hasParameter>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityGHK2 -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityGHK2">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">Time varying conductance density, _gDensity, which is distributed on an area of the cell, producing a current density _iDensity. Modified version of Jaffe et al. 1994 (used also in Lawrence et al. 2006). See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityGHK2</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityGHK2"/>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNernst -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNernst">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, _gDensity, which is distributed on an area of the _cell, producing a current density _iDensity and whose reversal potential is calculated from the Nernst equation. Hard coded for Ca only! See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNernst</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNernst"/>
+        <neuroml:exposes>erev</neuroml:exposes>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNernstCa2 -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNernstCa2">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">This component is similar to the original component type _channelDensityNernst_ but it is changed in order to have a reversal potential that depends on a second independent Ca++ pool (ca2). See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNernstCa2</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNernstCa2"/>
+        <neuroml:exposes>erev</neuroml:exposes>
+        <neuroml:requires>caConc2</neuroml:requires>
+        <neuroml:requires>caConcExt2</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNonUniform -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNonUniform">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying ohmic conductance density, which is distributed on a region of the _cell. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNonUniform</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNonUniform"/>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNonUniformGHK -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNonUniformGHK">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, which is distributed on a region of the _cell, and whose current is calculated from the Goldman-Hodgkin-Katz equation. Hard coded for Ca only!. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNonUniformGHK</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNonUniformGHK"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNonUniformNernst -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNonUniformNernst">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, which is distributed on a region of the _cell, and whose reversal potential is calculated from the Nernst equation. Hard coded for Ca only!. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNonUniformNernst</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNonUniformNernst"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityVShift -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityVShift">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/channelDensity"/>
+        <terms:description xml:lang="en">Same as _channelDensity_, but with a _vShift parameter to change voltage activation of gates. The exact usage of _vShift in expressions for rates is determined by the individual gates.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityVShift</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityVShift"/>
+        <neuroml:hasParameter>vShift</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelPopulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelPopulation">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelPopulation"/>
+        <terms:description xml:lang="en">Population of a _number of ohmic ion channels. These each produce a conductance _channelg across a reversal potential _erev, giving a total current _i. Note that active membrane currents are more frequently specified as a density over an area of the _cell_ using _channelDensity_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelPopulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelPopulation"/>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>number</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelPopulationNernst -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelPopulationNernst">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelPopulation"/>
+        <terms:description xml:lang="en">Population of a _number of channels with a time varying reversal potential _erev determined by Nernst equation. Note: hard coded for Ca only!</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelPopulationNernst</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelPopulationNernst"/>
+        <neuroml:exposes>erev</neuroml:exposes>
+        <neuroml:hasParameter>number</neuroml:hasParameter>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/closedState -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/closedState">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSState"/>
+        <terms:description xml:lang="en">A _KSState_ with _relativeConductance of 0</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">closedState</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#closedState"/>
+        <neuroml:hasParameter>relativeConductance</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/compoundInput -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/compoundInput">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a current which is the sum of all its child _basePointCurrent_ element, e.g. can be a combination of _pulseGenerator_, _sineGenerator_ elements producing a single _i. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">compoundInput</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#compoundInput"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/compoundInputDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/compoundInputDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Generates a current which is the sum of all its child _basePointCurrentDL_ elements, e.g. can be a combination of _pulseGeneratorDL_, _sineGeneratorDL_ elements producing a single _i. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">compoundInputDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#compoundInputDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/concentrationModel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/concentrationModel">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base for any model of an _ion concentration which changes with time. Internal (_concentration) and external (_extConcentration) values for the concentration of the ion are given.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">concentrationModel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#concentrationModel"/>
+        <neuroml:exposes>concentration</neuroml:exposes>
+        <neuroml:exposes>extConcentration</neuroml:exposes>
+        <neuroml:requires>initialConcentration</neuroml:requires>
+        <neuroml:requires>initialExtConcentration</neuroml:requires>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/connection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/connection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Event connection directly between named components, which gets processed via a new instance of a _synapse component which is created on the target component. Normally contained inside a _projection_ element.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">connection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#connection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/connectionWD -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/connectionWD">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/connection"/>
+        <terms:description xml:lang="en">Event connection between named components, which gets processed via a new instance of a synapse component which is created on the target component, includes setting of _weight and _delay for the synaptic connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">connectionWD</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#connectionWD"/>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousConnection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Can be used for analog synapses.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousConnectionInstance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousConnectionInstance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Can be used for analog synapses.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousConnectionInstance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousConnectionInstance"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousConnectionInstanceW -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousConnectionInstanceW">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/continuousConnectionInstance"/>
+        <terms:description xml:lang="en">An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Can be used for analog synapses. Includes setting of _weight for the connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousConnectionInstanceW</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousConnectionInstanceW"/>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousProjection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousProjection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A projection between _presynapticPopulation and _postsynapticPopulation through components _preComponent at the start and _postComponent at the end of a _continuousConnection_ or _continuousConnectionInstance_. Can be used for analog synapses.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousProjection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousProjection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/decayingPoolConcentrationModel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/decayingPoolConcentrationModel">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/concentrationModel"/>
+        <terms:description xml:lang="en">Model of an intracellular buffering mechanism for _ion (currently hard Coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course _decayConstant. The ion is assumed to occupy a shell inside the membrane of thickness _shellThickness.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">decayingPoolConcentrationModel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#decayingPoolConcentrationModel"/>
+        <neuroml:hasParameter>decayConstant</neuroml:hasParameter>
+        <neuroml:hasParameter>restingConc</neuroml:hasParameter>
+        <neuroml:hasParameter>shellThickness</neuroml:hasParameter>
+        <neuroml:requires>iCa</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/distal -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/distal">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/point3DWithDiam"/>
+        <terms:description xml:lang="en">Point on a _segment_ furthest from the soma. Should always be present in the description of a _segment_, unlike _proximal_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">distal</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#distal"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/distalDetails -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/distalDetails">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">What to do at the distal point when creating an inhomogeneous parameter</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">distalDetails</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#distalDetails"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/doubleSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/doubleSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Synapse consisting of two independent synaptic mechanisms (e.g. AMPA-R and NMDA-R), which can be easily colocated in connections</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">doubleSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#doubleSynapse"/>
+        <neuroml:eventPort>relay</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalConnection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">To enable connections between populations through gap junctions.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalConnectionInstance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalConnectionInstance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">To enable connections between populations through gap junctions. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalConnectionInstance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalConnectionInstance"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalConnectionInstanceW -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalConnectionInstanceW">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/electricalConnectionInstance"/>
+        <terms:description xml:lang="en">To enable connections between populations through gap junctions. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Includes setting of _weight for the connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalConnectionInstanceW</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalConnectionInstanceW"/>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalProjection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalProjection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A projection between _presynapticPopulation to another _postsynapticPopulation through gap junctions.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalProjection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalProjection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expCondSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expCondSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Conductance based synapse with instantaneous rise and single exponential decay (with time constant tau_syn)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expCondSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expCondSynapse"/>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>e_rev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expCurrSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expCurrSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Current based synapse with instantaneous rise and single exponential decay (with time constant tau_syn)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expCurrSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expCurrSynapse"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expOneSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expOneSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse"/>
+        <terms:description xml:lang="en">Ohmic synapse model whose conductance rises instantaneously by (_gbase * _weight) on receiving an event, and which decays exponentially to zero with time course _tauDecay</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expOneSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expOneSynapse"/>
+        <neuroml:hasParameter>tauDecay</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expThreeSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expThreeSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapseTwo"/>
+        <terms:description xml:lang="en">Ohmic synapse similar to expTwoSynapse but consisting of two components that can differ in decay times and max conductances but share the same rise time.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expThreeSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expThreeSynapse"/>
+        <neuroml:hasParameter>tauDecay1</neuroml:hasParameter>
+        <neuroml:hasParameter>tauDecay2</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRise</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expTwoSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expTwoSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse"/>
+        <terms:description xml:lang="en">Ohmic synapse model whose conductance waveform on receiving an event has a rise time of _tauRise and a decay time of _tauDecay. Max conductance reached during this time (assuming zero conductance before) is _gbase * _weight.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expTwoSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expTwoSynapse"/>
+        <neuroml:hasParameter>tauDecay</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRise</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/explicitConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/explicitConnection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Explicit event connection between components</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">explicitConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#explicitConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/explicitInput -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/explicitInput">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An explicit input (anything which extends _basePointCurrent_) to a target cell in a population</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">explicitInput</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#explicitInput"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fitzHughNagumo1969Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fitzHughNagumo1969Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotDL"/>
+        <terms:description xml:lang="en">The Fitzhugh Nagumo model is a two-dimensional simplification of the Hodgkin-Huxley model of spike generation in squid giant axons.  This system was suggested by FitzHugh (FitzHugh R. [1961]: Impulses and physiological states in theoretical models of nerve membrane.  Biophysical J.  1:445-466), who called it &quot; Bonhoeffer-van der Pol model &quot;, and the equivalent circuit by Nagumo et al.  (Nagumo J., Arimoto S., and Yoshizawa S. [1962] An active pulse transmission line simulating nerve axon. Proc IRE. 50:2061-2070.1962). This version corresponds to the one described in FitzHugh R.[1969]: Mathematical models of excitation and propagation in nerve.  Chapter 1 (pp. 1-85 in H.P. Schwan, ed. Biological Engineering, McGraw-Hill Book Co., N.Y.)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fitzHughNagumo1969Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fitzHughNagumo1969Cell"/>
+        <neuroml:exposes>F</neuroml:exposes>
+        <neuroml:exposes>W</neuroml:exposes>
+        <neuroml:hasParameter>I</neuroml:hasParameter>
+        <neuroml:hasParameter>V0</neuroml:hasParameter>
+        <neuroml:hasParameter>W0</neuroml:hasParameter>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>phi</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fitzHughNagumoCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fitzHughNagumoCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotDL"/>
+        <terms:description xml:lang="en">Simple dimensionless model of spiking cell from FitzHugh and Nagumo. Superseded by _fitzHughNagumo1969Cell (See https://github.com/NeuroML/NeuroML2/issues/42)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fitzHughNagumoCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fitzHughNagumoCell"/>
+        <neuroml:exposes>W</neuroml:exposes>
+        <neuroml:hasParameter>I</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModel">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/concentrationModel"/>
+        <terms:description xml:lang="en">Model of buffering of concentration of an ion (currently hard coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course _decayConstant. A fixed factor _rho is used to scale the incoming current *independently of the size of the compartment* to produce a concentration change.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fixedFactorConcentrationModel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fixedFactorConcentrationModel"/>
+        <neuroml:hasParameter>decayConstant</neuroml:hasParameter>
+        <neuroml:hasParameter>restingConc</neuroml:hasParameter>
+        <neuroml:hasParameter>rho</neuroml:hasParameter>
+        <neuroml:requires>iCa</neuroml:requires>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModelTraub -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModelTraub">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/concentrationModel"/>
+        <terms:description xml:lang="en">Model of buffering of concentration of an ion (currently hard coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course 1 / _beta. A fixed factor _phi is used to scale the incoming current *independently of the size of the compartment* to produce a concentration change. Not recommended for use in models other than Traub et al. 2005!</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fixedFactorConcentrationModelTraub</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fixedFactorConcentrationModelTraub"/>
+        <neuroml:hasParameter>beta</neuroml:hasParameter>
+        <neuroml:hasParameter>phi</neuroml:hasParameter>
+        <neuroml:hasParameter>restingConc</neuroml:hasParameter>
+        <neuroml:requires>iCa</neuroml:requires>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fixedTimeCourse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fixedTimeCourse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepTime"/>
+        <terms:description xml:lang="en">Time course of a fixed magnitude _tau which can be used for the time course in _gateHHtauInf_, _gateHHratesTau_ or _gateHHratesTauInf_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fixedTimeCourse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fixedTimeCourse"/>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_account -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_account">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_account</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_account"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_fundedBy -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_fundedBy">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_fundedBy</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_fundedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_homepage -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_homepage">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_homepage</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_homepage"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_mbox -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_mbox">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_mbox</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_mbox"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_name -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_name">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_name</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_name"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_publications -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_publications">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_publications</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_publications"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_thumbnail -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_thumbnail">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_thumbnail</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_thumbnail"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_weblog -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_weblog">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_weblog</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_weblog"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/forwardTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/forwardTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">A forward only _KSTransition_ for a _gateKS_ which specifies a _rate (type _baseHHRate_) which follows one of the standard Hodgkin Huxley forms (e.g. _HHExpRate_, _HHSigmoidRate_, _HHExpLinearRate_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">forwardTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#forwardTransition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/from -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/from">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">In a _path_ or _subTree_, specifies which _segment (inclusive) from which to calculate the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">from</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#from"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gapJunction -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gapJunction">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Gap junction/single electrical connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gapJunction</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gapJunction"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGate"/>
+        <terms:description xml:lang="en">Conveniently named baseGate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateFractional -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateFractional">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate composed of subgates contributing with fractional conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateFractional</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateFractional"/>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHInstantaneous -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHInstantaneous">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism but is instantaneous, so tau = 0 and gate follows exactly inf value</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHInstantaneous</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHInstantaneous"/>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHrates -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHrates">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHrates</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHrates"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHratesInf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHratesInf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHratesInf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHratesInf"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHratesTau -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHratesTau">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHratesTau</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHratesTau"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHratesTauInf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHratesTauInf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHratesTauInf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHratesTauInf"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHtauInf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHtauInf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHtauInf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHtauInf"/>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateKS -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateKS">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGate"/>
+        <terms:description xml:lang="en">A gate which consists of multiple _KSState_s and _KSTransition_s giving the rates of transition between them</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateKS</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateKS"/>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gradedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gradedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGradedSynapse"/>
+        <terms:description xml:lang="en">Graded/analog synapse. Based on synapse in Methods of http://www.nature.com/neuro/journal/v7/n12/abs/nn1352.html</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gradedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gradedSynapse"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+        <neuroml:hasParameter>Vth</neuroml:hasParameter>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:hasParameter>delta</neuroml:hasParameter>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>k</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/hindmarshRose1984Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/hindmarshRose1984Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">         The Hindmarsh Rose model is a simplified point cell model which         captures complex firing patterns of single neurons, such as         periodic and chaotic bursting. It has a fast spiking subsystem,         which is a generalization of the FitzHugh-Nagumo system, coupled         to a slower subsystem which allows the model to fire bursts. The         dynamical variables x,y,z correspond to the membrane potential, a         recovery variable, and a slower adaptation current, respectively.          See Hindmarsh J. L., and Rose R. M. (1984) A model of neuronal         bursting using three coupled first order differential equations.         Proc. R. Soc. London, Ser. B 221:87–102.         </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">hindmarshRose1984Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#hindmarshRose1984Cell"/>
+        <neuroml:exposes>chi</neuroml:exposes>
+        <neuroml:exposes>phi</neuroml:exposes>
+        <neuroml:exposes>rho</neuroml:exposes>
+        <neuroml:exposes>spiking</neuroml:exposes>
+        <neuroml:exposes>x</neuroml:exposes>
+        <neuroml:exposes>y</neuroml:exposes>
+        <neuroml:exposes>z</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>c</neuroml:hasParameter>
+        <neuroml:hasParameter>d</neuroml:hasParameter>
+        <neuroml:hasParameter>r</neuroml:hasParameter>
+        <neuroml:hasParameter>s</neuroml:hasParameter>
+        <neuroml:hasParameter>v_scaling</neuroml:hasParameter>
+        <neuroml:hasParameter>x0</neuroml:hasParameter>
+        <neuroml:hasParameter>x1</neuroml:hasParameter>
+        <neuroml:hasParameter>y0</neuroml:hasParameter>
+        <neuroml:hasParameter>z0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIafCapCell"/>
+        <terms:description xml:lang="en">Integrate and fire cell with capacitance _C, _leakConductance and _leakReversal</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafCell"/>
+        <neuroml:hasParameter>leakConductance</neuroml:hasParameter>
+        <neuroml:hasParameter>leakReversal</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafRefCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafRefCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/iafCell"/>
+        <terms:description xml:lang="en">Integrate and fire cell  with capacitance _C, _leakConductance, _leakReversal and refractory period _refract</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafRefCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafRefCell"/>
+        <neuroml:hasParameter>refract</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafTauCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafTauCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIaf"/>
+        <terms:description xml:lang="en">Integrate and fire cell which returns to its leak reversal potential of _leakReversal with a time constant _tau</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafTauCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafTauCell"/>
+        <neuroml:hasParameter>leakReversal</neuroml:hasParameter>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafTauRefCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafTauRefCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/iafTauCell"/>
+        <terms:description xml:lang="en">Integrate and fire cell which returns to its leak reversal potential of _leakReversal with a time course _tau. It has a refractory period of _refract after spiking</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafTauRefCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafTauRefCell"/>
+        <neuroml:hasParameter>refract</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/include -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/include">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Include all members of another _segmentGroup_ in this group</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">include</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#include"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inhomogeneousParameter -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inhomogeneousParameter">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An inhomogeneous parameter specified across the _segmentGroup_ (see _variableParameter_ for usage).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inhomogeneousParameter</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inhomogeneousParameter"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inhomogeneousValue -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inhomogeneousValue">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies the _value of an _inhomogeneousParameter. For usage see _variableParameter_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inhomogeneousValue</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inhomogeneousValue"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/initMembPotential -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/initMembPotential">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Explicitly set initial membrane potential for the cell</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">initMembPotential</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#initMembPotential"/>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/input -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/input">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies a single input to a _target, optionally giving the _segmentId (default 0) and _fractionAlong the segment (default 0.5).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">input</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#input"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inputList -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inputList">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An explicit list of _input_s to a _population.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inputList</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inputList"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inputW -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inputW">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/input"/>
+        <terms:description xml:lang="en">Specifies input lists. Can set _weight to scale individual inputs.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inputW</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inputW"/>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/instance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/instance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies a single instance of a component in a _population_ (placed at _location_).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">instance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#instance"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/intracellularProperties -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/intracellularProperties">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Biophysical properties related to the intracellular space within the _cell_, such as the _resistivity_ and the list of ionic _species_ present. _caConc and _caConcExt are explicitly exposed here to facilitate accessing these values from other Components, even though _caConcExt is clearly not an intracellular property</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">intracellularProperties</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#intracellularProperties"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>caConcExt</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/intracellularProperties2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/intracellularProperties2CaPools">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/intracellularProperties"/>
+        <terms:description xml:lang="en">Variant of intracellularProperties with 2 independent Ca pools</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">intracellularProperties2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#intracellularProperties2CaPools"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>caConc2</neuroml:exposes>
+        <neuroml:exposes>caConcExt</neuroml:exposes>
+        <neuroml:exposes>caConcExt2</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannel">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/ionChannelHH"/>
+        <terms:description xml:lang="en">Note _ionChannel_ and _ionChannelHH_ are currently functionally identical. This is needed since many existing examples use ionChannel, some use ionChannelHH. NeuroML v2beta4 should remove one of these, probably ionChannelHH.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannel"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelHH -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelHH">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIonChannel"/>
+        <terms:description xml:lang="en">Note _ionChannel_ and _ionChannelHH_ are currently functionally identical. This is needed since many existing examples use ionChannel, some use ionChannelHH. NeuroML v2beta4 should remove one of these, probably ionChannelHH.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelHH</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelHH"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelKS -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelKS">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIonChannel"/>
+        <terms:description xml:lang="en">A kinetic scheme based ion channel with multiple _gateKS_s, each of which consists of multiple _KSState_s and _KSTransition_s giving the rates of transition between them</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelKS</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelKS"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelPassive -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelPassive">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/ionChannel"/>
+        <terms:description xml:lang="en">Simple passive ion channel where the constant conductance through the channel is equal to _conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelPassive</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelPassive"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelVShift -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelVShift">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/ionChannel"/>
+        <terms:description xml:lang="en">Same as _ionChannel_, but with a _vShift parameter to change voltage activation of gates. The exact usage of _vShift in expressions for rates is determined by the individual gates.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelVShift</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelVShift"/>
+        <neuroml:hasParameter>vShift</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/izhikevich2007Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/izhikevich2007Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Cell based on the modified Izhikevich model in Izhikevich 2007, Dynamical systems in neuroscience, MIT Press</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">izhikevich2007Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#izhikevich2007Cell"/>
+        <neuroml:exposes>u</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>c</neuroml:hasParameter>
+        <neuroml:hasParameter>d</neuroml:hasParameter>
+        <neuroml:hasParameter>k</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+        <neuroml:hasParameter>vpeak</neuroml:hasParameter>
+        <neuroml:hasParameter>vr</neuroml:hasParameter>
+        <neuroml:hasParameter>vt</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/izhikevichCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/izhikevichCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Cell based on the 2003 model of Izhikevich, see http://izhikevich.org/publications/spikes.htm</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">izhikevichCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#izhikevichCell"/>
+        <neuroml:exposes>U</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>c</neuroml:hasParameter>
+        <neuroml:hasParameter>d</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/linearGradedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/linearGradedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGradedSynapse"/>
+        <terms:description xml:lang="en">Behaves just like a one way gap junction.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">linearGradedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#linearGradedSynapse"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/location -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/location">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies the (x,y,z) location of a single _instance_ of a component in a _population_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">location</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#location"/>
+        <neuroml:hasParameter>x</neuroml:hasParameter>
+        <neuroml:hasParameter>y</neuroml:hasParameter>
+        <neuroml:hasParameter>z</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/member -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/member">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A single identified _segment which is part of the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">member</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#member"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/membraneProperties -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/membraneProperties">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Properties specific to the membrane, such as the _populations of channels, _channelDensities, _specificCapacitance, etc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">membraneProperties</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#membraneProperties"/>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:exposes>totChanCurrent</neuroml:exposes>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/membraneProperties2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/membraneProperties2CaPools">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/membraneProperties"/>
+        <terms:description xml:lang="en">Variant of membraneProperties with 2 independent Ca pools</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">membraneProperties2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#membraneProperties2CaPools"/>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:exposes>iCa2</neuroml:exposes>
+        <neuroml:exposes>totChanCurrent</neuroml:exposes>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/morphology -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/morphology">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The collection of _segment_s which specify the 3D structure of the cell, along with a number of _segmentGroup_s</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">morphology</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#morphology"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/network -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/network">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">Network containing: _population_s (potentially of type _populationList_, and so specifying a list of cell _location_s); _projection_s (with lists of _connection_s) and/or _explicitConnection_s; and _inputList_s (with lists of _input_s) and/or _explicitInput_s. Note: often in NeuroML this will be of type _networkWithTemperature_ if there are temperature dependent elements (e.g. ion channels).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">network</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#network"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/networkWithTemperature -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/networkWithTemperature">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/network"/>
+        <terms:description xml:lang="en">Same as _network_, but with an explicit _temperature for temperature dependent elements (e.g. ion channels)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">networkWithTemperature</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#networkWithTemperature"/>
+        <neuroml:hasParameter>temperature</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/openState -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/openState">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSState"/>
+        <terms:description xml:lang="en">A _KSState_ with _relativeConductance of 1</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">openState</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#openState"/>
+        <neuroml:hasParameter>relativeConductance</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/orcid_id -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/orcid_id">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">orcid_id</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#orcid_id"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/parent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/parent">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies the _segment_ which is this segment&apos;s parent. The _fractionAlong specifies where it is connected, usually 1 (the default value), meaning the _distal_ point of the parent, or 0, meaning the _proximal_ point. If it is between these, a linear interpolation between the 2 points should be used.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">parent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#parent"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/path -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/path">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Include all the _segment_s between those specified by _from_ and _to_, inclusive</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">path</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#path"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pinskyRinzelCA3Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pinskyRinzelCA3Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Reduced CA3 cell model from Pinsky, P.F., Rinzel, J. Intrinsic and network rhythmogenesis in a reduced traub model for CA3 neurons. J Comput Neurosci 1, 39-60 (1994). See https://github.com/OpenSourceBrain/PinskyRinzelModel</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pinskyRinzelCA3Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pinskyRinzelCA3Cell"/>
+        <neuroml:exposes>Cad</neuroml:exposes>
+        <neuroml:exposes>ICad</neuroml:exposes>
+        <neuroml:exposes>Si</neuroml:exposes>
+        <neuroml:exposes>Vd</neuroml:exposes>
+        <neuroml:exposes>Vs</neuroml:exposes>
+        <neuroml:exposes>Wi</neuroml:exposes>
+        <neuroml:exposes>cd</neuroml:exposes>
+        <neuroml:exposes>hs</neuroml:exposes>
+        <neuroml:exposes>ns</neuroml:exposes>
+        <neuroml:exposes>qd</neuroml:exposes>
+        <neuroml:exposes>sd</neuroml:exposes>
+        <neuroml:hasParameter>alphac</neuroml:hasParameter>
+        <neuroml:hasParameter>betac</neuroml:hasParameter>
+        <neuroml:hasParameter>cm</neuroml:hasParameter>
+        <neuroml:hasParameter>eCa</neuroml:hasParameter>
+        <neuroml:hasParameter>eK</neuroml:hasParameter>
+        <neuroml:hasParameter>eL</neuroml:hasParameter>
+        <neuroml:hasParameter>eNa</neuroml:hasParameter>
+        <neuroml:hasParameter>gAmpa</neuroml:hasParameter>
+        <neuroml:hasParameter>gCa</neuroml:hasParameter>
+        <neuroml:hasParameter>gKC</neuroml:hasParameter>
+        <neuroml:hasParameter>gKahp</neuroml:hasParameter>
+        <neuroml:hasParameter>gKdr</neuroml:hasParameter>
+        <neuroml:hasParameter>gLd</neuroml:hasParameter>
+        <neuroml:hasParameter>gLs</neuroml:hasParameter>
+        <neuroml:hasParameter>gNa</neuroml:hasParameter>
+        <neuroml:hasParameter>gNmda</neuroml:hasParameter>
+        <neuroml:hasParameter>gc</neuroml:hasParameter>
+        <neuroml:hasParameter>iDend</neuroml:hasParameter>
+        <neuroml:hasParameter>iSoma</neuroml:hasParameter>
+        <neuroml:hasParameter>pp</neuroml:hasParameter>
+        <neuroml:hasParameter>qd0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/point3DWithDiam -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/point3DWithDiam">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type for ComponentTypes which specify an ( _x, _y, _z ) coordinate along with a _diameter. Note: no dimension used in the attributes for these coordinates! These are assumed to have dimension micrometer (10^-6 m). This is due to micrometers being the default option for the majority of neuronal morphology formats, and dimensions are omitted here to facilitate reading and writing of morphologies in NeuroML.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">point3DWithDiam</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#point3DWithDiam"/>
+        <neuroml:hasParameter>diameter</neuroml:hasParameter>
+        <neuroml:hasParameter>x</neuroml:hasParameter>
+        <neuroml:hasParameter>y</neuroml:hasParameter>
+        <neuroml:hasParameter>z</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pointCellCondBased -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pointCellCondBased">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Simple model of a conductance based cell, with no separate _morphology_ element, just an absolute capacitance _C, and a set of channel _populations. Note: use of _cell_ is generally preferable (and more widely supported), even for a single compartment cell.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pointCellCondBased</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pointCellCondBased"/>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pointCellCondBasedCa -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pointCellCondBasedCa">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">TEMPORARY: Point cell with conductances and Ca concentration info. Not yet fully tested!!! TODO: Remove in favour of _cell_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pointCellCondBasedCa</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pointCellCondBasedCa"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/poissonFiringSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/poissonFiringSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking"/>
+        <terms:description xml:lang="en">Poisson spike generator firing at _averageRate, which is connected to single _synapse that is triggered every time a spike is generated, producing an input current. See also _transientPoissonFiringSynapse_.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">poissonFiringSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#poissonFiringSynapse"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:exposes>tsince</neuroml:exposes>
+        <neuroml:hasParameter>averageRate</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/population -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/population">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePopulation"/>
+        <terms:description xml:lang="en">A population of components, with just one parameter for the _size, i.e. number of components to create. Note: quite often this is used with type=_populationList_ which means the size is determined by the number of _instance_s (with _location_s) in the list. The _size attribute is still set, and there will be a validation error if this does not match the number in the list.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">population</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#population"/>
+        <neuroml:hasParameter>size</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/populationList -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/populationList">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePopulation"/>
+        <terms:description xml:lang="en">An explicit list of _instance_s (with _location_s) of components in the population. </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">populationList</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#populationList"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/projection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/projection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Projection from one population, _presynapticPopulation to another, _postsynapticPopulation, through _synapse. Contains lists of _connection_ or _connectionWD_ elements.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">projection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#projection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/proximal -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/proximal">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/point3DWithDiam"/>
+        <terms:description xml:lang="en">Point on a _segment_ closest to the soma. Note, the proximal point can be omitted, and in this case is defined as being the point _fractionAlong between the proximal and _distal_ point of the _parent_, i.e. if _fractionAlong = 1 (as it is by default) it will be the _distal on the parent, or if _fractionAlong = 0, it will be the proximal point. If between 0 and 1, it is the linear interpolation between the two points.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">proximal</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#proximal"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/proximalDetails -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/proximalDetails">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">What to do at the proximal point when creating an inhomogeneous parameter</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">proximalDetails</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#proximalDetails"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pulseGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pulseGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a constant current pulse of a certain _amplitude for a specified _duration after a _delay. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pulseGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pulseGenerator"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pulseGeneratorDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pulseGeneratorDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Dimensionless equivalent of _pulseGenerator_. Generates a constant current pulse of a certain _amplitude for a specified _duration after a _delay. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pulseGeneratorDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pulseGeneratorDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/q10ConductanceScaling -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/q10ConductanceScaling">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceScaling"/>
+        <terms:description xml:lang="en">A value for the conductance scaling which varies as a standard function of the difference between the current temperature, _temperature, and the temperature at which the conductance was originally determined, _experimentalTemp</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">q10ConductanceScaling</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#q10ConductanceScaling"/>
+        <neuroml:hasParameter>experimentalTemp</neuroml:hasParameter>
+        <neuroml:hasParameter>q10Factor</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/q10ExpTemp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/q10ExpTemp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseQ10Settings"/>
+        <terms:description xml:lang="en">A value for the Q10 scaling which varies as a standard function of the difference between the current temperature, _temperature, and the temperature at which the gating variable equations were determined, _experimentalTemp</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">q10ExpTemp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#q10ExpTemp"/>
+        <neuroml:hasParameter>experimentalTemp</neuroml:hasParameter>
+        <neuroml:hasParameter>q10Factor</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/q10Fixed -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/q10Fixed">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseQ10Settings"/>
+        <terms:description xml:lang="en">A fixed value, _fixedQ10, for the scaling of the time course of the gating variable</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">q10Fixed</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#q10Fixed"/>
+        <neuroml:hasParameter>fixedQ10</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/rampGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/rampGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a ramping current after a time _delay, for a fixed _duration. During this time the current steadily changes from _startAmplitude to _finishAmplitude. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">rampGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#rampGenerator"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>baselineAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>finishAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>startAmplitude</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/rampGeneratorDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/rampGeneratorDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Dimensionless equivalent of _rampGenerator_. Generates a ramping current after a time _delay, for a fixed _duration. During this time the dimensionless current steadily changes from _startAmplitude to _finishAmplitude. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">rampGeneratorDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#rampGeneratorDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>baselineAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>finishAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>startAmplitude</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/rectangularExtent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/rectangularExtent">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">For defining a 3D rectangular box</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">rectangularExtent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#rectangularExtent"/>
+        <neuroml:hasParameter>xLength</neuroml:hasParameter>
+        <neuroml:hasParameter>xStart</neuroml:hasParameter>
+        <neuroml:hasParameter>yLength</neuroml:hasParameter>
+        <neuroml:hasParameter>yStart</neuroml:hasParameter>
+        <neuroml:hasParameter>zLength</neuroml:hasParameter>
+        <neuroml:hasParameter>zStart</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/region -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/region">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Initial attempt to specify 3D region for placing cells. Work in progress...</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">region</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#region"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/resistivity -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/resistivity">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The resistivity, or specific axial resistance, of the cytoplasm</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">resistivity</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#resistivity"/>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/reverseTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/reverseTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">A reverse only _KSTransition_ for a _gateKS_ which specifies a _rate (type _baseHHRate_) which follows one of the standard Hodgkin Huxley forms (e.g. _HHExpRate_, _HHSigmoidRate_, _HHExpLinearRate_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">reverseTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#reverseTransition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/segment -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/segment">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A segment defines the smallest unit within a possibly branching structure (_morphology_), such as a dendrite or axon. Its _id should be a nonnegative integer (usually soma/root = 0). Its end points are given by the _proximal_ and _distal_ points. The _proximal_ point can be omitted, usually because it is the same as a point on the _parent_ segment, see _proximal_ for details. _parent_ specifies the parent segment. The first segment of a _cell_ (with no _parent_) usually represents the soma. The shape is normally a cylinder (radii of the _proximal_ and _distal_ equal, but positions different) or a conical frustum (radii and positions different). If the x,y,x positions of the _proximal_ and _distal_ are equal, the segment can be interpreted as a sphere, and in this case the radii of these points must be equal. NOTE: LEMS does not yet support multicompartmental modelling, so the Dynamics here is only appropriate for single compartment modelling. </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">segment</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#segment"/>
+        <neuroml:exposes>length</neuroml:exposes>
+        <neuroml:exposes>radDist</neuroml:exposes>
+        <neuroml:exposes>surfaceArea</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/segmentGroup -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/segmentGroup">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A method to describe a group of _segment_s in a _morphology_, e.g. soma_group, dendrite_group, axon_group. While a name is useful to describe the group, the _neuroLexId attribute can be used to explicitly specify the meaning of the group, e.g. sao1044911821 for &apos;Neuronal Cell Body&apos;, sao1211023249 for &apos;Dendrite&apos;. The _segment_s in this group can be specified as: a list of individual _member_ segments; a _path_, all of the segments along which should be included; a _subTree_ of the _cell_ to include; other segmentGroups to _include_ (so all segments from those get included here). An _inhomogeneousParameter_ can be defined on the region of the cell specified by this group (see _variableParameter_ for usage).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">segmentGroup</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#segmentGroup"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/silentSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/silentSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGradedSynapse"/>
+        <terms:description xml:lang="en">Dummy synapse which emits no current. Used as presynaptic endpoint for analog synaptic connection.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">silentSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#silentSynapse"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/sineGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/sineGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a sinusoidally varying current after a time _delay, for a fixed _duration. The _period and maximum _amplitude of the current can be set as well as the _phase at which to start. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">sineGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#sineGenerator"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>period</neuroml:hasParameter>
+        <neuroml:hasParameter>phase</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/sineGeneratorDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/sineGeneratorDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Dimensionless equivalent of _sineGenerator_. Generates a sinusoidally varying current after a time _delay, for a fixed _duration. The _period and maximum _amplitude of the current can be set as well as the _phase at which to start. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">sineGeneratorDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#sineGeneratorDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>period</neuroml:hasParameter>
+        <neuroml:hasParameter>phase</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/species -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/species">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Description of a chemical species identified by _ion, which has internal, _concentration, and external, _extConcentration values for its concentration</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">species</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#species"/>
+        <neuroml:exposes>concentration</neuroml:exposes>
+        <neuroml:exposes>extConcentration</neuroml:exposes>
+        <neuroml:hasParameter>initialConcentration</neuroml:hasParameter>
+        <neuroml:hasParameter>initialExtConcentration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/specificCapacitance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/specificCapacitance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Capacitance per unit area</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">specificCapacitance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#specificCapacitance"/>
+        <neuroml:exposes>specCap</neuroml:exposes>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spike -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spike">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Emits a single spike at the specified _time</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spike</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spike"/>
+        <neuroml:exposes>spiked</neuroml:exposes>
+        <neuroml:hasParameter>time</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeArray -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeArray">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Set of spike ComponentTypes, each emitting one spike at a certain time. Can be used to feed a predetermined spike train into a cell</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeArray</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeArray"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Simple generator of spikes at a regular interval set by _period</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGenerator"/>
+        <neuroml:exposes>tnext</neuroml:exposes>
+        <neuroml:hasParameter>period</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGeneratorPoisson -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGeneratorPoisson">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Generator of spikes whose ISI is distributed according to an exponential PDF with scale: 1 / _averageRate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGeneratorPoisson</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGeneratorPoisson"/>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:hasParameter>averageRate</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGeneratorRandom -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGeneratorRandom">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Generator of spikes with a random interspike interval of at least _minISI and at most _maxISI</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGeneratorRandom</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGeneratorRandom"/>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnext</neuroml:exposes>
+        <neuroml:hasParameter>maxISI</neuroml:hasParameter>
+        <neuroml:hasParameter>minISI</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGeneratorRefPoisson -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGeneratorRefPoisson">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/spikeGeneratorPoisson"/>
+        <terms:description xml:lang="en">Generator of spikes whose ISI distribution is the maximum entropy distribution over [ _minimumISI, +infinity ) with mean: 1 / _averageRate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGeneratorRefPoisson</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGeneratorRefPoisson"/>
+        <neuroml:hasParameter>minimumISI</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeThresh -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeThresh">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Membrane potential at which to emit a spiking event. Note, usually the spiking event will not be emitted again until the membrane potential has fallen below this value and rises again to cross it in a positive direction</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeThresh</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeThresh"/>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/stdpSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/stdpSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/expTwoSynapse"/>
+        <terms:description xml:lang="en">Spike timing dependent plasticity mechanism,  NOTE: EXAMPLE NOT YET WORKING!!!! cno_0000034</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">stdpSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#stdpSynapse"/>
+        <neuroml:exposes>M</neuroml:exposes>
+        <neuroml:exposes>P</neuroml:exposes>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/subGate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/subGate">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Gate composed of subgates contributing with fractional conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">subGate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#subGate"/>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>q</neuroml:exposes>
+        <neuroml:exposes>qfrac</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+        <neuroml:hasParameter>fractionalConductance</neuroml:hasParameter>
+        <neuroml:requires>rateScale</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/subTree -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/subTree">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Include all the _segment_s distal to that specified by _from_ in the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">subTree</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#subTree"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/synapticConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/synapticConnection">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/explicitConnection"/>
+        <terms:description xml:lang="en">Explicit event connection between named components, which gets processed via a new instance of a _synapse component which is created on the target component</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">synapticConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#synapticConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/synapticConnectionWD -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/synapticConnectionWD">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/synapticConnection"/>
+        <terms:description xml:lang="en">Explicit event connection between named components, which gets processed via a new instance of a _synapse component which is created on the target component, includes setting of _weight and _delay for the synaptic connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">synapticConnectionWD</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#synapticConnectionWD"/>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/tauInfTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/tauInfTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">KS Transition specified in terms of time constant _tau_ and steady state _inf_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">tauInfTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#tauInfTransition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/timedSynapticInput -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/timedSynapticInput">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking"/>
+        <terms:description xml:lang="en">Spike array connected to a single _synapse, producing a current triggered by each _spike_ in the array.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">timedSynapticInput</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#timedSynapticInput"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/to -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/to">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">In a _path_, specifies which _segment (inclusive) up to which to calculate the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">to</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#to"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/transientPoissonFiringSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/transientPoissonFiringSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking"/>
+        <terms:description xml:lang="en">Poisson spike generator firing at _averageRate after a _delay and for a _duration, connected to single _synapse that is triggered every time a spike is generated, providing an input current.                       Similar to ComponentType _poissonFiringSynapse_.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">transientPoissonFiringSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#transientPoissonFiringSynapse"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:exposes>tsince</neuroml:exposes>
+        <neuroml:hasParameter>averageRate</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/tsodyksMarkramDepFacMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/tsodyksMarkramDepFacMechanism">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePlasticityMechanism"/>
+        <terms:description xml:lang="en">Full Tsodyks-Markram STP model with both depression and facilitation, as in Tsodyks, Pawelzik and Markram 1998.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">tsodyksMarkramDepFacMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#tsodyksMarkramDepFacMechanism"/>
+        <neuroml:hasParameter>initReleaseProb</neuroml:hasParameter>
+        <neuroml:hasParameter>tauFac</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRec</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/tsodyksMarkramDepMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/tsodyksMarkramDepMechanism">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePlasticityMechanism"/>
+        <terms:description xml:lang="en">Depression-only Tsodyks-Markram model, as in Tsodyks and Markram 1997.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">tsodyksMarkramDepMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#tsodyksMarkramDepMechanism"/>
+        <neuroml:hasParameter>initReleaseProb</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRec</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/vHalfTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/vHalfTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">Transition which specifies both the forward and reverse rates of transition</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">vHalfTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#vHalfTransition"/>
+        <neuroml:hasParameter>gamma</neuroml:hasParameter>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+        <neuroml:hasParameter>tauMin</neuroml:hasParameter>
+        <neuroml:hasParameter>vHalf</neuroml:hasParameter>
+        <neuroml:hasParameter>z</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/variableParameter -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/variableParameter">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies a _parameter (e.g. condDensity) which can vary its value across a _segmentGroup. The value is calculated from _value attribute of the _inhomogeneousValue_ subelement. This element is normally a child of _channelDensityNonUniform_, _channelDensityNonUniformNernst_ or _channelDensityNonUniformGHK_ and is used to calculate the value of the conductance, etc. which will vary on different parts of the cell. The _segmentGroup specified here needs to define an _inhomogeneousParameter_ (referenced from _inhomogeneousParameter in the _inhomogeneousValue_), which calculates a _variable (e.g. p) varying across the cell (e.g. based on the path length from soma), which is then used in the _value attribute of the _inhomogeneousValue_ (so for example condDensity = f(p))</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">variableParameter</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#variableParameter"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/voltageClamp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/voltageClamp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Voltage clamp. Applies a variable current _i to try to keep parent at _targetVoltage. Not yet fully tested!!! Consider using voltageClampTriple!!</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">voltageClamp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#voltageClamp"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>simpleSeriesResistance</neuroml:hasParameter>
+        <neuroml:hasParameter>targetVoltage</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/voltageClampTriple -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/voltageClampTriple">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Voltage clamp with 3 clamp levels. Applies a variable current _i (through _simpleSeriesResistance) to try to keep parent cell at _conditioningVoltage until time _delay, _testingVoltage until _delay + _duration, and _returnVoltage afterwards. Only enabled if _active = 1. </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">voltageClampTriple</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#voltageClampTriple"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>active</neuroml:hasParameter>
+        <neuroml:hasParameter>conditioningVoltage</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>returnVoltage</neuroml:hasParameter>
+        <neuroml:hasParameter>simpleSeriesResistance</neuroml:hasParameter>
+        <neuroml:hasParameter>testingVoltage</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/voltageConcDepBlockMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/voltageConcDepBlockMechanism">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseBlockMechanism"/>
+        <terms:description xml:lang="en">Synaptic blocking mechanism which varys with membrane potential across the synapse, e.g. in NMDA receptor mediated synapses</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">voltageConcDepBlockMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#voltageConcDepBlockMechanism"/>
+        <neuroml:hasParameter>blockConcentration</neuroml:hasParameter>
+        <neuroml:hasParameter>scalingConc</neuroml:hasParameter>
+        <neuroml:hasParameter>scalingVolt</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
     </owl:Class>
     
 
@@ -50874,6 +54143,7 @@ to a task-appropriate range (e.g. omega in Hz).
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/CouplingInput"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
         <skos:prefLabel xml:lang="en">CouplingInput</skos:prefLabel>
+        <skos:relatedMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#Requirement"/>
     </rdf:Description>
     <rdf:Description rdf:about="https://w3id.org/tvbo/Deterministic">
         <rdfs:label xml:lang="en">Deterministic</rdfs:label>

--- a/scripts/ontology/gen_neuroml.py
+++ b/scripts/ontology/gen_neuroml.py
@@ -80,13 +80,19 @@ def locate_core_types(dest: str) -> str:
     import pyneuroml
 
     libdir = os.path.join(os.path.dirname(pyneuroml.__file__), "lib")
-    jars = sorted(glob.glob(os.path.join(libdir, "jNeuroML-*-jar-with-dependencies.jar")))
+    jars = glob.glob(os.path.join(libdir, "jNeuroML-*-jar-with-dependencies.jar"))
     if not jars:
         raise FileNotFoundError(
             f"No jNeuroML-*-jar-with-dependencies.jar under {libdir}. "
             "Install the neuroml extra: pip install tvbo[neuroml]."
         )
-    jar = jars[-1]
+
+    def _version(path):
+        """Numeric version tuple, so 0.14.0 sorts above 0.9.0 (lexically it does not)."""
+        m = re.search(r"jNeuroML-([0-9]+(?:\.[0-9]+)*)", os.path.basename(path))
+        return tuple(int(p) for p in m.group(1).split(".")) if m else ()
+
+    jar = max(jars, key=_version)
     with zipfile.ZipFile(jar) as z:
         members = [n for n in z.namelist() if n.startswith("NeuroML2CoreTypes/") and n.endswith(".xml")]
         z.extractall(dest, members=members)

--- a/scripts/ontology/gen_neuroml.py
+++ b/scripts/ontology/gen_neuroml.py
@@ -1,0 +1,279 @@
+"""NeuroML-core ingestion generator for TVB-O.
+
+Walks the NeuroML2 core ``ComponentType`` definitions (the LEMS type system
+bundled inside the jNeuroML jar) and emits two artifacts from one pass:
+
+- ``ontology/tvb-o-neuroml.ttl`` — the semantic module merged into ``tvbo.owl``.
+  One ``owl:Class`` per ``ComponentType`` under the tvbo-scoped namespace
+  ``https://w3id.org/tvbo/neuroml/``; ``extends`` becomes ``rdfs:subClassOf``;
+  each class carries ``skos:exactMatch`` to its direct NeuroML IRI
+  (``http://www.neuroml.org/schema/neuroml2#<name>``) so both identifiers denote
+  the same type; local exposures / requirements / event ports / parameters are
+  recorded as annotations. This is the "tvbo.owl references NeuroML-core" link,
+  alongside the GO bridge.
+
+- ``tvbo/data/ontology/neuroml_contracts.json`` — the compiled, ``extends``-
+  accumulated contract index the NeuroML adapter loads at emit time (stdlib
+  ``json``, no owlready2/rdflib/pylems on the hot path). It is a projection of
+  the same ingested data: for each type, the full inherited set of exposures,
+  requirements, parameters, event ports, attachments, children, and on-start
+  assignments. This is what grounds the adapter's base-type contracts.
+
+Both outputs are checked in and CI-guarded against drift, exactly like the other
+generated ontology artifacts. Regenerate with ``make gen-neuroml`` (or directly)
+whenever the bundled jNeuroML version changes.
+
+The RDF/Dublin-Core/XML metadata plumbing types that the core files pull in for
+``<notes>``/``<annotation>`` handling (``rdf_*``, ``dc_*``, ``notes``, ...) are
+not neuroscience component types and are filtered out; the count of skipped
+types is logged so the filtering is never silent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+import zipfile
+
+from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib.namespace import DCTERMS, OWL, RDF, RDFS, SKOS
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+TVBO = Namespace("https://w3id.org/tvbo/")
+NML = Namespace("https://w3id.org/tvbo/neuroml/")
+NEUROML2 = Namespace("http://www.neuroml.org/schema/neuroml2#")
+NML_ONT = URIRef("https://w3id.org/tvbo/neuroml")
+
+DEFAULT_TTL = ROOT / "ontology" / "tvb-o-neuroml.ttl"
+DEFAULT_CONTRACTS = ROOT / "tvbo" / "data" / "ontology" / "neuroml_contracts.json"
+
+# RDF / Dublin-Core / XML metadata infrastructure the core files include for
+# <notes>/<annotation> handling. These are not NeuroML neuroscience types.
+_PLUMBING_RE = re.compile(r"^(rdf|dc|dcterms|bibtex|sbml|xsd|lems)_")
+_PLUMBING_NAMES = {"notes", "annotation", "property", "baseAnnotation_without_ns"}
+
+
+def _is_plumbing(name: str) -> bool:
+    """True for RDF/Dublin-Core/XML metadata types (skipped from the ontology)."""
+    return bool(_PLUMBING_RE.match(name)) or name in _PLUMBING_NAMES
+
+
+def locate_core_types(dest: str) -> str:
+    """Extract ``NeuroML2CoreTypes/*.xml`` from the bundled jNeuroML jar.
+
+    Locates the jar inside the installed ``pyneuroml`` package so the version is
+    never hard-coded, and unpacks the core type XML into *dest*.
+
+    Args:
+        dest: Directory to extract into.
+
+    Returns:
+        Path to the extracted ``NeuroML2CoreTypes`` directory.
+    """
+    import pyneuroml
+
+    libdir = os.path.join(os.path.dirname(pyneuroml.__file__), "lib")
+    jars = sorted(glob.glob(os.path.join(libdir, "jNeuroML-*-jar-with-dependencies.jar")))
+    if not jars:
+        raise FileNotFoundError(
+            f"No jNeuroML-*-jar-with-dependencies.jar under {libdir}. "
+            "Install the neuroml extra: pip install tvbo[neuroml]."
+        )
+    jar = jars[-1]
+    with zipfile.ZipFile(jar) as z:
+        members = [n for n in z.namelist() if n.startswith("NeuroML2CoreTypes/") and n.endswith(".xml")]
+        z.extractall(dest, members=members)
+    core = os.path.join(dest, "NeuroML2CoreTypes")
+    print(f"  extracted {len(members)} core XML files from {os.path.basename(jar)}", file=sys.stderr)
+    return core
+
+
+def load_model(core_dir: str):
+    """Load every core-type XML into one pylems ``Model`` (includes resolved)."""
+    from lems.model.model import Model
+
+    model = Model(include_includes=True)
+    for fname in sorted(os.listdir(core_dir)):
+        if fname.endswith(".xml"):
+            model.import_from_file(os.path.join(core_dir, fname))
+    return model
+
+
+def _chain(component_types, name):
+    """The ``extends`` chain child→…→root as a list of ComponentTypes."""
+    seq = []
+    seen = set()
+    while name and name in component_types and name not in seen:
+        ct = component_types[name]
+        seq.append(ct)
+        seen.add(name)
+        name = ct.extends
+    return seq
+
+
+def _accumulate(component_types, name):
+    """Accumulate every inherited slot for *name* up its ``extends`` chain.
+
+    Walks root→child so a nearer type overrides a farther one, and drops the
+    metadata-plumbing children (``notes``/``annotation``/``property``).
+
+    Returns:
+        A contract dict: ``extends``, ``chain``, and the accumulated
+        ``exposures`` / ``requirements`` / ``parameters`` (name→dimension),
+        ``event_ports`` (name→direction), ``attachments`` (name→type),
+        ``children`` (name→{type, multiple}), and ``on_start`` (var→value).
+    """
+    exposures, requirements, parameters = {}, {}, {}
+    event_ports, attachments, children, on_start = {}, {}, {}, {}
+    for ct in reversed(_chain(component_types, name)):
+        for e in ct.exposures:
+            exposures[e.name] = e.dimension
+        for r in ct.requirements:
+            requirements[r.name] = r.dimension
+        for p in ct.parameters:
+            parameters[p.name] = p.dimension
+        for ev in ct.event_ports:
+            event_ports[ev.name] = ev.direction
+        for a in ct.attachments:
+            attachments[a.name] = getattr(a, "type", None)
+        for ch in ct.children:
+            if _is_plumbing(ch.name):
+                continue
+            children[ch.name] = {
+                "type": getattr(ch, "type", None),
+                "multiple": bool(getattr(ch, "multiple", False)),
+            }
+        dyn = getattr(ct, "dynamics", None)
+        for os_block in (getattr(dyn, "on_starts", []) or []):
+            for sa in (getattr(os_block, "state_assignments", []) or []):
+                on_start[sa.variable] = sa.value
+    self_ct = component_types[name]
+    return {
+        "extends": self_ct.extends,
+        "chain": [c.name for c in _chain(component_types, name)],
+        "exposures": exposures,
+        "requirements": requirements,
+        "parameters": parameters,
+        "event_ports": event_ports,
+        "attachments": attachments,
+        "children": children,
+        "on_start": on_start,
+    }
+
+
+# Annotation properties recording each type's locally-declared LEMS slots.
+_ANNOT = {
+    "exposes": (NML.exposes, "exposes", "A quantity this NeuroML ComponentType exposes."),
+    "requires": (NML.requires, "requires", "A quantity this NeuroML ComponentType requires from its context."),
+    "eventPort": (NML.eventPort, "event port", "An event port declared by this NeuroML ComponentType."),
+    "hasParameter": (NML.hasParameter, "has parameter", "A parameter declared by this NeuroML ComponentType."),
+}
+
+
+def build_ttl(component_types, domain_names) -> Graph:
+    """Build the ``tvb-o-neuroml.ttl`` graph (classes + subClassOf + cross-ref).
+
+    Records local (not accumulated) exposures/requirements/event-ports/parameters
+    as annotations; inheritance is carried by ``rdfs:subClassOf`` for a reasoner
+    to accumulate. The compiled JSON contract carries the accumulated form.
+    """
+    g = Graph()
+    g.bind("owl", OWL)
+    g.bind("rdfs", RDFS)
+    g.bind("skos", SKOS)
+    g.bind("dcterms", DCTERMS)
+    g.bind("tvbo", TVBO)
+    g.bind("nml", NML)
+    g.bind("neuroml2", NEUROML2)
+
+    g.add((NML_ONT, RDF.type, OWL.Ontology))
+    g.add((NML_ONT, DCTERMS.title, Literal("TVB-O NeuroML-core reference", lang="en")))
+    g.add((NML_ONT, DCTERMS.description, Literal(
+        "OWL rendering of the NeuroML2 core LEMS ComponentType hierarchy: one class "
+        "per ComponentType, extends as rdfs:subClassOf, cross-referenced to the "
+        "canonical NeuroML type via skos:exactMatch.", lang="en")))
+    g.add((NML_ONT, DCTERMS.license, URIRef("https://creativecommons.org/licenses/by/4.0/")))
+    g.add((NML_ONT, RDFS.seeAlso, URIRef("http://www.neuroml.org/schema/neuroml2")))
+
+    for prop, label, comment in _ANNOT.values():
+        g.add((prop, RDF.type, OWL.AnnotationProperty))
+        g.add((prop, RDFS.label, Literal(label, lang="en")))
+        g.add((prop, RDFS.comment, Literal(comment, lang="en")))
+
+    for name in sorted(domain_names):
+        ct = component_types[name]
+        cls = NML[name]
+        g.add((cls, RDF.type, OWL.Class))
+        g.add((cls, RDFS.label, Literal(name, lang="en")))
+        g.add((cls, RDFS.isDefinedBy, NML_ONT))
+        g.add((cls, SKOS.exactMatch, NEUROML2[name]))
+        if ct.extends and ct.extends in domain_names:
+            g.add((cls, RDFS.subClassOf, NML[ct.extends]))
+        if getattr(ct, "description", None):
+            g.add((cls, DCTERMS.description, Literal(str(ct.description), lang="en")))
+        for e in ct.exposures:
+            g.add((cls, NML.exposes, Literal(e.name)))
+        for r in ct.requirements:
+            g.add((cls, NML.requires, Literal(r.name)))
+        for ev in ct.event_ports:
+            g.add((cls, NML.eventPort, Literal(ev.name)))
+        for p in ct.parameters:
+            g.add((cls, NML.hasParameter, Literal(p.name)))
+    return g
+
+
+def build_contracts(component_types, domain_names) -> dict:
+    """Compile the accumulated contract index for every domain type."""
+    return {name: _accumulate(component_types, name) for name in sorted(domain_names)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate the TVB-O NeuroML-core ontology module + contract index.")
+    ap.add_argument("-o", "--output", default=str(DEFAULT_TTL), help="Turtle module output path.")
+    ap.add_argument("--contracts", default=str(DEFAULT_CONTRACTS), help="JSON contract index output path.")
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        core = locate_core_types(tmp)
+        model = load_model(core)
+
+    all_types = dict(model.component_types)
+
+    def _is_domain(name: str) -> bool:
+        """Domain type unless it or any ``extends`` ancestor is metadata plumbing.
+
+        The BioModels-qualifier and RDF annotation types (``bqbiol_*``,
+        ``bqmodel_*``, ``rdfs_seeAlso``, ...) descend from ``baseAnnotation_*``,
+        so the check must walk the chain, not just the type's own name.
+        """
+        return not any(_is_plumbing(ct.name) for ct in _chain(all_types, name))
+
+    domain_names = {n for n in all_types if _is_domain(n)}
+    skipped = sorted(n for n in all_types if not _is_domain(n))
+    print(f"  {len(all_types)} ComponentTypes total; {len(domain_names)} domain, "
+          f"{len(skipped)} plumbing skipped: {', '.join(skipped[:8])}"
+          f"{' …' if len(skipped) > 8 else ''}", file=sys.stderr)
+
+    g = build_ttl(all_types, domain_names)
+    out = pathlib.Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    g.serialize(destination=str(out), format="turtle")
+    print(f"✓ {len(domain_names)} classes → {out}", file=sys.stderr)
+
+    contracts = build_contracts(all_types, domain_names)
+    cout = pathlib.Path(args.contracts)
+    cout.parent.mkdir(parents=True, exist_ok=True)
+    cout.write_text(json.dumps(contracts, indent=2, sort_keys=True) + "\n")
+    print(f"✓ {len(contracts)} contracts → {cout}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/functional/test_neuroml_custom_synapse.py
+++ b/tests/functional/test_neuroml_custom_synapse.py
@@ -97,6 +97,24 @@ integration:
 """
 
 
+def _norm(text: str) -> str:
+    """Collapse whitespace so assertions survive printer spacing changes."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _time_derivative(component: str, variable: str) -> str:
+    """The TimeDerivative expression for *variable*, whitespace-normalised."""
+    m = re.search(r'<TimeDerivative variable="%s" value="([^"]+)"' % variable, component)
+    assert m, f"no TimeDerivative for {variable} in:\n{component}"
+    return _norm(m.group(1))
+
+
+def _render(tmp_path, yaml_text: str) -> str:
+    path = tmp_path / "column.yaml"
+    path.write_text(yaml_text)
+    return SimulationExperiment.from_file(str(path)).render("lems")
+
+
 @pytest.fixture(scope="module")
 def rendered_lems(tmp_path_factory) -> str:
     path = tmp_path_factory.mktemp("nmda") / "column.yaml"
@@ -129,14 +147,25 @@ class TestCustomConductanceSynapseEmission:
         assert "<InstanceRequirement" not in nmda_component
 
     def test_saturating_two_ode_gate(self, nmda_component):
-        """Deco Eqs 3-4: the saturating alpha*x*(1-s) term and the rise ODE."""
-        assert "alpha*x*(1 - s)" in nmda_component
-        assert re.search(r'<TimeDerivative variable="x" value="\(-x/tauRise\)', nmda_component)
+        """Deco Eqs 3-4: the saturating gate and the spike-driven rise ODE.
+
+        Asserted on the parsed expression rather than an exact string, so a
+        change in the symbolic printer's term order or spacing does not fail a
+        run that is still semantically correct.
+        """
+        decay = _time_derivative(nmda_component, "s")
+        assert "-s/tauDecay" in decay, decay
+        assert "alpha" in decay and "1 - s" in decay, decay  # the saturating term
+        rise = _time_derivative(nmda_component, "x")
+        assert "-x/tauRise" in rise, rise
 
     def test_spike_driven_onevent(self, nmda_component):
         """Presynaptic spike increments the rise variable (no linear proxy)."""
-        assert "<OnEvent port=\"in\">" in nmda_component
-        assert re.search(r'<StateAssignment variable="x" value="1 \+ x"', nmda_component)
+        assert '<OnEvent port="in">' in nmda_component
+        m = re.search(r'<OnEvent port="in">(.*?)</OnEvent>', nmda_component, re.S)
+        assign = re.search(r'<StateAssignment variable="x" value="([^"]+)"', m.group(1))
+        assert assign, m.group(1)
+        assert set(_norm(assign.group(1)).replace("+", " ").split()) == {"1", "x"}
 
     def test_mg_voltage_block(self, nmda_component):
         assert "mgFactor*exp(-v/scalingVolt)" in nmda_component
@@ -173,3 +202,43 @@ class TestCustomConductanceSynapseEmission:
             name = model.component_types[name].extends
         assert "baseConductanceBasedSynapse" in chain
         assert "baseStandalone" in chain  # resolves all the way to the root
+
+
+# A synapse with no base-type IRI keeps the historical current-based default.
+CURRENT_SYNAPSE_YAML = NMDA_COLUMN_YAML.replace(
+    """    NMDA:
+      iri: "extends:baseConductanceBasedSynapse\"""",
+    """    NMDA:""",
+).replace(
+    """      description: Deco (2014) Eqs 3-4 saturating NMDA gate with Mg2+ voltage block.
+""",
+    "",
+)
+
+
+class TestCurrentBasedSynapseUnchanged:
+    """The default path must not shift when no base type is declared.
+
+    Nothing in the tvbo database exercises the synapse emitter, so this pins the
+    pre-existing current-based behaviour that the ontology grounding defaults to.
+    """
+
+    @pytest.fixture(scope="class")
+    def component(self, tmp_path_factory) -> str:
+        xml = _render(tmp_path_factory.mktemp("cur"), CURRENT_SYNAPSE_YAML)
+        m = re.search(r'<ComponentType name="syn_edge0".*?</ComponentType>', xml, re.S)
+        assert m, "synapse ComponentType was not emitted"
+        return m.group(0)
+
+    def test_defaults_to_base_synapse(self, component):
+        assert 'extends="baseSynapse"' in component
+
+    def test_declares_own_parameters(self, component):
+        """baseSynapse inherits no parameters, so none are skipped."""
+        assert '<Parameter name="gbase"' in component
+        assert '<Parameter name="erev"' in component
+
+    def test_exposes_current_and_requires_voltage(self, component):
+        assert re.search(r'<DerivedVariable name="i"[^>]*exposure="i"', component)
+        # v is not inherited from baseSynapse, so it is declared explicitly.
+        assert '<InstanceRequirement name="v" type="voltage"/>' in component

--- a/tests/functional/test_neuroml_custom_synapse.py
+++ b/tests/functional/test_neuroml_custom_synapse.py
@@ -204,6 +204,43 @@ class TestCustomConductanceSynapseEmission:
         assert "baseStandalone" in chain  # resolves all the way to the root
 
 
+class TestUnknownBaseTypeWarns:
+    """A base type tvbo cannot resolve must not fail silently.
+
+    Emitting against an unknown type yields a ComponentType extending something
+    NeuroML has never heard of; without this warning the failure only surfaces
+    much later inside jNeuroML, with nothing pointing at the bad reference.
+    """
+
+    @staticmethod
+    def _resolve(ref):
+        from tvbo.adapters.neuroml import _base_type_meta
+
+        # The contract lookup is cached per name, so a warning fires only once
+        # per process for a given type.
+        _base_type_meta.cache_clear()
+        return _base_type_meta(ref)
+
+    def test_typo_warns_and_suggests_the_intended_type(self):
+        with pytest.warns(UserWarning, match="Unknown NeuroML base type") as rec:
+            meta = self._resolve("extends:baseConductnceBasedSynapse")
+        assert meta == {}
+        assert "baseConductanceBasedSynapse" in str(rec[0].message)
+
+    def test_unrecognisable_name_still_warns(self):
+        with pytest.warns(UserWarning, match="totallyBogusType"):
+            self._resolve("extends:totallyBogusType")
+
+    def test_known_base_types_are_silent(self):
+        import warnings as _w
+
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")
+            for ref in ("baseConductanceBasedSynapse", "baseSynapse", "baseCellMembPot"):
+                self._resolve(ref)
+        assert [str(c.message) for c in caught] == []
+
+
 # A synapse with no base-type IRI keeps the historical current-based default.
 CURRENT_SYNAPSE_YAML = NMDA_COLUMN_YAML.replace(
     """    NMDA:

--- a/tests/functional/test_neuroml_custom_synapse.py
+++ b/tests/functional/test_neuroml_custom_synapse.py
@@ -1,0 +1,175 @@
+"""Acceptance test: custom conductance-based synapse LEMS emission.
+
+Before the ontology grounding, tvbo could only emit current-based synapses
+(hardcoded ``extends="baseSynapse"``, exposing ``i``). Deco (2014)'s saturating
+NMDA gate (Eqs 3-4) is conductance-based — it exposes ``g`` and extends
+``baseConductanceBasedSynapse`` — so it was downgraded to the linear standard
+``blockingPlasticSynapse``.
+
+This test authors the *faithful* saturating NMDA as a custom tvbo Dynamics and
+checks that it emits, grounded in the ingested NeuroML ontology contract, as a
+valid conductance-based LEMS ComponentType: the base type, the ``g`` exposure,
+the two-ODE saturating gate with a spike-driven ``OnEvent``, and the Mg2+ block.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import zipfile
+
+import pytest
+
+from tvbo.classes.experiment import SimulationExperiment
+
+# A two-neuron column whose single edge is the custom saturating NMDA synapse.
+# The cell is a minimal LIF; the synapse carries the faithful Deco Eqs 3-4.
+NMDA_COLUMN_YAML = """
+label: "Custom saturating-NMDA column"
+network:
+  dynamics:
+    LIFCell:
+      iri: "extends:baseCellMembPot"
+      parameters:
+        C: {value: 0.5, unit: nF}
+        gL: {value: 25.0, unit: nS}
+        EL: {value: -70.0, unit: mV}
+        thresh: {value: -50.0, unit: mV}
+        reset: {value: -55.0, unit: mV}
+        v0: {value: -70.0, unit: mV}
+      state_variables:
+        v:
+          equation: {rhs: "(gL * (EL - v)) / C"}
+          initial_value: -70.0
+          unit: mV
+      events:
+        spike:
+          condition: {rhs: "v > thresh"}
+          affect: {rhs: "v = reset"}
+    NMDA:
+      iri: "extends:baseConductanceBasedSynapse"
+      description: Deco (2014) Eqs 3-4 saturating NMDA gate with Mg2+ voltage block.
+      parameters:
+        gbase: {value: 0.20, unit: nS}
+        erev: {value: 0.0, unit: mV}
+        tauDecay: {value: 100.0, unit: ms}
+        tauRise: {value: 2.0, unit: ms}
+        alpha: {value: 0.5, unit: per_ms}
+        mgFactor: {value: 0.28, unit: dimensionless}
+        scalingVolt: {value: 16.129, unit: mV}
+      coupling_inputs: [v]
+      state_variables:
+        s:
+          equation: {rhs: "-s / tauDecay + alpha * x * (1 - s)"}
+          initial_value: 0.0
+          unit: dimensionless
+        x:
+          equation: {rhs: "-x / tauRise"}
+          initial_value: 0.0
+          unit: dimensionless
+      derived_variables:
+        block:
+          equation: {rhs: "1 / (1 + mgFactor * exp(-v / scalingVolt))"}
+          unit: dimensionless
+        g:
+          equation: {rhs: "gbase * s * block"}
+          unit: nS
+        i:
+          equation: {rhs: "g * (erev - v)"}
+          unit: nA
+      events:
+        spike_in:
+          affect: {rhs: "x = x + 1"}
+  nodes:
+    - {id: 0, dynamics: LIFCell}
+    - {id: 1, dynamics: LIFCell}
+  edges:
+    - source: 0
+      target: 1
+      dynamics: NMDA
+      parameters:
+        weight: {value: 1.0}
+integration:
+  method: euler
+  step_size: 0.02
+  duration: 500.0
+  time_scale: ms
+"""
+
+
+@pytest.fixture(scope="module")
+def rendered_lems(tmp_path_factory) -> str:
+    path = tmp_path_factory.mktemp("nmda") / "column.yaml"
+    path.write_text(NMDA_COLUMN_YAML)
+    exp = SimulationExperiment.from_file(str(path))
+    return exp.render("lems")
+
+
+@pytest.fixture(scope="module")
+def nmda_component(rendered_lems) -> str:
+    # The edge's synapse ComponentType (id derived from the edge).
+    m = re.search(r'<ComponentType name="syn_edge0".*?</ComponentType>', rendered_lems, re.S)
+    assert m, "custom synapse ComponentType was not emitted"
+    return m.group(0)
+
+
+class TestCustomConductanceSynapseEmission:
+    def test_extends_conductance_based_synapse(self, nmda_component):
+        """Grounded in the ontology, not the hardcoded current-based baseSynapse."""
+        assert 'extends="baseConductanceBasedSynapse"' in nmda_component
+
+    def test_exposes_conductance(self, nmda_component):
+        assert re.search(r'<DerivedVariable name="g"[^>]*exposure="g"', nmda_component)
+        assert re.search(r'<DerivedVariable name="i"[^>]*exposure="i"', nmda_component)
+
+    def test_inherited_parameters_not_redeclared(self, nmda_component):
+        """gbase/erev come from baseConductanceBasedSynapse; v from the chain."""
+        assert '<Parameter name="gbase"' not in nmda_component
+        assert '<Parameter name="erev"' not in nmda_component
+        assert "<InstanceRequirement" not in nmda_component
+
+    def test_saturating_two_ode_gate(self, nmda_component):
+        """Deco Eqs 3-4: the saturating alpha*x*(1-s) term and the rise ODE."""
+        assert "alpha*x*(1 - s)" in nmda_component
+        assert re.search(r'<TimeDerivative variable="x" value="\(-x/tauRise\)', nmda_component)
+
+    def test_spike_driven_onevent(self, nmda_component):
+        """Presynaptic spike increments the rise variable (no linear proxy)."""
+        assert "<OnEvent port=\"in\">" in nmda_component
+        assert re.search(r'<StateAssignment variable="x" value="1 \+ x"', nmda_component)
+
+    def test_mg_voltage_block(self, nmda_component):
+        assert "mgFactor*exp(-v/scalingVolt)" in nmda_component
+
+    def test_pylems_valid_against_core_types(self, rendered_lems, tmp_path):
+        """The synapse resolves against the real NeuroML baseConductanceBasedSynapse."""
+        pytest.importorskip("lems")
+        pyneuroml = pytest.importorskip("pyneuroml")
+        from lems.model.model import Model
+
+        import glob
+
+        libdir = os.path.join(os.path.dirname(pyneuroml.__file__), "lib")
+        jars = sorted(glob.glob(os.path.join(libdir, "jNeuroML-*-jar-with-dependencies.jar")))
+        if not jars:
+            pytest.skip("jNeuroML jar not available")
+        with zipfile.ZipFile(jars[-1]) as z:
+            members = [n for n in z.namelist() if n.startswith("NeuroML2CoreTypes/") and n.endswith(".xml")]
+            z.extractall(tmp_path, members=members)
+        core = str(tmp_path / "NeuroML2CoreTypes")
+        sim = os.path.join(core, "_column_sim.xml")
+        with open(sim, "w") as fh:
+            fh.write(rendered_lems)
+
+        model = Model(include_includes=True)
+        model.add_include_directory(core)
+        model.import_from_file(sim)
+
+        ct = model.component_types["syn_edge0"]
+        assert ct.extends == "baseConductanceBasedSynapse"
+        chain, name = [], ct.extends
+        while name and name in model.component_types:
+            chain.append(name)
+            name = model.component_types[name].extends
+        assert "baseConductanceBasedSynapse" in chain
+        assert "baseStandalone" in chain  # resolves all the way to the root

--- a/tests/functional/test_neuroml_custom_synapse.py
+++ b/tests/functional/test_neuroml_custom_synapse.py
@@ -37,9 +37,10 @@ network:
         thresh: {value: -50.0, unit: mV}
         reset: {value: -55.0, unit: mV}
         v0: {value: -70.0, unit: mV}
+      coupling_inputs: [iSyn]
       state_variables:
         v:
-          equation: {rhs: "(gL * (EL - v)) / C"}
+          equation: {rhs: "(gL * (EL - v) + iSyn) / C"}
           initial_value: -70.0
           unit: mV
       events:
@@ -202,6 +203,25 @@ class TestCustomConductanceSynapseEmission:
             name = model.component_types[name].extends
         assert "baseConductanceBasedSynapse" in chain
         assert "baseStandalone" in chain  # resolves all the way to the root
+
+
+class TestSynapticTransmissionWiring:
+    """The synapse must actually reach the postsynaptic membrane equation.
+
+    A valid synapse ComponentType is not enough: the cell has to host it and sum
+    its current, or the synapse is emitted but inert.
+    """
+
+    def test_cell_hosts_and_sums_attached_synapses(self, rendered_lems):
+        cell = re.search(r'<ComponentType name="LIFCell".*?</ComponentType>', rendered_lems, re.S)
+        assert cell, "cell ComponentType was not emitted"
+        cell = cell.group(0)
+        assert '<Attachments name="synapses" type="basePointCurrent"/>' in cell
+        assert re.search(r'<DerivedVariable name="iSyn"[^>]*select="synapses\[\*\]/i"[^>]*reduce="add"', cell)
+        assert "iSyn" in _time_derivative(cell, "v")
+
+    def test_connection_targets_the_synapse(self, rendered_lems):
+        assert re.search(r'synapse="syn_edge0"[^>]*destination="synapses"', rendered_lems)
 
 
 class TestUnknownBaseTypeWarns:

--- a/tests/test_neuroml_ontology.py
+++ b/tests/test_neuroml_ontology.py
@@ -1,0 +1,146 @@
+"""Tests for the ingested NeuroML-core ontology module and contract index.
+
+Covers the two artifacts emitted by ``scripts/ontology/gen_neuroml.py``:
+
+- ``ontology/tvb-o-neuroml.ttl`` — the semantic module (classes, ``subClassOf``
+  from ``extends``, ``skos:exactMatch`` cross-reference to NeuroML).
+- ``tvbo/data/ontology/neuroml_contracts.json`` — the accumulated contract index
+  the adapter loads to ground its base-type emission.
+
+These assert the committed artifacts have the structure the adapter and the
+ontology merge depend on; a final determinism check (gated on pylems + the jar)
+guards against generator drift.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from rdflib import Graph, Namespace
+from rdflib.namespace import OWL, RDF, RDFS, SKOS
+
+import tvbo
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TTL_PATH = REPO_ROOT / "ontology" / "tvb-o-neuroml.ttl"
+CONTRACTS_PATH = pathlib.Path(tvbo.__file__).resolve().parent / "data" / "ontology" / "neuroml_contracts.json"
+
+NML = Namespace("https://w3id.org/tvbo/neuroml/")
+NEUROML2 = Namespace("http://www.neuroml.org/schema/neuroml2#")
+
+# The synapse branch is the first ingested vertical slice; its chain anchors the
+# structural assertions below.
+SYNAPSE_CHAIN = [
+    "baseConductanceBasedSynapse",
+    "baseVoltageDepSynapse",
+    "baseSynapse",
+    "basePointCurrent",
+    "baseStandalone",
+]
+
+
+@pytest.fixture(scope="module")
+def ttl() -> Graph:
+    assert TTL_PATH.exists(), f"missing generated module {TTL_PATH} (run `make gen-neuroml`)"
+    g = Graph()
+    g.parse(str(TTL_PATH), format="turtle")
+    return g
+
+
+@pytest.fixture(scope="module")
+def contracts() -> dict:
+    assert CONTRACTS_PATH.exists(), f"missing contract index {CONTRACTS_PATH} (run `make gen-neuroml`)"
+    return json.loads(CONTRACTS_PATH.read_text())
+
+
+class TestNeuroMLOntologyModule:
+    """The Turtle module merged into ``tvbo.owl``."""
+
+    def test_has_many_domain_classes(self, ttl):
+        classes = set(ttl.subjects(RDF.type, OWL.Class))
+        assert len(classes) > 200, "expected the full NeuroML2 core hierarchy"
+
+    def test_synapse_subclass_chain(self, ttl):
+        """``extends`` is faithfully rendered as a navigable ``subClassOf`` chain."""
+        def parent(cls):
+            supers = list(ttl.objects(cls, RDFS.subClassOf))
+            return supers[0] if supers else None
+
+        cls = NML["baseConductanceBasedSynapse"]
+        walked = []
+        while cls is not None:
+            walked.append(str(cls).rsplit("/", 1)[-1])
+            cls = parent(cls)
+        assert walked == SYNAPSE_CHAIN
+
+    def test_exactmatch_crossref_to_neuroml(self, ttl):
+        """Both the tvbo-scoped and the direct NeuroML IRI denote the type."""
+        matches = set(ttl.objects(NML["baseConductanceBasedSynapse"], SKOS.exactMatch))
+        assert NEUROML2["baseConductanceBasedSynapse"] in matches
+
+    def test_local_slot_annotations(self, ttl):
+        exposes = {str(o) for o in ttl.objects(NML["baseConductanceBasedSynapse"], NML.exposes)}
+        assert "g" in exposes
+        event_ports = {str(o) for o in ttl.objects(NML["baseSynapse"], NML.eventPort)}
+        assert "in" in event_ports
+
+    def test_plumbing_types_excluded(self, ttl):
+        """RDF/Dublin-Core metadata plumbing is not part of the ontology."""
+        for junk in ("notes", "annotation", "dc_title", "rdf_RDF"):
+            assert (NML[junk], RDF.type, OWL.Class) not in ttl
+
+
+class TestNeuroMLContracts:
+    """The accumulated JSON contract index consumed by the adapter."""
+
+    def test_synapse_contract_accumulated(self, contracts):
+        c = contracts["baseConductanceBasedSynapse"]
+        assert c["exposures"] == {"g": "conductance", "i": "current"}
+        assert c["requirements"] == {"v": "voltage"}
+        assert c["event_ports"] == {"in": "in"}
+        assert c["parameters"] == {"gbase": "conductance", "erev": "voltage"}
+        assert c["chain"] == SYNAPSE_CHAIN
+
+    def test_inheritance_extends_parent(self, contracts):
+        """A concrete synapse inherits its base contract and adds its own params."""
+        c = contracts["expOneSynapse"]
+        assert c["extends"] == "baseConductanceBasedSynapse"
+        assert {"gbase", "erev"} <= set(c["parameters"])  # inherited
+        assert "tauDecay" in c["parameters"]  # own
+
+    def test_cell_synapse_attachment_derived(self, contracts):
+        """Synapse-hosting is declared on concrete cells (not the abstract base)."""
+        assert contracts["iafRefCell"]["attachments"] == {"synapses": "basePointCurrent"}
+
+    def test_contract_covers_module_classes(self, contracts, ttl):
+        classes = {str(s).rsplit("/", 1)[-1] for s in ttl.subjects(RDF.type, OWL.Class)}
+        assert set(contracts) == classes
+
+
+class TestGeneratorDeterminism:
+    """Regenerating from the jar must reproduce the committed artifacts byte-for-byte."""
+
+    def test_regeneration_matches_committed(self, tmp_path):
+        pytest.importorskip("lems")
+        pytest.importorskip("pyneuroml")
+        import subprocess
+        import sys
+
+        ttl_out = tmp_path / "nml.ttl"
+        json_out = tmp_path / "nml.json"
+        script = REPO_ROOT / "scripts" / "ontology" / "gen_neuroml.py"
+        try:
+            subprocess.run(
+                [sys.executable, str(script), "-o", str(ttl_out), "--contracts", str(json_out)],
+                check=True, capture_output=True,
+            )
+        except FileNotFoundError:
+            pytest.skip("jNeuroML jar not available")
+        except subprocess.CalledProcessError as exc:
+            if b"No jNeuroML" in exc.stderr:
+                pytest.skip("jNeuroML jar not available")
+            raise
+        assert ttl_out.read_text() == TTL_PATH.read_text(), "tvb-o-neuroml.ttl drifted from generator"
+        assert json_out.read_text() == CONTRACTS_PATH.read_text(), "neuroml_contracts.json drifted from generator"

--- a/tvbo/adapters/neuroml.py
+++ b/tvbo/adapters/neuroml.py
@@ -1409,7 +1409,7 @@ def _resolve_base_type_name(ref: str) -> str:
     (``.../neuroml/<name>``) and the direct NeuroML IRI (``...neuroml2#<name>``),
     so a Dynamics may point at a base type by any of them interchangeably.
     """
-    ref = ref.strip()
+    ref = (ref or "").strip()
     if ref.startswith("extends:"):
         ref = ref.split(":", 1)[1]
     if "#" in ref:
@@ -1437,6 +1437,7 @@ def _extends_base(iri: str) -> str | None:
     return None
 
 
+@functools.lru_cache(maxsize=None)
 def _base_type_meta(extends: str) -> dict:
     """Emission contract for a NeuroML base type.
 
@@ -1444,6 +1445,9 @@ def _base_type_meta(extends: str) -> dict:
     slots a custom ComponentType inherits from *extends*. Built-in cell/channel/
     gate/rate bases use their fixed emission structure; every other base type is
     grounded in the ingested NeuroML ontology contract index.
+
+    The returned mapping is cached and shared between callers — treat it as
+    read-only.
     """
     name = _resolve_base_type_name(extends)
     if name in _BUILTIN_BASE_META:
@@ -3437,7 +3441,6 @@ def build_lems_context(experiment):
                     k for k, ev in ct_events.items() if not getattr(getattr(ev, "condition", None), "rhs", None)
                 ]
                 # Exposure / InstanceRequirement detection
-                has_i_exposure = "i" in ct_dvs or any(str(k) == "i" for k in ct_svs)
                 has_v_req = any(str(ci) == "v" for ci in ct_coupling_inputs)
 
                 # Ground the synapse's base type and its inherited exposures /
@@ -3480,7 +3483,6 @@ def build_lems_context(experiment):
                     "lems_sym": syn_lems_sym_fn,
                     # Synapse-specific extras
                     "is_synapse": True,
-                    "has_i_exposure": has_i_exposure,
                     "has_v_req": has_v_req,
                     "external_event_names": external_event_names,
                     "synapse_extends": syn_extends,

--- a/tvbo/adapters/neuroml.py
+++ b/tvbo/adapters/neuroml.py
@@ -12,6 +12,9 @@ Simulation can be run via pyNeuroML (jnml).
 
 from __future__ import annotations
 
+import functools
+import json
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -1342,13 +1345,19 @@ def _render_event_children(dyn_obj, time_scale="ms", indent=8):
 # biological types).  The adapter generates custom ComponentTypes that
 # extend the LEMS base types for type-system compatibility.
 #
-# The lookup tables below encode the LEMS *type-system infrastructure*
-# (what Child/Children/Attachments slots each base type declares, which
-# parameters are inherited, etc.).  This is NOT biological knowledge —
-# it's the equivalent of knowing that an abstract base class has certain
-# methods.
+# Emitting a custom ComponentType needs its base type's contract: the
+# quantities it exposes and requires, its inherited parameters, and the
+# Child/Children/Attachments slots it carries. ``_base_type_meta`` returns that
+# contract for any NeuroML base type, grounded in the ingested NeuroML ontology
+# (``neuroml_contracts.json``) — no per-type entry needed.
+#
+# ``_BUILTIN_BASE_META`` covers only the abstract cell/channel/gate/rate bases
+# the standard biological emitter drives. NeuroML declares their synapse-
+# hosting, gate-children and initial-value structure on concrete descendants
+# (``iafCell``, ``ionChannelHH``, ...), not on the abstract base, so the
+# canonical structure a custom cell/channel/gate emits is fixed here.
 
-_BASE_TYPE_META = {
+_BUILTIN_BASE_META = {
     "baseCellMembPot": {
         "inherited_params": set(),
         "exposures": {"v": "voltage"},
@@ -1379,6 +1388,82 @@ _BASE_TYPE_META = {
         "requirements": {"v": "voltage"},
     },
 }
+
+
+@functools.lru_cache(maxsize=1)
+def _load_neuroml_contracts() -> dict:
+    """Load the ingested NeuroML base-type contract index (cached).
+
+    Generated from the NeuroML core types by ``scripts/ontology/gen_neuroml.py``
+    and shipped at ``tvbo/data/ontology/neuroml_contracts.json``.
+    """
+    path = os.path.join(os.path.dirname(__file__), "..", "data", "ontology", "neuroml_contracts.json")
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _resolve_base_type_name(ref: str) -> str:
+    """Normalise a base-type reference to a bare NeuroML type name.
+
+    Accepts the ``extends:`` shorthand, the tvbo-scoped IRI
+    (``.../neuroml/<name>``) and the direct NeuroML IRI (``...neuroml2#<name>``),
+    so a Dynamics may point at a base type by any of them interchangeably.
+    """
+    ref = ref.strip()
+    if ref.startswith("extends:"):
+        ref = ref.split(":", 1)[1]
+    if "#" in ref:
+        ref = ref.rsplit("#", 1)[-1]
+    if "/" in ref:
+        ref = ref.rsplit("/", 1)[-1]
+    return ref
+
+
+def _extends_base(iri: str) -> str | None:
+    """Bare base-type name if *iri* references a NeuroML base type to extend.
+
+    Recognises the ``extends:`` shorthand, the tvbo-scoped IRI
+    (``.../neuroml/<name>`` or ``tvbo:neuroml/<name>``) and the direct NeuroML
+    IRI (``...neuroml2#<name>``). Returns ``None`` otherwise — in particular for
+    the ``neuroml:<name>`` standard-type reference, which is not an extension.
+    """
+    iri = (iri or "").strip()
+    if iri.startswith("extends:"):
+        return iri.split(":", 1)[1]
+    if "neuroml.org/schema/neuroml2#" in iri:
+        return iri.rsplit("#", 1)[-1]
+    if "/tvbo/neuroml/" in iri or iri.startswith("tvbo:neuroml/"):
+        return iri.rsplit("/", 1)[-1]
+    return None
+
+
+def _base_type_meta(extends: str) -> dict:
+    """Emission contract for a NeuroML base type.
+
+    Returns the exposures, requirements, inherited parameters and structural
+    slots a custom ComponentType inherits from *extends*. Built-in cell/channel/
+    gate/rate bases use their fixed emission structure; every other base type is
+    grounded in the ingested NeuroML ontology contract index.
+    """
+    name = _resolve_base_type_name(extends)
+    if name in _BUILTIN_BASE_META:
+        return _BUILTIN_BASE_META[name]
+    contract = _load_neuroml_contracts().get(name)
+    if not contract:
+        return {}
+    children = contract.get("children") or {}
+    plural = [(n, c["type"]) for n, c in children.items() if c.get("multiple")]
+    meta = {
+        "exposures": contract.get("exposures", {}),
+        "requirements": contract.get("requirements", {}),
+        "inherited_params": set(contract.get("parameters", {})),
+        "on_start_refs": dict(contract.get("on_start", {})),
+        "attachments": [(n, t) for n, t in (contract.get("attachments") or {}).items()],
+        "child_roles": {n: c["type"] for n, c in children.items() if not c.get("multiple")},
+    }
+    if plural:
+        meta["children"] = plural[0]
+    return meta
 
 
 def _hier_format_attr_value(param):
@@ -1436,7 +1521,7 @@ def _hier_build_dynamics(dyn, extends, all_params):
     Reads state_variables, derived_variables, and events from the
     Dynamics object and converts them to LEMS template data.
     """
-    meta = _BASE_TYPE_META.get(extends, {})
+    meta = _base_type_meta(extends)
     exposures = meta.get("exposures", {})
 
     # Collect all symbol names for expression conversion
@@ -1623,19 +1708,18 @@ def _build_hier_custom_context(experiment):
     type_defs = OrderedDict()
     type_order = []
 
-    root_extends = dyn.iri.split(":", 1)[1]
+    root_extends = _extends_base(dyn.iri)
     root_type_name = getattr(dyn, "label", None) or f"custom{root_extends}"
-    root_meta = _BASE_TYPE_META.get(root_extends, {})
+    root_meta = _base_type_meta(root_extends)
 
     channels = []
     channel_pops = []
 
     for ch_key, ch_dyn in (dyn.modes or {}).items():
-        ch_iri = getattr(ch_dyn, "iri", "") or ""
-        if not ch_iri.startswith("extends:"):
+        ch_extends = _extends_base(getattr(ch_dyn, "iri", ""))
+        if ch_extends is None:
             continue
-        ch_extends = ch_iri.split(":", 1)[1]
-        ch_meta = _BASE_TYPE_META.get(ch_extends, {})
+        ch_meta = _base_type_meta(ch_extends)
         ch_type_name = getattr(ch_dyn, "label", None) or f"custom{ch_extends}"
         ch_params = ch_dyn.parameters or {}
 
@@ -1651,11 +1735,10 @@ def _build_hier_custom_context(experiment):
         # ── Process gates (Children of channel) ──
         gate_instances = []
         for g_key, g_dyn in (ch_dyn.modes or {}).items():
-            g_iri = getattr(g_dyn, "iri", "") or ""
-            if not g_iri.startswith("extends:"):
+            g_extends = _extends_base(getattr(g_dyn, "iri", ""))
+            if g_extends is None:
                 continue
-            g_extends = g_iri.split(":", 1)[1]
-            g_meta = _BASE_TYPE_META.get(g_extends, {})
+            g_meta = _base_type_meta(g_extends)
             g_type_name = getattr(g_dyn, "label", None) or f"custom{g_extends}"
             g_params = g_dyn.parameters or {}
             g_inherited = g_meta.get("inherited_params", set())
@@ -1664,11 +1747,10 @@ def _build_hier_custom_context(experiment):
             # ── Process rates (Child of gate) ──
             rate_children = OrderedDict()
             for r_key, r_dyn in (g_dyn.modes or {}).items():
-                r_iri = getattr(r_dyn, "iri", "") or ""
-                if not r_iri.startswith("extends:"):
+                r_extends = _extends_base(getattr(r_dyn, "iri", ""))
+                if r_extends is None:
                     continue
-                r_extends = r_iri.split(":", 1)[1]
-                r_meta = _BASE_TYPE_META.get(r_extends, {})
+                r_meta = _base_type_meta(r_extends)
                 r_type_name = getattr(r_dyn, "label", None) or f"custom{r_extends}"
                 r_params = r_dyn.parameters or {}
                 r_inherited = r_meta.get("inherited_params", set())
@@ -1877,8 +1959,9 @@ def build_std_lems_context(experiment):
 
     iri = getattr(dyn, "iri", None) or ""
 
-    # Hierarchical custom types: iri starts with "extends:"
-    if iri.startswith("extends:"):
+    # Hierarchical custom types: iri references a NeuroML base type to extend
+    # (extends: shorthand, tvbo-scoped IRI, or direct NeuroML IRI).
+    if _extends_base(iri) is not None:
         return _build_hier_custom_context(experiment)
 
     if not iri.startswith("neuroml:"):

--- a/tvbo/adapters/neuroml.py
+++ b/tvbo/adapters/neuroml.py
@@ -12,10 +12,12 @@ Simulation can be run via pyNeuroML (jnml).
 
 from __future__ import annotations
 
+import difflib
 import functools
 import json
 import os
 import re
+import warnings
 from typing import TYPE_CHECKING
 
 from tvbo.adapters.base import BaseAdapter
@@ -1452,8 +1454,20 @@ def _base_type_meta(extends: str) -> dict:
     name = _resolve_base_type_name(extends)
     if name in _BUILTIN_BASE_META:
         return _BUILTIN_BASE_META[name]
-    contract = _load_neuroml_contracts().get(name)
+    contracts = _load_neuroml_contracts()
+    contract = contracts.get(name)
     if not contract:
+        # Emitting against an unknown base type produces a ComponentType that
+        # extends something NeuroML has never heard of, and the failure would
+        # otherwise only surface much later inside jNeuroML with no pointer back
+        # to the reference that was wrong.
+        close = difflib.get_close_matches(name, contracts, n=3)
+        hint = f" Did you mean {' or '.join(repr(c) for c in close)}?" if close else ""
+        warnings.warn(
+            f"Unknown NeuroML base type {name!r} — not in the ingested NeuroML ontology. "
+            f"The emitted ComponentType will extend a type that does not exist.{hint}",
+            stacklevel=2,
+        )
         return {}
     children = contract.get("children") or {}
     plural = [(n, c["type"]) for n, c in children.items() if c.get("multiple")]

--- a/tvbo/adapters/neuroml.py
+++ b/tvbo/adapters/neuroml.py
@@ -3440,6 +3440,19 @@ def build_lems_context(experiment):
                 has_i_exposure = "i" in ct_dvs or any(str(k) == "i" for k in ct_svs)
                 has_v_req = any(str(ci) == "v" for ci in ct_coupling_inputs)
 
+                # Ground the synapse's base type and its inherited exposures /
+                # parameters / requirements in the NeuroML ontology contract, so a
+                # conductance-based synapse (extends baseConductanceBasedSynapse,
+                # exposing g) emits as well as the current-based baseSynapse default.
+                syn_extends = _extends_base(getattr(ct_dyn, "iri", "")) or "baseSynapse"
+                syn_contract = _base_type_meta(syn_extends)
+                syn_exposure_names = set(syn_contract.get("exposures", {})) or {"i"}
+                syn_inherited_params = set(syn_contract.get("inherited_params", set()))
+                # v is inherited down the voltage-dependent base chain; only declare
+                # an InstanceRequirement when the base does not already require it.
+                if "v" in syn_contract.get("requirements", {}):
+                    has_v_req = False
+
                 # Use real LEMS dimensions so jNeuroML outputs SI.
                 syn_needs_sec = True  # synapse CTs always need SEC
 
@@ -3470,6 +3483,9 @@ def build_lems_context(experiment):
                     "has_i_exposure": has_i_exposure,
                     "has_v_req": has_v_req,
                     "external_event_names": external_event_names,
+                    "synapse_extends": syn_extends,
+                    "synapse_inherited_params": syn_inherited_params,
+                    "synapse_exposure_names": syn_exposure_names,
                     "has_threshold_events": False,
                     "threshold_event_names": [],
                 }

--- a/tvbo/data/ontology/neuroml_contracts.json
+++ b/tvbo/data/ontology/neuroml_contracts.json
@@ -1,0 +1,5381 @@
+{
+  "Display": {
+    "attachments": {},
+    "chain": [
+      "Display"
+    ],
+    "children": {
+      "lines": {
+        "multiple": true,
+        "type": "Line"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "timeScale": "time",
+      "xmax": "none",
+      "xmin": "none",
+      "ymax": "none",
+      "ymin": "none"
+    },
+    "requirements": {}
+  },
+  "EIF_cond_alpha_isfa_ista": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "EIF_cond_alpha_isfa_ista",
+      "basePyNNIaFCondCell",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage",
+      "w": "none"
+    },
+    "extends": "basePyNNIaFCondCell",
+    "on_start": {},
+    "parameters": {
+      "a": "none",
+      "b": "none",
+      "cm": "none",
+      "delta_T": "none",
+      "e_rev_E": "none",
+      "e_rev_I": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "tau_w": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_spike": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "EIF_cond_exp_isfa_ista": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "EIF_cond_exp_isfa_ista",
+      "basePyNNIaFCondCell",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage",
+      "w": "none"
+    },
+    "extends": "basePyNNIaFCondCell",
+    "on_start": {},
+    "parameters": {
+      "a": "none",
+      "b": "none",
+      "cm": "none",
+      "delta_T": "none",
+      "e_rev_E": "none",
+      "e_rev_I": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "tau_w": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_spike": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "EventOutputFile": {
+    "attachments": {},
+    "chain": [
+      "EventOutputFile"
+    ],
+    "children": {
+      "eventSelection": {
+        "multiple": true,
+        "type": "EventSelection"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "EventSelection": {
+    "attachments": {},
+    "chain": [
+      "EventSelection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "HHExpLinearRate": {
+    "attachments": {},
+    "chain": [
+      "HHExpLinearRate",
+      "baseHHRate",
+      "baseVoltageDepRate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "r": "per_time"
+    },
+    "extends": "baseHHRate",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "per_time",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "HHExpLinearVariable": {
+    "attachments": {},
+    "chain": [
+      "HHExpLinearVariable",
+      "baseHHVariable",
+      "baseVoltageDepVariable"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "x": "none"
+    },
+    "extends": "baseHHVariable",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "none",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "HHExpRate": {
+    "attachments": {},
+    "chain": [
+      "HHExpRate",
+      "baseHHRate",
+      "baseVoltageDepRate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "r": "per_time"
+    },
+    "extends": "baseHHRate",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "per_time",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "HHExpVariable": {
+    "attachments": {},
+    "chain": [
+      "HHExpVariable",
+      "baseHHVariable",
+      "baseVoltageDepVariable"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "x": "none"
+    },
+    "extends": "baseHHVariable",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "none",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "HHSigmoidRate": {
+    "attachments": {},
+    "chain": [
+      "HHSigmoidRate",
+      "baseHHRate",
+      "baseVoltageDepRate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "r": "per_time"
+    },
+    "extends": "baseHHRate",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "per_time",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "HHSigmoidVariable": {
+    "attachments": {},
+    "chain": [
+      "HHSigmoidVariable",
+      "baseHHVariable",
+      "baseVoltageDepVariable"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "x": "none"
+    },
+    "extends": "baseHHVariable",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "none",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "HH_cond_exp": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "HH_cond_exp",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "h": "none",
+      "iSyn": "current",
+      "m": "none",
+      "n": "none",
+      "v": "voltage"
+    },
+    "extends": "basePyNNCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "e_rev_E": "none",
+      "e_rev_I": "none",
+      "e_rev_K": "none",
+      "e_rev_Na": "none",
+      "e_rev_leak": "none",
+      "g_leak": "none",
+      "gbar_K": "none",
+      "gbar_Na": "none",
+      "i_offset": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_offset": "none"
+    },
+    "requirements": {}
+  },
+  "IF_cond_alpha": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "IF_cond_alpha",
+      "basePyNNIaFCondCell",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "basePyNNIaFCondCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "e_rev_E": "none",
+      "e_rev_I": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "IF_cond_exp": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "IF_cond_exp",
+      "basePyNNIaFCondCell",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "basePyNNIaFCondCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "e_rev_E": "none",
+      "e_rev_I": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "IF_curr_alpha": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "IF_curr_alpha",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "basePyNNIaFCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "IF_curr_exp": {
+    "attachments": {
+      "synapses": "baseSynapse"
+    },
+    "chain": [
+      "IF_curr_exp",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "basePyNNIaFCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "KSState": {
+    "attachments": {},
+    "chain": [
+      "KSState"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "occupancy": "none",
+      "q": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "relativeConductance": "none"
+    },
+    "requirements": {}
+  },
+  "KSTransition": {
+    "attachments": {},
+    "chain": [
+      "KSTransition"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "rf": "per_time",
+      "rr": "per_time"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "Line": {
+    "attachments": {},
+    "chain": [
+      "Line"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "scale": "*",
+      "timeScale": "*"
+    },
+    "requirements": {}
+  },
+  "Meta": {
+    "attachments": {},
+    "chain": [
+      "Meta"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "OutputColumn": {
+    "attachments": {},
+    "chain": [
+      "OutputColumn"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "OutputFile": {
+    "attachments": {},
+    "chain": [
+      "OutputFile"
+    ],
+    "children": {
+      "outputColumn": {
+        "multiple": true,
+        "type": "OutputColumn"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "Simulation": {
+    "attachments": {},
+    "chain": [
+      "Simulation"
+    ],
+    "children": {
+      "displays": {
+        "multiple": true,
+        "type": "Display"
+      },
+      "events": {
+        "multiple": true,
+        "type": "EventOutputFile"
+      },
+      "metas": {
+        "multiple": true,
+        "type": "Meta"
+      },
+      "outputs": {
+        "multiple": true,
+        "type": "OutputFile"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "length": "time",
+      "step": "time"
+    },
+    "requirements": {}
+  },
+  "SpikeSourcePoisson": {
+    "attachments": {},
+    "chain": [
+      "SpikeSourcePoisson",
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in",
+      "spike": "out"
+    },
+    "exposures": {
+      "isi": "time",
+      "tnextIdeal": "time",
+      "tnextUsed": "time",
+      "tsince": "time"
+    },
+    "extends": "baseSpikeSource",
+    "on_start": {},
+    "parameters": {
+      "duration": "time",
+      "rate": "per_time",
+      "start": "time"
+    },
+    "requirements": {}
+  },
+  "adExIaFCell": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "adExIaFCell",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage",
+      "w": "current"
+    },
+    "extends": "baseCellMembPotCap",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "EL": "voltage",
+      "VT": "voltage",
+      "a": "conductance",
+      "b": "current",
+      "delT": "voltage",
+      "gL": "conductance",
+      "refract": "time",
+      "reset": "voltage",
+      "tauw": "time",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "alphaCondSynapse": {
+    "attachments": {},
+    "chain": [
+      "alphaCondSynapse",
+      "basePynnSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "A": "none",
+      "g": "none",
+      "i": "current"
+    },
+    "extends": "basePynnSynapse",
+    "on_start": {},
+    "parameters": {
+      "e_rev": "none",
+      "tau_syn": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "alphaCurrSynapse": {
+    "attachments": {},
+    "chain": [
+      "alphaCurrSynapse",
+      "basePynnSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "A": "current",
+      "i": "current"
+    },
+    "extends": "basePynnSynapse",
+    "on_start": {},
+    "parameters": {
+      "tau_syn": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "alphaCurrentSynapse": {
+    "attachments": {},
+    "chain": [
+      "alphaCurrentSynapse",
+      "baseCurrentBasedSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseCurrentBasedSynapse",
+    "on_start": {},
+    "parameters": {
+      "ibase": "current",
+      "tau": "time"
+    },
+    "requirements": {}
+  },
+  "alphaSynapse": {
+    "attachments": {},
+    "chain": [
+      "alphaSynapse",
+      "baseConductanceBasedSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "baseConductanceBasedSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase": "conductance",
+      "tau": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseBlockMechanism": {
+    "attachments": {},
+    "chain": [
+      "baseBlockMechanism"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "blockFactor": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseCell": {
+    "attachments": {},
+    "chain": [
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "baseStandalone",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseCellMembPot": {
+    "attachments": {},
+    "chain": [
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "v": "voltage"
+    },
+    "extends": "baseSpikingCell",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseCellMembPotCap": {
+    "attachments": {},
+    "chain": [
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPot",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance"
+    },
+    "requirements": {}
+  },
+  "baseCellMembPotDL": {
+    "attachments": {},
+    "chain": [
+      "baseCellMembPotDL",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "V": "none"
+    },
+    "extends": "baseSpikingCell",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseChannelDensity": {
+    "attachments": {},
+    "chain": [
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "iDensity": "currentDensity"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseChannelDensityCond": {
+    "attachments": {},
+    "chain": [
+      "baseChannelDensityCond",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "gDensity": "conductanceDensity",
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensity",
+    "on_start": {},
+    "parameters": {
+      "condDensity": "conductanceDensity"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseChannelPopulation": {
+    "attachments": {},
+    "chain": [
+      "baseChannelPopulation",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseVoltageDepPointCurrent",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseConductanceBasedSynapse": {
+    "attachments": {},
+    "chain": [
+      "baseConductanceBasedSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "baseVoltageDepSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseConductanceBasedSynapseTwo": {
+    "attachments": {},
+    "chain": [
+      "baseConductanceBasedSynapseTwo",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "baseVoltageDepSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase1": "conductance",
+      "gbase2": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseConductanceScaling": {
+    "attachments": {},
+    "chain": [
+      "baseConductanceScaling"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "factor": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "temperature": "temperature"
+    }
+  },
+  "baseConductanceScalingCaDependent": {
+    "attachments": {},
+    "chain": [
+      "baseConductanceScalingCaDependent",
+      "baseConductanceScaling"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "factor": "none"
+    },
+    "extends": "baseConductanceScaling",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "caConc": "concentration",
+      "temperature": "temperature"
+    }
+  },
+  "baseCurrentBasedSynapse": {
+    "attachments": {},
+    "chain": [
+      "baseCurrentBasedSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseSynapse",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseGate": {
+    "attachments": {},
+    "chain": [
+      "baseGate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "fcond": "none",
+      "q": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "baseGradedSynapse": {
+    "attachments": {},
+    "chain": [
+      "baseGradedSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseSynapse",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseHHRate": {
+    "attachments": {},
+    "chain": [
+      "baseHHRate",
+      "baseVoltageDepRate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "r": "per_time"
+    },
+    "extends": "baseVoltageDepRate",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "per_time",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseHHVariable": {
+    "attachments": {},
+    "chain": [
+      "baseHHVariable",
+      "baseVoltageDepVariable"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "x": "none"
+    },
+    "extends": "baseVoltageDepVariable",
+    "on_start": {},
+    "parameters": {
+      "midpoint": "voltage",
+      "rate": "none",
+      "scale": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseIaf": {
+    "attachments": {},
+    "chain": [
+      "baseIaf",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPot",
+    "on_start": {},
+    "parameters": {
+      "reset": "voltage",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "baseIafCapCell": {
+    "attachments": {},
+    "chain": [
+      "baseIafCapCell",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPotCap",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "reset": "voltage",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "baseIonChannel": {
+    "attachments": {},
+    "chain": [
+      "baseIonChannel"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "fopen": "none",
+      "g": "conductance"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "basePlasticityMechanism": {
+    "attachments": {},
+    "chain": [
+      "basePlasticityMechanism"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "plasticityFactor": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "basePointCurrent": {
+    "attachments": {},
+    "chain": [
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseStandalone",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "basePointCurrentDL": {
+    "attachments": {},
+    "chain": [
+      "basePointCurrentDL"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "I": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "basePopulation": {
+    "attachments": {},
+    "chain": [
+      "basePopulation",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "baseStandalone",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "basePyNNCell": {
+    "attachments": {},
+    "chain": [
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPot",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "i_offset": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none"
+    },
+    "requirements": {}
+  },
+  "basePyNNIaFCell": {
+    "attachments": {},
+    "chain": [
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "basePyNNCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "basePyNNIaFCondCell": {
+    "attachments": {},
+    "chain": [
+      "basePyNNIaFCondCell",
+      "basePyNNIaFCell",
+      "basePyNNCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out",
+      "spike_in_E": "in",
+      "spike_in_I": "in"
+    },
+    "exposures": {
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "basePyNNIaFCell",
+    "on_start": {},
+    "parameters": {
+      "cm": "none",
+      "e_rev_E": "none",
+      "e_rev_I": "none",
+      "i_offset": "none",
+      "tau_m": "none",
+      "tau_refrac": "none",
+      "tau_syn_E": "none",
+      "tau_syn_I": "none",
+      "v_init": "none",
+      "v_reset": "none",
+      "v_rest": "none",
+      "v_thresh": "none"
+    },
+    "requirements": {}
+  },
+  "basePynnSynapse": {
+    "attachments": {},
+    "chain": [
+      "basePynnSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseVoltageDepSynapse",
+    "on_start": {},
+    "parameters": {
+      "tau_syn": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseQ10Settings": {
+    "attachments": {},
+    "chain": [
+      "baseQ10Settings"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "q10": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "temperature": "temperature"
+    }
+  },
+  "baseSpikeSource": {
+    "attachments": {},
+    "chain": [
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "tsince": "time"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseSpikingCell": {
+    "attachments": {},
+    "chain": [
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {},
+    "extends": "baseCell",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseStandalone": {
+    "attachments": {},
+    "chain": [
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseSynapse": {
+    "attachments": {},
+    "chain": [
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePointCurrent",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "baseSynapseDL": {
+    "attachments": {},
+    "chain": [
+      "baseSynapseDL",
+      "baseVoltageDepPointCurrentDL",
+      "basePointCurrentDL"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "I": "none"
+    },
+    "extends": "baseVoltageDepPointCurrentDL",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "V": "none"
+    }
+  },
+  "baseVoltageConcDepRate": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageConcDepRate",
+      "baseVoltageDepRate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "r": "per_time"
+    },
+    "extends": "baseVoltageDepRate",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "caConc": "concentration",
+      "v": "voltage"
+    }
+  },
+  "baseVoltageConcDepTime": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageConcDepTime",
+      "baseVoltageDepTime"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "t": "time"
+    },
+    "extends": "baseVoltageDepTime",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "caConc": "concentration",
+      "v": "voltage"
+    }
+  },
+  "baseVoltageConcDepVariable": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageConcDepVariable",
+      "baseVoltageDepVariable"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "x": "none"
+    },
+    "extends": "baseVoltageDepVariable",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "caConc": "concentration",
+      "v": "voltage"
+    }
+  },
+  "baseVoltageDepPointCurrent": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePointCurrent",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseVoltageDepPointCurrentDL": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepPointCurrentDL",
+      "basePointCurrentDL"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "I": "none"
+    },
+    "extends": "basePointCurrentDL",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "V": "none"
+    }
+  },
+  "baseVoltageDepPointCurrentSpiking": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepPointCurrentSpiking",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "i": "current",
+      "tsince": "time"
+    },
+    "extends": "baseVoltageDepPointCurrent",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseVoltageDepRate": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepRate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "r": "per_time"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseVoltageDepSynapse": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseSynapse",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseVoltageDepTime": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepTime"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "t": "time"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "baseVoltageDepVariable": {
+    "attachments": {},
+    "chain": [
+      "baseVoltageDepVariable"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "x": "none"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "biophysicalProperties": {
+    "attachments": {},
+    "chain": [
+      "biophysicalProperties"
+    ],
+    "children": {
+      "intracellularProperties": {
+        "multiple": false,
+        "type": "intracellularProperties"
+      },
+      "membraneProperties": {
+        "multiple": false,
+        "type": "membraneProperties"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "totSpecCap": "specificCapacitance"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "biophysicalProperties2CaPools": {
+    "attachments": {},
+    "chain": [
+      "biophysicalProperties2CaPools"
+    ],
+    "children": {
+      "intracellularProperties2CaPools": {
+        "multiple": false,
+        "type": "intracellularProperties2CaPools"
+      },
+      "membraneProperties2CaPools": {
+        "multiple": false,
+        "type": "membraneProperties2CaPools"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "totSpecCap": "specificCapacitance"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "blockingPlasticSynapse": {
+    "attachments": {},
+    "chain": [
+      "blockingPlasticSynapse",
+      "expTwoSynapse",
+      "baseConductanceBasedSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {
+      "blockMechanisms": {
+        "multiple": true,
+        "type": "baseBlockMechanism"
+      },
+      "plasticityMechanisms": {
+        "multiple": true,
+        "type": "basePlasticityMechanism"
+      }
+    },
+    "event_ports": {
+      "in": "in",
+      "relay": "out"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "expTwoSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase": "conductance",
+      "tauDecay": "time",
+      "tauRise": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "cell": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "cell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {
+      "biophysicalProperties": {
+        "multiple": false,
+        "type": "biophysicalProperties"
+      },
+      "morphology": {
+        "multiple": false,
+        "type": "morphology"
+      }
+    },
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "caConc": "concentration",
+      "caConcExt": "concentration",
+      "iCa": "current",
+      "iChannels": "current",
+      "iSyn": "current",
+      "spiking": "none",
+      "surfaceArea": "area",
+      "totSpecCap": "specificCapacitance",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPot",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "cell2CaPools": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "cell2CaPools",
+      "cell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {
+      "biophysicalProperties": {
+        "multiple": false,
+        "type": "biophysicalProperties"
+      },
+      "biophysicalProperties2CaPools": {
+        "multiple": false,
+        "type": "biophysicalProperties2CaPools"
+      },
+      "morphology": {
+        "multiple": false,
+        "type": "morphology"
+      }
+    },
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "caConc": "concentration",
+      "caConc2": "concentration",
+      "caConcExt": "concentration",
+      "caConcExt2": "concentration",
+      "iCa": "current",
+      "iCa2": "current",
+      "iChannels": "current",
+      "iSyn": "current",
+      "spiking": "none",
+      "surfaceArea": "area",
+      "totSpecCap": "specificCapacitance",
+      "v": "voltage"
+    },
+    "extends": "cell",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "channelDensity": {
+    "attachments": {},
+    "chain": [
+      "channelDensity",
+      "baseChannelDensityCond",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "gDensity": "conductanceDensity",
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensityCond",
+    "on_start": {},
+    "parameters": {
+      "condDensity": "conductanceDensity",
+      "erev": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "channelDensityGHK": {
+    "attachments": {},
+    "chain": [
+      "channelDensityGHK",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensity",
+    "on_start": {},
+    "parameters": {
+      "permeability": "permeability"
+    },
+    "requirements": {
+      "caConc": "concentration",
+      "caConcExt": "concentration",
+      "temperature": "temperature",
+      "v": "voltage"
+    }
+  },
+  "channelDensityGHK2": {
+    "attachments": {},
+    "chain": [
+      "channelDensityGHK2",
+      "baseChannelDensityCond",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "gDensity": "conductanceDensity",
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensityCond",
+    "on_start": {},
+    "parameters": {
+      "condDensity": "conductanceDensity"
+    },
+    "requirements": {
+      "caConc": "concentration",
+      "caConcExt": "concentration",
+      "temperature": "temperature",
+      "v": "voltage"
+    }
+  },
+  "channelDensityNernst": {
+    "attachments": {},
+    "chain": [
+      "channelDensityNernst",
+      "baseChannelDensityCond",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "erev": "voltage",
+      "gDensity": "conductanceDensity",
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensityCond",
+    "on_start": {},
+    "parameters": {
+      "condDensity": "conductanceDensity"
+    },
+    "requirements": {
+      "caConc": "concentration",
+      "caConcExt": "concentration",
+      "temperature": "temperature",
+      "v": "voltage"
+    }
+  },
+  "channelDensityNernstCa2": {
+    "attachments": {},
+    "chain": [
+      "channelDensityNernstCa2",
+      "baseChannelDensityCond",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "erev": "voltage",
+      "gDensity": "conductanceDensity",
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensityCond",
+    "on_start": {},
+    "parameters": {
+      "condDensity": "conductanceDensity"
+    },
+    "requirements": {
+      "caConc2": "concentration",
+      "caConcExt2": "concentration",
+      "temperature": "temperature",
+      "v": "voltage"
+    }
+  },
+  "channelDensityNonUniform": {
+    "attachments": {},
+    "chain": [
+      "channelDensityNonUniform",
+      "baseChannelDensity"
+    ],
+    "children": {
+      "variableParameter": {
+        "multiple": false,
+        "type": "variableParameter"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensity",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "channelDensityNonUniformGHK": {
+    "attachments": {},
+    "chain": [
+      "channelDensityNonUniformGHK",
+      "baseChannelDensity"
+    ],
+    "children": {
+      "variableParameter": {
+        "multiple": false,
+        "type": "variableParameter"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensity",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "channelDensityNonUniformNernst": {
+    "attachments": {},
+    "chain": [
+      "channelDensityNonUniformNernst",
+      "baseChannelDensity"
+    ],
+    "children": {
+      "variableParameter": {
+        "multiple": false,
+        "type": "variableParameter"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "iDensity": "currentDensity"
+    },
+    "extends": "baseChannelDensity",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "channelDensityVShift": {
+    "attachments": {},
+    "chain": [
+      "channelDensityVShift",
+      "channelDensity",
+      "baseChannelDensityCond",
+      "baseChannelDensity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "gDensity": "conductanceDensity",
+      "iDensity": "currentDensity"
+    },
+    "extends": "channelDensity",
+    "on_start": {},
+    "parameters": {
+      "condDensity": "conductanceDensity",
+      "erev": "voltage",
+      "vShift": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "channelPopulation": {
+    "attachments": {},
+    "chain": [
+      "channelPopulation",
+      "baseChannelPopulation",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseChannelPopulation",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "number": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "channelPopulationNernst": {
+    "attachments": {},
+    "chain": [
+      "channelPopulationNernst",
+      "baseChannelPopulation",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "erev": "voltage",
+      "i": "current"
+    },
+    "extends": "baseChannelPopulation",
+    "on_start": {},
+    "parameters": {
+      "number": "none"
+    },
+    "requirements": {
+      "caConc": "concentration",
+      "caConcExt": "concentration",
+      "temperature": "temperature",
+      "v": "voltage"
+    }
+  },
+  "closedState": {
+    "attachments": {},
+    "chain": [
+      "closedState",
+      "KSState"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "occupancy": "none",
+      "q": "none"
+    },
+    "extends": "KSState",
+    "on_start": {},
+    "parameters": {
+      "relativeConductance": "__dimension_inherited__"
+    },
+    "requirements": {}
+  },
+  "compoundInput": {
+    "attachments": {},
+    "chain": [
+      "compoundInput",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {
+      "currents": {
+        "multiple": true,
+        "type": "basePointCurrent"
+      }
+    },
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePointCurrent",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "compoundInputDL": {
+    "attachments": {},
+    "chain": [
+      "compoundInputDL",
+      "basePointCurrentDL"
+    ],
+    "children": {
+      "currents": {
+        "multiple": true,
+        "type": "basePointCurrentDL"
+      }
+    },
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "I": "none"
+    },
+    "extends": "basePointCurrentDL",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "concentrationModel": {
+    "attachments": {},
+    "chain": [
+      "concentrationModel"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "concentration": "concentration",
+      "extConcentration": "concentration"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "initialConcentration": "concentration",
+      "initialExtConcentration": "concentration",
+      "surfaceArea": "area"
+    }
+  },
+  "connection": {
+    "attachments": {},
+    "chain": [
+      "connection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "connectionWD": {
+    "attachments": {},
+    "chain": [
+      "connectionWD",
+      "connection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "connection",
+    "on_start": {},
+    "parameters": {
+      "delay": "time",
+      "weight": "none"
+    },
+    "requirements": {}
+  },
+  "continuousConnection": {
+    "attachments": {},
+    "chain": [
+      "continuousConnection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "continuousConnectionInstance": {
+    "attachments": {},
+    "chain": [
+      "continuousConnectionInstance"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "continuousConnectionInstanceW": {
+    "attachments": {},
+    "chain": [
+      "continuousConnectionInstanceW",
+      "continuousConnectionInstance"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "continuousConnectionInstance",
+    "on_start": {},
+    "parameters": {
+      "weight": "none"
+    },
+    "requirements": {}
+  },
+  "continuousProjection": {
+    "attachments": {},
+    "chain": [
+      "continuousProjection"
+    ],
+    "children": {
+      "connectionInstances": {
+        "multiple": true,
+        "type": "continuousConnectionInstance"
+      },
+      "connections": {
+        "multiple": true,
+        "type": "continuousConnection"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "decayingPoolConcentrationModel": {
+    "attachments": {},
+    "chain": [
+      "decayingPoolConcentrationModel",
+      "concentrationModel"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "concentration": "concentration",
+      "extConcentration": "concentration"
+    },
+    "extends": "concentrationModel",
+    "on_start": {},
+    "parameters": {
+      "decayConstant": "time",
+      "restingConc": "concentration",
+      "shellThickness": "length"
+    },
+    "requirements": {
+      "iCa": "current",
+      "initialConcentration": "concentration",
+      "initialExtConcentration": "concentration",
+      "surfaceArea": "area"
+    }
+  },
+  "distal": {
+    "attachments": {},
+    "chain": [
+      "distal",
+      "point3DWithDiam"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "point3DWithDiam",
+    "on_start": {},
+    "parameters": {
+      "diameter": "none",
+      "x": "none",
+      "y": "none",
+      "z": "none"
+    },
+    "requirements": {}
+  },
+  "distalDetails": {
+    "attachments": {},
+    "chain": [
+      "distalDetails"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "doubleSynapse": {
+    "attachments": {},
+    "chain": [
+      "doubleSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in",
+      "relay": "out"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseVoltageDepSynapse",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "electricalConnection": {
+    "attachments": {},
+    "chain": [
+      "electricalConnection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "electricalConnectionInstance": {
+    "attachments": {},
+    "chain": [
+      "electricalConnectionInstance"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "electricalConnectionInstanceW": {
+    "attachments": {},
+    "chain": [
+      "electricalConnectionInstanceW",
+      "electricalConnectionInstance"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "electricalConnectionInstance",
+    "on_start": {},
+    "parameters": {
+      "weight": "none"
+    },
+    "requirements": {}
+  },
+  "electricalProjection": {
+    "attachments": {},
+    "chain": [
+      "electricalProjection"
+    ],
+    "children": {
+      "connectionInstances": {
+        "multiple": true,
+        "type": "electricalConnectionInstance"
+      },
+      "connections": {
+        "multiple": true,
+        "type": "electricalConnection"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "expCondSynapse": {
+    "attachments": {},
+    "chain": [
+      "expCondSynapse",
+      "basePynnSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "none",
+      "i": "current"
+    },
+    "extends": "basePynnSynapse",
+    "on_start": {},
+    "parameters": {
+      "e_rev": "none",
+      "tau_syn": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "expCurrSynapse": {
+    "attachments": {},
+    "chain": [
+      "expCurrSynapse",
+      "basePynnSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePynnSynapse",
+    "on_start": {},
+    "parameters": {
+      "tau_syn": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "expOneSynapse": {
+    "attachments": {},
+    "chain": [
+      "expOneSynapse",
+      "baseConductanceBasedSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "baseConductanceBasedSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase": "conductance",
+      "tauDecay": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "expThreeSynapse": {
+    "attachments": {},
+    "chain": [
+      "expThreeSynapse",
+      "baseConductanceBasedSynapseTwo",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "baseConductanceBasedSynapseTwo",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase1": "conductance",
+      "gbase2": "conductance",
+      "tauDecay1": "time",
+      "tauDecay2": "time",
+      "tauRise": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "expTwoSynapse": {
+    "attachments": {},
+    "chain": [
+      "expTwoSynapse",
+      "baseConductanceBasedSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "g": "conductance",
+      "i": "current"
+    },
+    "extends": "baseConductanceBasedSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase": "conductance",
+      "tauDecay": "time",
+      "tauRise": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "explicitConnection": {
+    "attachments": {},
+    "chain": [
+      "explicitConnection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "explicitInput": {
+    "attachments": {},
+    "chain": [
+      "explicitInput"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "fitzHughNagumo1969Cell": {
+    "attachments": {},
+    "chain": [
+      "fitzHughNagumo1969Cell",
+      "baseCellMembPotDL",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "F": "none",
+      "V": "none",
+      "W": "none"
+    },
+    "extends": "baseCellMembPotDL",
+    "on_start": {},
+    "parameters": {
+      "I": "none",
+      "V0": "none",
+      "W0": "none",
+      "a": "none",
+      "b": "none",
+      "phi": "none"
+    },
+    "requirements": {}
+  },
+  "fitzHughNagumoCell": {
+    "attachments": {},
+    "chain": [
+      "fitzHughNagumoCell",
+      "baseCellMembPotDL",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "V": "none",
+      "W": "none"
+    },
+    "extends": "baseCellMembPotDL",
+    "on_start": {},
+    "parameters": {
+      "I": "none"
+    },
+    "requirements": {}
+  },
+  "fixedFactorConcentrationModel": {
+    "attachments": {},
+    "chain": [
+      "fixedFactorConcentrationModel",
+      "concentrationModel"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "concentration": "concentration",
+      "extConcentration": "concentration"
+    },
+    "extends": "concentrationModel",
+    "on_start": {},
+    "parameters": {
+      "decayConstant": "time",
+      "restingConc": "concentration",
+      "rho": "rho_factor"
+    },
+    "requirements": {
+      "iCa": "current",
+      "initialConcentration": "concentration",
+      "initialExtConcentration": "concentration",
+      "surfaceArea": "area"
+    }
+  },
+  "fixedFactorConcentrationModelTraub": {
+    "attachments": {},
+    "chain": [
+      "fixedFactorConcentrationModelTraub",
+      "concentrationModel"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "concentration": "concentration",
+      "extConcentration": "concentration"
+    },
+    "extends": "concentrationModel",
+    "on_start": {},
+    "parameters": {
+      "beta": "per_time",
+      "phi": "rho_factor",
+      "restingConc": "concentration"
+    },
+    "requirements": {
+      "iCa": "current",
+      "initialConcentration": "concentration",
+      "initialExtConcentration": "concentration",
+      "surfaceArea": "area"
+    }
+  },
+  "fixedTimeCourse": {
+    "attachments": {},
+    "chain": [
+      "fixedTimeCourse",
+      "baseVoltageDepTime"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "t": "time"
+    },
+    "extends": "baseVoltageDepTime",
+    "on_start": {},
+    "parameters": {
+      "tau": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "foaf_account": {
+    "attachments": {},
+    "chain": [
+      "foaf_account"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_fundedBy": {
+    "attachments": {},
+    "chain": [
+      "foaf_fundedBy"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_homepage": {
+    "attachments": {},
+    "chain": [
+      "foaf_homepage"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_mbox": {
+    "attachments": {},
+    "chain": [
+      "foaf_mbox"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_name": {
+    "attachments": {},
+    "chain": [
+      "foaf_name"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_publications": {
+    "attachments": {},
+    "chain": [
+      "foaf_publications"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_thumbnail": {
+    "attachments": {},
+    "chain": [
+      "foaf_thumbnail"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "foaf_weblog": {
+    "attachments": {},
+    "chain": [
+      "foaf_weblog"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "forwardTransition": {
+    "attachments": {},
+    "chain": [
+      "forwardTransition",
+      "KSTransition"
+    ],
+    "children": {
+      "rate": {
+        "multiple": false,
+        "type": "baseHHRate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "rf": "per_time",
+      "rr": "per_time"
+    },
+    "extends": "KSTransition",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "from": {
+    "attachments": {},
+    "chain": [
+      "from"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "gapJunction": {
+    "attachments": {},
+    "chain": [
+      "gapJunction",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseSynapse",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "gate": {
+    "attachments": {},
+    "chain": [
+      "gate",
+      "baseGate"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "fcond": "none",
+      "q": "none"
+    },
+    "extends": "baseGate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateFractional": {
+    "attachments": {},
+    "chain": [
+      "gateFractional",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "subGate": {
+        "multiple": true,
+        "type": "subGate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fcond": "none",
+      "q": "none",
+      "rateScale": "none"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateHHInstantaneous": {
+    "attachments": {},
+    "chain": [
+      "gateHHInstantaneous",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "steadyState": {
+        "multiple": false,
+        "type": "baseVoltageDepVariable"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fcond": "none",
+      "inf": "none",
+      "q": "none",
+      "tau": "time"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateHHrates": {
+    "attachments": {},
+    "chain": [
+      "gateHHrates",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "forwardRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "reverseRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "alpha": "per_time",
+      "beta": "per_time",
+      "fcond": "none",
+      "inf": "none",
+      "q": "none",
+      "rateScale": "none",
+      "tau": "time"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateHHratesInf": {
+    "attachments": {},
+    "chain": [
+      "gateHHratesInf",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "forwardRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "reverseRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "steadyState": {
+        "multiple": false,
+        "type": "baseVoltageDepVariable"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "alpha": "per_time",
+      "beta": "per_time",
+      "fcond": "none",
+      "inf": "none",
+      "q": "none",
+      "rateScale": "none",
+      "tau": "time"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateHHratesTau": {
+    "attachments": {},
+    "chain": [
+      "gateHHratesTau",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "forwardRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "reverseRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "timeCourse": {
+        "multiple": false,
+        "type": "baseVoltageDepTime"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "alpha": "per_time",
+      "beta": "per_time",
+      "fcond": "none",
+      "inf": "none",
+      "q": "none",
+      "rateScale": "none",
+      "tau": "time"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateHHratesTauInf": {
+    "attachments": {},
+    "chain": [
+      "gateHHratesTauInf",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "forwardRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "reverseRate": {
+        "multiple": false,
+        "type": "baseVoltageDepRate"
+      },
+      "steadyState": {
+        "multiple": false,
+        "type": "baseVoltageDepVariable"
+      },
+      "timeCourse": {
+        "multiple": false,
+        "type": "baseVoltageDepTime"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "alpha": "per_time",
+      "beta": "per_time",
+      "fcond": "none",
+      "inf": "none",
+      "q": "none",
+      "rateScale": "none",
+      "tau": "time"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateHHtauInf": {
+    "attachments": {},
+    "chain": [
+      "gateHHtauInf",
+      "gate",
+      "baseGate"
+    ],
+    "children": {
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "steadyState": {
+        "multiple": false,
+        "type": "baseVoltageDepVariable"
+      },
+      "timeCourse": {
+        "multiple": false,
+        "type": "baseVoltageDepTime"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fcond": "none",
+      "inf": "none",
+      "q": "none",
+      "rateScale": "none",
+      "tau": "time"
+    },
+    "extends": "gate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gateKS": {
+    "attachments": {},
+    "chain": [
+      "gateKS",
+      "baseGate"
+    ],
+    "children": {
+      "q10Settings": {
+        "multiple": true,
+        "type": "baseQ10Settings"
+      },
+      "states": {
+        "multiple": true,
+        "type": "KSState"
+      },
+      "transitions": {
+        "multiple": true,
+        "type": "KSTransition"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fcond": "none",
+      "q": "none",
+      "rateScale": "none"
+    },
+    "extends": "baseGate",
+    "on_start": {},
+    "parameters": {
+      "instances": "none"
+    },
+    "requirements": {}
+  },
+  "gradedSynapse": {
+    "attachments": {},
+    "chain": [
+      "gradedSynapse",
+      "baseGradedSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current",
+      "inf": "none",
+      "tau": "time"
+    },
+    "extends": "baseGradedSynapse",
+    "on_start": {},
+    "parameters": {
+      "Vth": "voltage",
+      "conductance": "conductance",
+      "delta": "voltage",
+      "erev": "voltage",
+      "k": "per_time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "hindmarshRose1984Cell": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "hindmarshRose1984Cell",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "chi": "none",
+      "iMemb": "current",
+      "iSyn": "current",
+      "phi": "none",
+      "rho": "none",
+      "spiking": "none",
+      "v": "voltage",
+      "x": "none",
+      "y": "none",
+      "z": "none"
+    },
+    "extends": "baseCellMembPotCap",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "a": "none",
+      "b": "none",
+      "c": "none",
+      "d": "none",
+      "r": "none",
+      "s": "none",
+      "v_scaling": "voltage",
+      "x0": "none",
+      "x1": "none",
+      "y0": "none",
+      "z0": "none"
+    },
+    "requirements": {}
+  },
+  "iafCell": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "iafCell",
+      "baseIafCapCell",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "baseIafCapCell",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "leakConductance": "conductance",
+      "leakReversal": "voltage",
+      "reset": "voltage",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "iafRefCell": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "iafRefCell",
+      "iafCell",
+      "baseIafCapCell",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "iafCell",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "leakConductance": "conductance",
+      "leakReversal": "voltage",
+      "refract": "time",
+      "reset": "voltage",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "iafTauCell": {
+    "attachments": {},
+    "chain": [
+      "iafTauCell",
+      "baseIaf",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "v": "voltage"
+    },
+    "extends": "baseIaf",
+    "on_start": {},
+    "parameters": {
+      "leakReversal": "voltage",
+      "reset": "voltage",
+      "tau": "time",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "iafTauRefCell": {
+    "attachments": {},
+    "chain": [
+      "iafTauRefCell",
+      "iafTauCell",
+      "baseIaf",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "v": "voltage"
+    },
+    "extends": "iafTauCell",
+    "on_start": {},
+    "parameters": {
+      "leakReversal": "voltage",
+      "refract": "time",
+      "reset": "voltage",
+      "tau": "time",
+      "thresh": "voltage"
+    },
+    "requirements": {}
+  },
+  "include": {
+    "attachments": {},
+    "chain": [
+      "include"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "inhomogeneousParameter": {
+    "attachments": {},
+    "chain": [
+      "inhomogeneousParameter"
+    ],
+    "children": {
+      "distal": {
+        "multiple": false,
+        "type": "distalDetails"
+      },
+      "proximal": {
+        "multiple": false,
+        "type": "proximalDetails"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "inhomogeneousValue": {
+    "attachments": {},
+    "chain": [
+      "inhomogeneousValue"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "initMembPotential": {
+    "attachments": {},
+    "chain": [
+      "initMembPotential"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "value": "voltage"
+    },
+    "requirements": {}
+  },
+  "input": {
+    "attachments": {},
+    "chain": [
+      "input"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "inputList": {
+    "attachments": {},
+    "chain": [
+      "inputList"
+    ],
+    "children": {
+      "inputs": {
+        "multiple": true,
+        "type": "input"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "inputW": {
+    "attachments": {},
+    "chain": [
+      "inputW",
+      "input"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "input",
+    "on_start": {},
+    "parameters": {
+      "weight": "none"
+    },
+    "requirements": {}
+  },
+  "instance": {
+    "attachments": {},
+    "chain": [
+      "instance"
+    ],
+    "children": {
+      "location": {
+        "multiple": false,
+        "type": "location"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "intracellularProperties": {
+    "attachments": {},
+    "chain": [
+      "intracellularProperties"
+    ],
+    "children": {
+      "resistivity": {
+        "multiple": true,
+        "type": "resistivity"
+      },
+      "speciesList": {
+        "multiple": true,
+        "type": "species"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "caConc": "concentration",
+      "caConcExt": "concentration"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "intracellularProperties2CaPools": {
+    "attachments": {},
+    "chain": [
+      "intracellularProperties2CaPools",
+      "intracellularProperties"
+    ],
+    "children": {
+      "resistivity": {
+        "multiple": true,
+        "type": "resistivity"
+      },
+      "speciesList": {
+        "multiple": true,
+        "type": "species"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "caConc": "concentration",
+      "caConc2": "concentration",
+      "caConcExt": "concentration",
+      "caConcExt2": "concentration"
+    },
+    "extends": "intracellularProperties",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "ionChannel": {
+    "attachments": {},
+    "chain": [
+      "ionChannel",
+      "ionChannelHH",
+      "baseIonChannel"
+    ],
+    "children": {
+      "conductanceScaling": {
+        "multiple": true,
+        "type": "baseConductanceScaling"
+      },
+      "gates": {
+        "multiple": true,
+        "type": "gate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fopen": "none",
+      "g": "conductance"
+    },
+    "extends": "ionChannelHH",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "ionChannelHH": {
+    "attachments": {},
+    "chain": [
+      "ionChannelHH",
+      "baseIonChannel"
+    ],
+    "children": {
+      "conductanceScaling": {
+        "multiple": true,
+        "type": "baseConductanceScaling"
+      },
+      "gates": {
+        "multiple": true,
+        "type": "gate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fopen": "none",
+      "g": "conductance"
+    },
+    "extends": "baseIonChannel",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "ionChannelKS": {
+    "attachments": {},
+    "chain": [
+      "ionChannelKS",
+      "baseIonChannel"
+    ],
+    "children": {
+      "conductanceScaling": {
+        "multiple": true,
+        "type": "baseConductanceScaling"
+      },
+      "gates": {
+        "multiple": true,
+        "type": "gateKS"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fopen": "none",
+      "g": "conductance"
+    },
+    "extends": "baseIonChannel",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "ionChannelPassive": {
+    "attachments": {},
+    "chain": [
+      "ionChannelPassive",
+      "ionChannel",
+      "ionChannelHH",
+      "baseIonChannel"
+    ],
+    "children": {
+      "conductanceScaling": {
+        "multiple": true,
+        "type": "baseConductanceScaling"
+      },
+      "gates": {
+        "multiple": true,
+        "type": "gate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fopen": "none",
+      "g": "conductance"
+    },
+    "extends": "ionChannel",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "ionChannelVShift": {
+    "attachments": {},
+    "chain": [
+      "ionChannelVShift",
+      "ionChannel",
+      "ionChannelHH",
+      "baseIonChannel"
+    ],
+    "children": {
+      "conductanceScaling": {
+        "multiple": true,
+        "type": "baseConductanceScaling"
+      },
+      "gates": {
+        "multiple": true,
+        "type": "gate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "fopen": "none",
+      "g": "conductance"
+    },
+    "extends": "ionChannel",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance",
+      "vShift": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "izhikevich2007Cell": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "izhikevich2007Cell",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "u": "current",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPotCap",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "a": "per_time",
+      "b": "conductance",
+      "c": "voltage",
+      "d": "current",
+      "k": "conductance_per_voltage",
+      "v0": "voltage",
+      "vpeak": "voltage",
+      "vr": "voltage",
+      "vt": "voltage"
+    },
+    "requirements": {}
+  },
+  "izhikevichCell": {
+    "attachments": {
+      "synapses": "basePointCurrentDL"
+    },
+    "chain": [
+      "izhikevichCell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "U": "none",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPot",
+    "on_start": {},
+    "parameters": {
+      "a": "none",
+      "b": "none",
+      "c": "none",
+      "d": "none",
+      "thresh": "voltage",
+      "v0": "voltage"
+    },
+    "requirements": {}
+  },
+  "linearGradedSynapse": {
+    "attachments": {},
+    "chain": [
+      "linearGradedSynapse",
+      "baseGradedSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseGradedSynapse",
+    "on_start": {},
+    "parameters": {
+      "conductance": "conductance"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "location": {
+    "attachments": {},
+    "chain": [
+      "location"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "x": "none",
+      "y": "none",
+      "z": "none"
+    },
+    "requirements": {}
+  },
+  "member": {
+    "attachments": {},
+    "chain": [
+      "member"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "membraneProperties": {
+    "attachments": {},
+    "chain": [
+      "membraneProperties"
+    ],
+    "children": {
+      "channelDensities": {
+        "multiple": true,
+        "type": "baseChannelDensity"
+      },
+      "initMembPotential": {
+        "multiple": false,
+        "type": "initMembPotential"
+      },
+      "populations": {
+        "multiple": true,
+        "type": "baseChannelPopulation"
+      },
+      "specificCapacitances": {
+        "multiple": true,
+        "type": "specificCapacitance"
+      },
+      "spikeThresh": {
+        "multiple": false,
+        "type": "spikeThresh"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "iCa": "current",
+      "totChanCurrent": "current",
+      "totSpecCap": "specificCapacitance"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "surfaceArea": "area"
+    }
+  },
+  "membraneProperties2CaPools": {
+    "attachments": {},
+    "chain": [
+      "membraneProperties2CaPools",
+      "membraneProperties"
+    ],
+    "children": {
+      "channelDensities": {
+        "multiple": true,
+        "type": "baseChannelDensity"
+      },
+      "initMembPotential": {
+        "multiple": false,
+        "type": "initMembPotential"
+      },
+      "populations": {
+        "multiple": true,
+        "type": "baseChannelPopulation"
+      },
+      "specificCapacitances": {
+        "multiple": true,
+        "type": "specificCapacitance"
+      },
+      "spikeThresh": {
+        "multiple": false,
+        "type": "spikeThresh"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "iCa": "current",
+      "iCa2": "current",
+      "totChanCurrent": "current",
+      "totSpecCap": "specificCapacitance"
+    },
+    "extends": "membraneProperties",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "surfaceArea": "area"
+    }
+  },
+  "morphology": {
+    "attachments": {},
+    "chain": [
+      "morphology"
+    ],
+    "children": {
+      "segmentGroups": {
+        "multiple": true,
+        "type": "segmentGroup"
+      },
+      "segments": {
+        "multiple": true,
+        "type": "segment"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "network": {
+    "attachments": {},
+    "chain": [
+      "network",
+      "baseStandalone"
+    ],
+    "children": {
+      "continuousProjection": {
+        "multiple": true,
+        "type": "continuousProjection"
+      },
+      "electricalProjection": {
+        "multiple": true,
+        "type": "electricalProjection"
+      },
+      "explicitInputs": {
+        "multiple": true,
+        "type": "explicitInput"
+      },
+      "inputs": {
+        "multiple": true,
+        "type": "inputList"
+      },
+      "populations": {
+        "multiple": true,
+        "type": "basePopulation"
+      },
+      "projections": {
+        "multiple": true,
+        "type": "projection"
+      },
+      "regions": {
+        "multiple": true,
+        "type": "region"
+      },
+      "synapticConnections": {
+        "multiple": true,
+        "type": "explicitConnection"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": "baseStandalone",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "networkWithTemperature": {
+    "attachments": {},
+    "chain": [
+      "networkWithTemperature",
+      "network",
+      "baseStandalone"
+    ],
+    "children": {
+      "continuousProjection": {
+        "multiple": true,
+        "type": "continuousProjection"
+      },
+      "electricalProjection": {
+        "multiple": true,
+        "type": "electricalProjection"
+      },
+      "explicitInputs": {
+        "multiple": true,
+        "type": "explicitInput"
+      },
+      "inputs": {
+        "multiple": true,
+        "type": "inputList"
+      },
+      "populations": {
+        "multiple": true,
+        "type": "basePopulation"
+      },
+      "projections": {
+        "multiple": true,
+        "type": "projection"
+      },
+      "regions": {
+        "multiple": true,
+        "type": "region"
+      },
+      "synapticConnections": {
+        "multiple": true,
+        "type": "explicitConnection"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": "network",
+    "on_start": {},
+    "parameters": {
+      "temperature": "temperature"
+    },
+    "requirements": {}
+  },
+  "openState": {
+    "attachments": {},
+    "chain": [
+      "openState",
+      "KSState"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "occupancy": "none",
+      "q": "none"
+    },
+    "extends": "KSState",
+    "on_start": {},
+    "parameters": {
+      "relativeConductance": "__dimension_inherited__"
+    },
+    "requirements": {}
+  },
+  "orcid_id": {
+    "attachments": {},
+    "chain": [
+      "orcid_id"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "parent": {
+    "attachments": {},
+    "chain": [
+      "parent"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "path": {
+    "attachments": {},
+    "chain": [
+      "path"
+    ],
+    "children": {
+      "from": {
+        "multiple": false,
+        "type": "from"
+      },
+      "to": {
+        "multiple": false,
+        "type": "to"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "pinskyRinzelCA3Cell": {
+    "attachments": {},
+    "chain": [
+      "pinskyRinzelCA3Cell",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "Cad": "none",
+      "ICad": "currentDensity",
+      "Si": "none",
+      "Vd": "voltage",
+      "Vs": "voltage",
+      "Wi": "none",
+      "cd": "none",
+      "hs": "none",
+      "ns": "none",
+      "qd": "none",
+      "sd": "none",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPot",
+    "on_start": {},
+    "parameters": {
+      "alphac": "none",
+      "betac": "none",
+      "cm": "specificCapacitance",
+      "eCa": "voltage",
+      "eK": "voltage",
+      "eL": "voltage",
+      "eNa": "voltage",
+      "gAmpa": "conductanceDensity",
+      "gCa": "conductanceDensity",
+      "gKC": "conductanceDensity",
+      "gKahp": "conductanceDensity",
+      "gKdr": "conductanceDensity",
+      "gLd": "conductanceDensity",
+      "gLs": "conductanceDensity",
+      "gNa": "conductanceDensity",
+      "gNmda": "conductanceDensity",
+      "gc": "conductanceDensity",
+      "iDend": "currentDensity",
+      "iSoma": "currentDensity",
+      "pp": "none",
+      "qd0": "none"
+    },
+    "requirements": {}
+  },
+  "point3DWithDiam": {
+    "attachments": {},
+    "chain": [
+      "point3DWithDiam"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "diameter": "none",
+      "x": "none",
+      "y": "none",
+      "z": "none"
+    },
+    "requirements": {}
+  },
+  "pointCellCondBased": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "pointCellCondBased",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {
+      "populations": {
+        "multiple": true,
+        "type": "baseChannelPopulation"
+      }
+    },
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPotCap",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "thresh": "voltage",
+      "v0": "voltage"
+    },
+    "requirements": {}
+  },
+  "pointCellCondBasedCa": {
+    "attachments": {
+      "synapses": "basePointCurrent"
+    },
+    "chain": [
+      "pointCellCondBasedCa",
+      "baseCellMembPotCap",
+      "baseCellMembPot",
+      "baseSpikingCell",
+      "baseCell",
+      "baseStandalone"
+    ],
+    "children": {
+      "concentrationModels": {
+        "multiple": true,
+        "type": "concentrationModel"
+      },
+      "populations": {
+        "multiple": true,
+        "type": "baseChannelPopulation"
+      }
+    },
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "caConc": "concentration",
+      "iCa": "current",
+      "iMemb": "current",
+      "iSyn": "current",
+      "v": "voltage"
+    },
+    "extends": "baseCellMembPotCap",
+    "on_start": {},
+    "parameters": {
+      "C": "capacitance",
+      "thresh": "voltage",
+      "v0": "voltage"
+    },
+    "requirements": {}
+  },
+  "poissonFiringSynapse": {
+    "attachments": {},
+    "chain": [
+      "poissonFiringSynapse",
+      "baseVoltageDepPointCurrentSpiking",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in",
+      "spike": "out"
+    },
+    "exposures": {
+      "i": "current",
+      "isi": "time",
+      "tnextIdeal": "time",
+      "tnextUsed": "time",
+      "tsince": "time"
+    },
+    "extends": "baseVoltageDepPointCurrentSpiking",
+    "on_start": {},
+    "parameters": {
+      "averageRate": "per_time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "population": {
+    "attachments": {},
+    "chain": [
+      "population",
+      "basePopulation",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "basePopulation",
+    "on_start": {},
+    "parameters": {
+      "size": "none"
+    },
+    "requirements": {}
+  },
+  "populationList": {
+    "attachments": {},
+    "chain": [
+      "populationList",
+      "basePopulation",
+      "baseStandalone"
+    ],
+    "children": {
+      "instances": {
+        "multiple": true,
+        "type": "instance"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": "basePopulation",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "projection": {
+    "attachments": {},
+    "chain": [
+      "projection"
+    ],
+    "children": {
+      "connections": {
+        "multiple": true,
+        "type": "connection"
+      },
+      "connectionsWD": {
+        "multiple": true,
+        "type": "connectionWD"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "proximal": {
+    "attachments": {},
+    "chain": [
+      "proximal",
+      "point3DWithDiam"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "point3DWithDiam",
+    "on_start": {},
+    "parameters": {
+      "diameter": "none",
+      "x": "none",
+      "y": "none",
+      "z": "none"
+    },
+    "requirements": {}
+  },
+  "proximalDetails": {
+    "attachments": {},
+    "chain": [
+      "proximalDetails"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "pulseGenerator": {
+    "attachments": {},
+    "chain": [
+      "pulseGenerator",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePointCurrent",
+    "on_start": {},
+    "parameters": {
+      "amplitude": "current",
+      "delay": "time",
+      "duration": "time"
+    },
+    "requirements": {}
+  },
+  "pulseGeneratorDL": {
+    "attachments": {},
+    "chain": [
+      "pulseGeneratorDL",
+      "basePointCurrentDL"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "I": "none"
+    },
+    "extends": "basePointCurrentDL",
+    "on_start": {},
+    "parameters": {
+      "amplitude": "none",
+      "delay": "time",
+      "duration": "time"
+    },
+    "requirements": {}
+  },
+  "q10ConductanceScaling": {
+    "attachments": {},
+    "chain": [
+      "q10ConductanceScaling",
+      "baseConductanceScaling"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "factor": "none"
+    },
+    "extends": "baseConductanceScaling",
+    "on_start": {},
+    "parameters": {
+      "experimentalTemp": "temperature",
+      "q10Factor": "none"
+    },
+    "requirements": {
+      "temperature": "temperature"
+    }
+  },
+  "q10ExpTemp": {
+    "attachments": {},
+    "chain": [
+      "q10ExpTemp",
+      "baseQ10Settings"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "q10": "none"
+    },
+    "extends": "baseQ10Settings",
+    "on_start": {},
+    "parameters": {
+      "experimentalTemp": "temperature",
+      "q10Factor": "none"
+    },
+    "requirements": {
+      "temperature": "temperature"
+    }
+  },
+  "q10Fixed": {
+    "attachments": {},
+    "chain": [
+      "q10Fixed",
+      "baseQ10Settings"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "q10": "none"
+    },
+    "extends": "baseQ10Settings",
+    "on_start": {},
+    "parameters": {
+      "fixedQ10": "none"
+    },
+    "requirements": {
+      "temperature": "temperature"
+    }
+  },
+  "rampGenerator": {
+    "attachments": {},
+    "chain": [
+      "rampGenerator",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePointCurrent",
+    "on_start": {},
+    "parameters": {
+      "baselineAmplitude": "current",
+      "delay": "time",
+      "duration": "time",
+      "finishAmplitude": "current",
+      "startAmplitude": "current"
+    },
+    "requirements": {}
+  },
+  "rampGeneratorDL": {
+    "attachments": {},
+    "chain": [
+      "rampGeneratorDL",
+      "basePointCurrentDL"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "I": "none"
+    },
+    "extends": "basePointCurrentDL",
+    "on_start": {},
+    "parameters": {
+      "baselineAmplitude": "none",
+      "delay": "time",
+      "duration": "time",
+      "finishAmplitude": "none",
+      "startAmplitude": "none"
+    },
+    "requirements": {}
+  },
+  "rectangularExtent": {
+    "attachments": {},
+    "chain": [
+      "rectangularExtent"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "xLength": "none",
+      "xStart": "none",
+      "yLength": "none",
+      "yStart": "none",
+      "zLength": "none",
+      "zStart": "none"
+    },
+    "requirements": {}
+  },
+  "region": {
+    "attachments": {},
+    "chain": [
+      "region"
+    ],
+    "children": {
+      "rectangularExtent": {
+        "multiple": false,
+        "type": "rectangularExtent"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "resistivity": {
+    "attachments": {},
+    "chain": [
+      "resistivity"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "value": "resistivity"
+    },
+    "requirements": {}
+  },
+  "reverseTransition": {
+    "attachments": {},
+    "chain": [
+      "reverseTransition",
+      "KSTransition"
+    ],
+    "children": {
+      "rate": {
+        "multiple": false,
+        "type": "baseHHRate"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "rf": "per_time",
+      "rr": "per_time"
+    },
+    "extends": "KSTransition",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "segment": {
+    "attachments": {},
+    "chain": [
+      "segment"
+    ],
+    "children": {
+      "distal": {
+        "multiple": false,
+        "type": "distal"
+      },
+      "parent": {
+        "multiple": false,
+        "type": "parent"
+      },
+      "proximal": {
+        "multiple": false,
+        "type": "proximal"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "length": "length",
+      "radDist": "length",
+      "surfaceArea": "area"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "segmentGroup": {
+    "attachments": {},
+    "chain": [
+      "segmentGroup"
+    ],
+    "children": {
+      "includes": {
+        "multiple": true,
+        "type": "include"
+      },
+      "inhomogeneousParameter": {
+        "multiple": true,
+        "type": "inhomogeneousParameter"
+      },
+      "members": {
+        "multiple": true,
+        "type": "member"
+      },
+      "paths": {
+        "multiple": true,
+        "type": "path"
+      },
+      "subTrees": {
+        "multiple": true,
+        "type": "subTree"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "silentSynapse": {
+    "attachments": {},
+    "chain": [
+      "silentSynapse",
+      "baseGradedSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseGradedSynapse",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "sineGenerator": {
+    "attachments": {},
+    "chain": [
+      "sineGenerator",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "basePointCurrent",
+    "on_start": {},
+    "parameters": {
+      "amplitude": "current",
+      "delay": "time",
+      "duration": "time",
+      "period": "time",
+      "phase": "none"
+    },
+    "requirements": {}
+  },
+  "sineGeneratorDL": {
+    "attachments": {},
+    "chain": [
+      "sineGeneratorDL",
+      "basePointCurrentDL"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "I": "none"
+    },
+    "extends": "basePointCurrentDL",
+    "on_start": {},
+    "parameters": {
+      "amplitude": "none",
+      "delay": "time",
+      "duration": "time",
+      "period": "time",
+      "phase": "none"
+    },
+    "requirements": {}
+  },
+  "species": {
+    "attachments": {},
+    "chain": [
+      "species"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "concentration": "concentration",
+      "extConcentration": "concentration"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "initialConcentration": "concentration",
+      "initialExtConcentration": "concentration"
+    },
+    "requirements": {}
+  },
+  "specificCapacitance": {
+    "attachments": {},
+    "chain": [
+      "specificCapacitance"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "specCap": "specificCapacitance"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "value": "specificCapacitance"
+    },
+    "requirements": {}
+  },
+  "spike": {
+    "attachments": {},
+    "chain": [
+      "spike",
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "spiked": "none",
+      "tsince": "time"
+    },
+    "extends": "baseSpikeSource",
+    "on_start": {},
+    "parameters": {
+      "time": "time"
+    },
+    "requirements": {}
+  },
+  "spikeArray": {
+    "attachments": {},
+    "chain": [
+      "spikeArray",
+      "baseSpikeSource"
+    ],
+    "children": {
+      "spikes": {
+        "multiple": true,
+        "type": "spike"
+      }
+    },
+    "event_ports": {
+      "in": "in",
+      "spike": "out"
+    },
+    "exposures": {
+      "tsince": "time"
+    },
+    "extends": "baseSpikeSource",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "spikeGenerator": {
+    "attachments": {},
+    "chain": [
+      "spikeGenerator",
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "tnext": "time",
+      "tsince": "time"
+    },
+    "extends": "baseSpikeSource",
+    "on_start": {},
+    "parameters": {
+      "period": "time"
+    },
+    "requirements": {}
+  },
+  "spikeGeneratorPoisson": {
+    "attachments": {},
+    "chain": [
+      "spikeGeneratorPoisson",
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "isi": "time",
+      "tnextIdeal": "time",
+      "tnextUsed": "time",
+      "tsince": "time"
+    },
+    "extends": "baseSpikeSource",
+    "on_start": {},
+    "parameters": {
+      "averageRate": "per_time"
+    },
+    "requirements": {}
+  },
+  "spikeGeneratorRandom": {
+    "attachments": {},
+    "chain": [
+      "spikeGeneratorRandom",
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "isi": "time",
+      "tnext": "time",
+      "tsince": "time"
+    },
+    "extends": "baseSpikeSource",
+    "on_start": {},
+    "parameters": {
+      "maxISI": "time",
+      "minISI": "time"
+    },
+    "requirements": {}
+  },
+  "spikeGeneratorRefPoisson": {
+    "attachments": {},
+    "chain": [
+      "spikeGeneratorRefPoisson",
+      "spikeGeneratorPoisson",
+      "baseSpikeSource"
+    ],
+    "children": {},
+    "event_ports": {
+      "spike": "out"
+    },
+    "exposures": {
+      "isi": "time",
+      "tnextIdeal": "time",
+      "tnextUsed": "time",
+      "tsince": "time"
+    },
+    "extends": "spikeGeneratorPoisson",
+    "on_start": {},
+    "parameters": {
+      "averageRate": "per_time",
+      "minimumISI": "time"
+    },
+    "requirements": {}
+  },
+  "spikeThresh": {
+    "attachments": {},
+    "chain": [
+      "spikeThresh"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "value": "voltage"
+    },
+    "requirements": {}
+  },
+  "stdpSynapse": {
+    "attachments": {},
+    "chain": [
+      "stdpSynapse",
+      "expTwoSynapse",
+      "baseConductanceBasedSynapse",
+      "baseVoltageDepSynapse",
+      "baseSynapse",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "M": "none",
+      "P": "none",
+      "g": "conductance",
+      "i": "current",
+      "tsince": "time"
+    },
+    "extends": "expTwoSynapse",
+    "on_start": {},
+    "parameters": {
+      "erev": "voltage",
+      "gbase": "conductance",
+      "tauDecay": "time",
+      "tauRise": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "subGate": {
+    "attachments": {},
+    "chain": [
+      "subGate"
+    ],
+    "children": {
+      "steadyState": {
+        "multiple": false,
+        "type": "baseVoltageDepVariable"
+      },
+      "timeCourse": {
+        "multiple": false,
+        "type": "baseVoltageDepTime"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "inf": "none",
+      "q": "none",
+      "qfrac": "none",
+      "tau": "time"
+    },
+    "extends": null,
+    "on_start": {},
+    "parameters": {
+      "fractionalConductance": "none"
+    },
+    "requirements": {
+      "rateScale": "none"
+    }
+  },
+  "subTree": {
+    "attachments": {},
+    "chain": [
+      "subTree"
+    ],
+    "children": {
+      "from": {
+        "multiple": false,
+        "type": "from"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "synapticConnection": {
+    "attachments": {},
+    "chain": [
+      "synapticConnection",
+      "explicitConnection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "explicitConnection",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "synapticConnectionWD": {
+    "attachments": {},
+    "chain": [
+      "synapticConnectionWD",
+      "synapticConnection",
+      "explicitConnection"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": "synapticConnection",
+    "on_start": {},
+    "parameters": {
+      "delay": "time",
+      "weight": "none"
+    },
+    "requirements": {}
+  },
+  "tauInfTransition": {
+    "attachments": {},
+    "chain": [
+      "tauInfTransition",
+      "KSTransition"
+    ],
+    "children": {
+      "steadyState": {
+        "multiple": false,
+        "type": "baseVoltageDepVariable"
+      },
+      "timeCourse": {
+        "multiple": false,
+        "type": "baseVoltageDepTime"
+      }
+    },
+    "event_ports": {},
+    "exposures": {
+      "rf": "per_time",
+      "rr": "per_time"
+    },
+    "extends": "KSTransition",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "timedSynapticInput": {
+    "attachments": {},
+    "chain": [
+      "timedSynapticInput",
+      "baseVoltageDepPointCurrentSpiking",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {
+      "spikes": {
+        "multiple": true,
+        "type": "spike"
+      }
+    },
+    "event_ports": {
+      "in": "in",
+      "spike": "out"
+    },
+    "exposures": {
+      "i": "current",
+      "tsince": "time"
+    },
+    "extends": "baseVoltageDepPointCurrentSpiking",
+    "on_start": {},
+    "parameters": {},
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "to": {
+    "attachments": {},
+    "chain": [
+      "to"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "transientPoissonFiringSynapse": {
+    "attachments": {},
+    "chain": [
+      "transientPoissonFiringSynapse",
+      "baseVoltageDepPointCurrentSpiking",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in",
+      "spike": "out"
+    },
+    "exposures": {
+      "i": "current",
+      "isi": "time",
+      "tnextIdeal": "time",
+      "tnextUsed": "time",
+      "tsince": "time"
+    },
+    "extends": "baseVoltageDepPointCurrentSpiking",
+    "on_start": {},
+    "parameters": {
+      "averageRate": "per_time",
+      "delay": "time",
+      "duration": "time"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "tsodyksMarkramDepFacMechanism": {
+    "attachments": {},
+    "chain": [
+      "tsodyksMarkramDepFacMechanism",
+      "basePlasticityMechanism"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "plasticityFactor": "none"
+    },
+    "extends": "basePlasticityMechanism",
+    "on_start": {},
+    "parameters": {
+      "initReleaseProb": "none",
+      "tauFac": "time",
+      "tauRec": "time"
+    },
+    "requirements": {}
+  },
+  "tsodyksMarkramDepMechanism": {
+    "attachments": {},
+    "chain": [
+      "tsodyksMarkramDepMechanism",
+      "basePlasticityMechanism"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "plasticityFactor": "none"
+    },
+    "extends": "basePlasticityMechanism",
+    "on_start": {},
+    "parameters": {
+      "initReleaseProb": "none",
+      "tauRec": "time"
+    },
+    "requirements": {}
+  },
+  "vHalfTransition": {
+    "attachments": {},
+    "chain": [
+      "vHalfTransition",
+      "KSTransition"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "rf": "per_time",
+      "rr": "per_time"
+    },
+    "extends": "KSTransition",
+    "on_start": {},
+    "parameters": {
+      "gamma": "none",
+      "tau": "time",
+      "tauMin": "time",
+      "vHalf": "voltage",
+      "z": "none"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "variableParameter": {
+    "attachments": {},
+    "chain": [
+      "variableParameter"
+    ],
+    "children": {
+      "inhomogeneousValue": {
+        "multiple": false,
+        "type": "inhomogeneousValue"
+      }
+    },
+    "event_ports": {},
+    "exposures": {},
+    "extends": null,
+    "on_start": {},
+    "parameters": {},
+    "requirements": {}
+  },
+  "voltageClamp": {
+    "attachments": {},
+    "chain": [
+      "voltageClamp",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseVoltageDepPointCurrent",
+    "on_start": {},
+    "parameters": {
+      "delay": "time",
+      "duration": "time",
+      "simpleSeriesResistance": "resistance",
+      "targetVoltage": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "voltageClampTriple": {
+    "attachments": {},
+    "chain": [
+      "voltageClampTriple",
+      "baseVoltageDepPointCurrent",
+      "basePointCurrent",
+      "baseStandalone"
+    ],
+    "children": {},
+    "event_ports": {
+      "in": "in"
+    },
+    "exposures": {
+      "i": "current"
+    },
+    "extends": "baseVoltageDepPointCurrent",
+    "on_start": {},
+    "parameters": {
+      "active": "none",
+      "conditioningVoltage": "voltage",
+      "delay": "time",
+      "duration": "time",
+      "returnVoltage": "voltage",
+      "simpleSeriesResistance": "resistance",
+      "testingVoltage": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  },
+  "voltageConcDepBlockMechanism": {
+    "attachments": {},
+    "chain": [
+      "voltageConcDepBlockMechanism",
+      "baseBlockMechanism"
+    ],
+    "children": {},
+    "event_ports": {},
+    "exposures": {
+      "blockFactor": "none"
+    },
+    "extends": "baseBlockMechanism",
+    "on_start": {},
+    "parameters": {
+      "blockConcentration": "concentration",
+      "scalingConc": "concentration",
+      "scalingVolt": "voltage"
+    },
+    "requirements": {
+      "v": "voltage"
+    }
+  }
+}

--- a/tvbo/data/ontology/tvbo.owl
+++ b/tvbo/data/ontology/tvbo.owl
@@ -14,10 +14,11 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:linkml="https://w3id.org/linkml/"
      xmlns:schema="http://schema.org/"
+     xmlns:neuroml="https://w3id.org/tvbo/neuroml/"
      xmlns:clinical="https://w3id.org/tvbo/clinical/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="https://w3id.org/tvbo/tvbo.owl">
-        <owl:versionIRI rdf:resource="https://w3id.org/tvbo/struct/0.4.0"/>
+        <owl:versionIRI rdf:resource="https://w3id.org/tvbo/2026-07-20/tvbo.owl"/>
         <terms:contributor>The Virtual Brain Ontology contributors</terms:contributor>
         <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-01</terms:created>
         <terms:description>Metadata schema for simulation studies using The Virtual Brain neuroinformatics platform or other dynamic network models of large-scale brain activity.</terms:description>
@@ -219,6 +220,12 @@
     
 
 
+    <!-- http://www.w3.org/2004/02/skos/core#closeMatch -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch"/>
+    
+
+
     <!-- http://www.w3.org/2004/02/skos/core#definition -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
@@ -252,6 +259,12 @@
     <!-- http://www.w3.org/2004/02/skos/core#prefLabel -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+    
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#relatedMatch -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#relatedMatch"/>
     
 
 
@@ -365,6 +378,42 @@
 
     <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/clinical/icd11Code">
         <rdfs:label>ICD-11 code</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/eventPort -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/eventPort">
+        <rdfs:comment xml:lang="en">An event port declared by this NeuroML ComponentType.</rdfs:comment>
+        <rdfs:label xml:lang="en">event port</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/exposes -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/exposes">
+        <rdfs:comment xml:lang="en">A quantity this NeuroML ComponentType exposes.</rdfs:comment>
+        <rdfs:label xml:lang="en">exposes</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/hasParameter -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/hasParameter">
+        <rdfs:comment xml:lang="en">A parameter declared by this NeuroML ComponentType.</rdfs:comment>
+        <rdfs:label xml:lang="en">has parameter</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/requires -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/tvbo/neuroml/requires">
+        <rdfs:comment xml:lang="en">A quantity this NeuroML ComponentType requires from its context.</rdfs:comment>
+        <rdfs:label xml:lang="en">requires</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -1821,6 +1870,12 @@
     
 
 
+    <!-- https://w3id.org/tvbo/outsym -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/tvbo/outsym"/>
+    
+
+
     <!-- https://w3id.org/tvbo/over -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/tvbo/over">
@@ -2280,12 +2335,6 @@
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
         <skos:notation>sweep_seeding</skos:notation>
     </owl:ObjectProperty>
-    
-
-
-    <!-- https://w3id.org/tvbo/symmetry -->
-
-    <owl:ObjectProperty rdf:about="https://w3id.org/tvbo/symmetry"/>
     
 
 
@@ -9908,6 +9957,12 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/outsym"/>
+                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/parameters"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
@@ -9933,12 +9988,6 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/regional_connectivity"/>
-                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -10010,12 +10059,6 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
-                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/delayed"/>
                 <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
             </owl:Restriction>
@@ -10064,13 +10107,13 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/outsym"/>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/sparse"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/tvbo/sparse"/>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -10101,6 +10144,12 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/tvbo/sparse"/>
+                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/tvbo/symmetry"/>
                 <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -10687,6 +10736,7 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>DerivedVariable</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#DerivedVariable"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/DerivedVariable"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
     </owl:Class>
@@ -11844,6 +11894,7 @@
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>Dynamics</rdfs:label>
         <skos:altLabel>NeuralMassModel</skos:altLabel>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#ComponentType"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
         <skos:note>Successor class replacing deprecated NeuralMassModel.</skos:note>
@@ -12933,6 +12984,7 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>Event</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#EventPort"/>
         <skos:definition>A discrete or continuous event that modifies the system during simulation. Generalizes Stimulus: can represent external inputs (stimulus type), threshold-triggered state changes (continuous/discrete type), or time-scheduled interventions (preset_time type). Attaches to components (nodes/edges) or to the experiment level.</skos:definition>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/Event"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
@@ -19295,6 +19347,7 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>Parameter</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#Parameter"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/Parameter"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
     </owl:Class>
@@ -22130,6 +22183,7 @@ Aligns with the BIDS phenotype standard (https://bids-specification.readthedocs.
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/struct"/>
         <rdfs:label>StateVariable</rdfs:label>
+        <skos:closeMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#StateVariable"/>
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/StateVariable"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
     </owl:Class>
@@ -27381,6 +27435,3221 @@ Aligns with the BIDS phenotype standard (https://bids-specification.readthedocs.
         <skos:definition>DBS parameters for a specific session.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo/dbs"/>
         <skos:notation>StimulationSetting</skos:notation>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Display -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Display">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Details of a display to generate (usually a set of traces given by _Line_s in a newly opened window) on completion of the simulation.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Display</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Display"/>
+        <neuroml:hasParameter>timeScale</neuroml:hasParameter>
+        <neuroml:hasParameter>xmax</neuroml:hasParameter>
+        <neuroml:hasParameter>xmin</neuroml:hasParameter>
+        <neuroml:hasParameter>ymax</neuroml:hasParameter>
+        <neuroml:hasParameter>ymin</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EIF_cond_alpha_isfa_ista -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EIF_cond_alpha_isfa_ista">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Adaptive exponential integrate and fire neuron according to Brette R and Gerstner W (2005) with alpha-function-shaped post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EIF_cond_alpha_isfa_ista</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EIF_cond_alpha_isfa_ista"/>
+        <neuroml:exposes>w</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>delta_T</neuroml:hasParameter>
+        <neuroml:hasParameter>i_offset</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_refrac</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_w</neuroml:hasParameter>
+        <neuroml:hasParameter>v_rest</neuroml:hasParameter>
+        <neuroml:hasParameter>v_spike</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EIF_cond_exp_isfa_ista -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EIF_cond_exp_isfa_ista">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Adaptive exponential integrate and fire neuron according to Brette R and Gerstner W (2005) with exponentially-decaying post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EIF_cond_exp_isfa_ista</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EIF_cond_exp_isfa_ista"/>
+        <neuroml:exposes>w</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>delta_T</neuroml:hasParameter>
+        <neuroml:hasParameter>i_offset</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_refrac</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_w</neuroml:hasParameter>
+        <neuroml:hasParameter>v_rest</neuroml:hasParameter>
+        <neuroml:hasParameter>v_spike</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EventOutputFile -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EventOutputFile">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A file in which to save event information (e.g. spikes from cells in a population) in a specified _format</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EventOutputFile</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EventOutputFile"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/EventSelection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/EventSelection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A specific source of events with an associated _id, which will be recorded inside the file specified in the parent _EventOutputFile_. The attribute _select should point to a cell inside a _population_ (e.g. hhpop[0], see https://docs.neuroml.org/Userdocs/Paths.html), and the _eventPort specifies the port for the emitted events, which usually has id: spike. Note: the _id used on this element (and appearing in the file alongside the event time) can be different from the id/index of the cell in the population.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">EventSelection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#EventSelection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpLinearRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpLinearRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHRate"/>
+        <terms:description xml:lang="en">Exponential linear form for rate equation. Linear for large positive _v, exponentially decays for large negative _v.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpLinearRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpLinearRate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpLinearVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpLinearVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHVariable"/>
+        <terms:description xml:lang="en">Exponential linear form for variable equation. Linear for large positive _v, exponentially decays for large negative _v.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpLinearVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpLinearVariable"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHRate"/>
+        <terms:description xml:lang="en">Exponential form for rate equation (Q: Should these be renamed hhExpRate, etc?)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpRate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHExpVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHExpVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHVariable"/>
+        <terms:description xml:lang="en">Exponential form for variable equation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHExpVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHExpVariable"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHSigmoidRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHSigmoidRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHRate"/>
+        <terms:description xml:lang="en">Sigmoidal form for rate equation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHSigmoidRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHSigmoidRate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HHSigmoidVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HHSigmoidVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseHHVariable"/>
+        <terms:description xml:lang="en">Sigmoidal form for variable equation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HHSigmoidVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HHSigmoidVariable"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/HH_cond_exp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/HH_cond_exp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNCell"/>
+        <terms:description xml:lang="en">Single-compartment Hodgkin-Huxley-type neuron with transient sodium and delayed-rectifier potassium currents using the ion channel models from Traub.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">HH_cond_exp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#HH_cond_exp"/>
+        <neuroml:exposes>h</neuroml:exposes>
+        <neuroml:exposes>m</neuroml:exposes>
+        <neuroml:exposes>n</neuroml:exposes>
+        <neuroml:hasParameter>e_rev_E</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_I</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_K</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_Na</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_leak</neuroml:hasParameter>
+        <neuroml:hasParameter>g_leak</neuroml:hasParameter>
+        <neuroml:hasParameter>gbar_K</neuroml:hasParameter>
+        <neuroml:hasParameter>gbar_Na</neuroml:hasParameter>
+        <neuroml:hasParameter>v_offset</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_cond_alpha -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_cond_alpha">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and alpha-function-shaped post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_cond_alpha</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_cond_alpha"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_cond_exp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_cond_exp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and exponentially-decaying post-synaptic conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_cond_exp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_cond_exp"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_curr_alpha -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_curr_alpha">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and alpha-function-shaped post-synaptic current</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_curr_alpha</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_curr_alpha"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/IF_curr_exp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/IF_curr_exp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCell"/>
+        <terms:description xml:lang="en">Leaky integrate and fire model with fixed threshold and decaying-exponential post-synaptic current</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">IF_curr_exp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#IF_curr_exp"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/KSState -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/KSState">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">One of the states in which a _gateKS_ can be. The rates of transitions between these states are given by _KSTransition_s</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">KSState</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#KSState"/>
+        <neuroml:exposes>occupancy</neuroml:exposes>
+        <neuroml:exposes>q</neuroml:exposes>
+        <neuroml:hasParameter>relativeConductance</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/KSTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/KSTransition">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specified the forward and reverse rates of transition between two _KSState_s in a _gateKS_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">KSTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#KSTransition"/>
+        <neuroml:exposes>rf</neuroml:exposes>
+        <neuroml:exposes>rr</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Line -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Line">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specification of a single time varying _quantity to plot on the _Display_. Note that all quantities are handled internally in LEMS in SI units, and so a _scale should be used if it is to be displayed in other units.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Line</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Line"/>
+        <neuroml:hasParameter>scale</neuroml:hasParameter>
+        <neuroml:hasParameter>timeScale</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Meta -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Meta">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Metadata to add to simulation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Meta</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Meta"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/OutputColumn -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/OutputColumn">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specification of a single time varying _quantity to record during the simulation. Note that all quantities are handled internally in LEMS in SI units, and so the value for the quantity in the file (as well as time) will be in SI units.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">OutputColumn</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#OutputColumn"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/OutputFile -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/OutputFile">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A file in which to save recorded values from the simulation</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">OutputFile</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#OutputFile"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/Simulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/Simulation">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The main element in a LEMS Simulation file. Defines the _length of simulation, the timestep (dt) _step and an optional _seed to use for stochastic elements, as well as _Display_s, _OutputFile_s and _EventOutputFile_s to record. Specifies a _target component to run, usually the id of a _network_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">Simulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#Simulation"/>
+        <neuroml:hasParameter>length</neuroml:hasParameter>
+        <neuroml:hasParameter>step</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/SpikeSourcePoisson -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/SpikeSourcePoisson">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Spike source, generating spikes according to a Poisson process.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">SpikeSourcePoisson</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#SpikeSourcePoisson"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>rate</neuroml:hasParameter>
+        <neuroml:hasParameter>start</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/adExIaFCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/adExIaFCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Model based on Brette R and Gerstner W (2005) Adaptive Exponential Integrate-and-Fire Model as an Effective Description of Neuronal Activity. J Neurophysiol 94:3637-3642</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">adExIaFCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#adExIaFCell"/>
+        <neuroml:exposes>w</neuroml:exposes>
+        <neuroml:hasParameter>EL</neuroml:hasParameter>
+        <neuroml:hasParameter>VT</neuroml:hasParameter>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>delT</neuroml:hasParameter>
+        <neuroml:hasParameter>gL</neuroml:hasParameter>
+        <neuroml:hasParameter>refract</neuroml:hasParameter>
+        <neuroml:hasParameter>reset</neuroml:hasParameter>
+        <neuroml:hasParameter>tauw</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaCondSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaCondSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Alpha synapse: rise time and decay time are both tau_syn. Conductance based synapse.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaCondSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaCondSynapse"/>
+        <neuroml:exposes>A</neuroml:exposes>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>e_rev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaCurrSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaCurrSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Alpha synapse: rise time and decay time are both tau_syn. Current based synapse.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaCurrSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaCurrSynapse"/>
+        <neuroml:exposes>A</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaCurrentSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaCurrentSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCurrentBasedSynapse"/>
+        <terms:description xml:lang="en">Alpha current synapse: rise time and decay time are both _tau.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaCurrentSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaCurrentSynapse"/>
+        <neuroml:hasParameter>ibase</neuroml:hasParameter>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/alphaSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/alphaSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse"/>
+        <terms:description xml:lang="en">Ohmic synapse model where rise time and decay time are both _tau. Max conductance reached during this time (assuming zero conductance before) is _gbase * _weight.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">alphaSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#alphaSynapse"/>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseBlockMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseBlockMechanism">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base of any ComponentType which produces a varying scaling (or blockage) of synaptic strength of magnitude _scaling</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseBlockMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseBlockMechanism"/>
+        <neuroml:exposes>blockFactor</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">Base type of any cell (e.g. point neuron like _izhikevich2007Cell_, or a morphologically detailed _Cell_ with _segment_s) which can be used in a _population_</terms:description>
+        <rdfs:comment xml:lang="en">A tvbo:Dynamics acting as a neuron is emitted as a descendant of baseCell.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCell"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCellMembPot -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCellMembPot">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikingCell"/>
+        <terms:description xml:lang="en">Any spiking cell which has a membrane potential _v with units of voltage (as opposed to a dimensionless membrane potential used in _baseCellMembPotDL_).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCellMembPot</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCellMembPot"/>
+        <neuroml:exposes>v</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCellMembPotCap -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCellMembPotCap">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Any cell with a membrane potential _v with voltage units and a membrane capacitance _C. Also defines exposed value _iSyn for current due to external synapses and _iMemb for total transmembrane current (usually channel currents plus _iSyn)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCellMembPotCap</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCellMembPotCap"/>
+        <neuroml:exposes>iMemb</neuroml:exposes>
+        <neuroml:exposes>iSyn</neuroml:exposes>
+        <neuroml:hasParameter>C</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCellMembPotDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCellMembPotDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikingCell"/>
+        <terms:description xml:lang="en">Any spiking cell which has a dimensioness membrane potential, _V (as opposed to a membrane potential units of voltage, _baseCellMembPot_).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCellMembPotDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCellMembPotDL"/>
+        <neuroml:exposes>V</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseChannelDensity -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseChannelDensity">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type for a current of density _iDensity distributed on an area of a _cell_, flowing through the specified _ionChannel. Instances of this (normally _channelDensity_) are specified in the _membraneProperties_ of the _cell_.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseChannelDensity</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseChannelDensity"/>
+        <neuroml:exposes>iDensity</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseChannelDensityCond -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseChannelDensityCond">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Base type for distributed conductances on an area of a cell producing a (not necessarily ohmic) current</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseChannelDensityCond</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseChannelDensityCond"/>
+        <neuroml:exposes>gDensity</neuroml:exposes>
+        <neuroml:hasParameter>condDensity</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseChannelPopulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseChannelPopulation">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Base type for any current produced by a population of channels, all of which are of type _ionChannel</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseChannelPopulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseChannelPopulation"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Synapse model which exposes a conductance _g in addition to producing a current. Not necessarily ohmic!! cno_0000027</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceBasedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceBasedSynapse"/>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>gbase</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapseTwo -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapseTwo">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Synapse model suited for a sum of two expTwoSynapses which exposes a conductance _g in addition to producing a current. Not necessarily ohmic!! cno_0000027</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceBasedSynapseTwo</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceBasedSynapseTwo"/>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>gbase1</neuroml:hasParameter>
+        <neuroml:hasParameter>gbase2</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceScaling -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceScaling">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for a scaling to apply to a gate&apos;s conductance, e.g. temperature dependent scaling</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceScaling</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceScaling"/>
+        <neuroml:exposes>factor</neuroml:exposes>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseConductanceScalingCaDependent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseConductanceScalingCaDependent">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceScaling"/>
+        <terms:description xml:lang="en">Base ComponentType for a scaling to apply to a gate&apos;s conductance which depends on Ca concentration. Usually a generic expression of _caConc (so no standard, non-base form here).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseConductanceScalingCaDependent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseConductanceScalingCaDependent"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseCurrentBasedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseCurrentBasedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Synapse model which produces a synaptic current.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseCurrentBasedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseCurrentBasedSynapse"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseGate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseGate">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for a voltage and/or concentration dependent gate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseGate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseGate"/>
+        <neuroml:exposes>fcond</neuroml:exposes>
+        <neuroml:exposes>q</neuroml:exposes>
+        <neuroml:hasParameter>instances</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseGradedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseGradedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Base type for graded synapses</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseGradedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseGradedSynapse"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseHHRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseHHRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepRate"/>
+        <terms:description xml:lang="en">Base ComponentType for rate which follow one of the typical forms for rate equations in the standard HH formalism, using the parameters _rate, _midpoint and _scale</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseHHRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseHHRate"/>
+        <neuroml:hasParameter>midpoint</neuroml:hasParameter>
+        <neuroml:hasParameter>rate</neuroml:hasParameter>
+        <neuroml:hasParameter>scale</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseHHVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseHHVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepVariable"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent dimensionless variable which follow one of the typical forms for variable equations in the standard HH formalism, using the parameters _rate, _midpoint, _scale</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseHHVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseHHVariable"/>
+        <neuroml:hasParameter>midpoint</neuroml:hasParameter>
+        <neuroml:hasParameter>rate</neuroml:hasParameter>
+        <neuroml:hasParameter>scale</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseIaf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseIaf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Base ComponentType for an integrate and fire cell which emits a spiking event at membrane potential _thresh and and resets to _reset</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseIaf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseIaf"/>
+        <neuroml:hasParameter>reset</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseIafCapCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseIafCapCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Base Type for all Integrate and Fire cells with a capacitance _C, threshold _thresh and reset membrane potential _reset</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseIafCapCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseIafCapCell"/>
+        <neuroml:hasParameter>reset</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseIonChannel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseIonChannel">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base for all ion channel ComponentTypes</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseIonChannel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseIonChannel"/>
+        <neuroml:exposes>fopen</neuroml:exposes>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePlasticityMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePlasticityMechanism">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base plasticity mechanism.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePlasticityMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePlasticityMechanism"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:exposes>plasticityFactor</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePointCurrent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePointCurrent">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a current _i (with dimension current)</terms:description>
+        <rdfs:comment xml:lang="en">A tvbo:Dynamics acting as an input current is emitted as a descendant of basePointCurrent.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePointCurrent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePointCurrent"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
+        <neuroml:exposes>i</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePointCurrentDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePointCurrentDL">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a dimensionless current _I. There are many dimensionless equivalents of all the core current producing ComponentTypes such as _pulseGenerator_ / _pulseGeneratorDL_, _sineGenerator_ / _sineGeneratorDL_ and _rampGenerator_ / _rampGeneratorDL_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePointCurrentDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePointCurrentDL"/>
+        <neuroml:exposes>I</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePopulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePopulation">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">A population of multiple instances of a specific _component, which anything which extends _baseCell_. </terms:description>
+        <rdfs:comment xml:lang="en">A NeuroML population corresponds to a tvbo network node (a group of cells of one type).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePopulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePopulation"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Node"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePyNNCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePyNNCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Base type of any PyNN standard cell model. Note: membrane potential _v has dimensions voltage, but all other parameters are dimensionless. This is to facilitate translation to and from PyNN scripts in Python, where these parameters have implicit units, see http://neuralensemble.org/trac/PyNN/wiki/StandardModels</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePyNNCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePyNNCell"/>
+        <neuroml:eventPort>spike_in_E</neuroml:eventPort>
+        <neuroml:eventPort>spike_in_I</neuroml:eventPort>
+        <neuroml:exposes>iSyn</neuroml:exposes>
+        <neuroml:hasParameter>cm</neuroml:hasParameter>
+        <neuroml:hasParameter>i_offset</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_syn_E</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_syn_I</neuroml:hasParameter>
+        <neuroml:hasParameter>v_init</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePyNNIaFCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePyNNIaFCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNCell"/>
+        <terms:description xml:lang="en">Base type of any PyNN standard integrate and fire model</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePyNNIaFCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePyNNIaFCell"/>
+        <neuroml:hasParameter>tau_m</neuroml:hasParameter>
+        <neuroml:hasParameter>tau_refrac</neuroml:hasParameter>
+        <neuroml:hasParameter>v_reset</neuroml:hasParameter>
+        <neuroml:hasParameter>v_rest</neuroml:hasParameter>
+        <neuroml:hasParameter>v_thresh</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePyNNIaFCondCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePyNNIaFCell"/>
+        <terms:description xml:lang="en">Base type of conductance based PyNN IaF cell models</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePyNNIaFCondCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePyNNIaFCondCell"/>
+        <neuroml:hasParameter>e_rev_E</neuroml:hasParameter>
+        <neuroml:hasParameter>e_rev_I</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/basePynnSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/basePynnSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Base type for all PyNN synapses. Note, the current _I produced is dimensionless, but it requires a membrane potential _v with dimension voltage</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">basePynnSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#basePynnSynapse"/>
+        <neuroml:hasParameter>tau_syn</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseQ10Settings -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseQ10Settings">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for a scaling to apply to gating variable time course, usually temperature dependent</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseQ10Settings</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseQ10Settings"/>
+        <neuroml:exposes>q10</neuroml:exposes>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSpikeSource -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSpikeSource">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base for any ComponentType whose main purpose is to emit spikes (on a port _spike). The exposed variable _tsince can be used for plotting the time since the Component has spiked last.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSpikeSource</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSpikeSource"/>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSpikingCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSpikingCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCell"/>
+        <terms:description xml:lang="en">Base type of any cell which can emit _spike events.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSpikingCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSpikingCell"/>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseStandalone -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseStandalone">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type of any Component which can have _Notes_, _Annotation_, or a _property_ list.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseStandalone</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseStandalone"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Base type for all synapses, i.e. ComponentTypes which produce a current (dimension current) and change Dynamics in response to an incoming event. cno_0000009</terms:description>
+        <rdfs:comment xml:lang="en">A tvbo:Dynamics acting as a synapse is emitted as a descendant of baseSynapse.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSynapse"/>
+        <skos:relatedMatch rdf:resource="https://w3id.org/tvbo/Dynamics"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseSynapseDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseSynapseDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentDL"/>
+        <terms:description xml:lang="en">Base type for all synapses, i.e. ComponentTypes which produce a dimensionless current and change Dynamics in response to an incoming event. cno_0000009</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseSynapseDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseSynapseDL"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageConcDepRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageConcDepRate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepRate"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage and concentration dependent rate. Produces a time varying rate _r which depends on _v and _caConc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageConcDepRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageConcDepRate"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageConcDepTime -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageConcDepTime">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepTime"/>
+        <terms:description xml:lang="en">Base type for voltage and calcium concentration dependent ComponentType producing value _t with dimension time (e.g. for time course of rate variable).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageConcDepTime</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageConcDepTime"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageConcDepVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageConcDepVariable">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepVariable"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage and calcium concentration dependent variable _x, which depends on _v and _caConc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageConcDepVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageConcDepVariable"/>
+        <neuroml:requires>caConc</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a current _i (with dimension current) and require a voltage _v exposed on the parent Component, which would often be the membrane potential of a Component extending _baseCellMembPot_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepPointCurrent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepPointCurrent"/>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a dimensionless current _I and require a dimensionless membrane potential _V exposed on the parent Component</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepPointCurrentDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepPointCurrentDL"/>
+        <neuroml:requires>V</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Base type for all ComponentTypes which produce a current _i, require a membrane potential _v exposed on the parent and emit spikes (on a port _spike). The exposed variable _tsince can be used for plotting the time since the Component has spiked last</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepPointCurrentSpiking</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepPointCurrentSpiking"/>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepRate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepRate">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent rate. Produces a time varying rate _r which depends on _v.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepRate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepRate"/>
+        <neuroml:exposes>r</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Base type for synapses with a dependence on membrane potential</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepSynapse"/>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepTime -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepTime">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent ComponentType producing value _t with dimension time (e.g. for time course of rate variable). Note: time course would not normally be fit to exp/sigmoid etc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepTime</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepTime"/>
+        <neuroml:exposes>t</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/baseVoltageDepVariable -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/baseVoltageDepVariable">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base ComponentType for voltage dependent variable  _x, which depends on _v. Can be used for inf/steady state of rate variable.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">baseVoltageDepVariable</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#baseVoltageDepVariable"/>
+        <neuroml:exposes>x</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/biophysicalProperties -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/biophysicalProperties">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The biophysical properties of the _cell_, including the _membraneProperties_ and the _intracellularProperties_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">biophysicalProperties</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#biophysicalProperties"/>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/biophysicalProperties2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/biophysicalProperties2CaPools">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The biophysical properties of the _cell_, including the _membraneProperties2CaPools_ and the _intracellularProperties2CaPools_ for a cell with two Ca pools</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">biophysicalProperties2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#biophysicalProperties2CaPools"/>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/blockingPlasticSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/blockingPlasticSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/expTwoSynapse"/>
+        <terms:description xml:lang="en">Biexponential synapse that allows for     optional block and plasticity     mechanisms, which can be expressed as     child elements.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">blockingPlasticSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#blockingPlasticSynapse"/>
+        <neuroml:eventPort>relay</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Cell with _segment_s specified in a _morphology_ element along with details on its _biophysicalProperties_. NOTE: this can only be correctly simulated using jLEMS when there is a single segment in the cell, and _v of this cell represents the membrane potential in that isopotential segment.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#cell"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>caConcExt</neuroml:exposes>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:exposes>iChannels</neuroml:exposes>
+        <neuroml:exposes>iSyn</neuroml:exposes>
+        <neuroml:exposes>spiking</neuroml:exposes>
+        <neuroml:exposes>surfaceArea</neuroml:exposes>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/cell2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/cell2CaPools">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/cell"/>
+        <terms:description xml:lang="en">Variant of cell with two independent Ca2+ pools. Cell with _segment_s specified in a _morphology_ element along with details on its _biophysicalProperties_. NOTE: this can only be correctly simulated using jLEMS when there is a single segment in the cell, and _v of this cell represents the membrane potential in that isopotential segment.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">cell2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#cell2CaPools"/>
+        <neuroml:exposes>caConc2</neuroml:exposes>
+        <neuroml:exposes>caConcExt2</neuroml:exposes>
+        <neuroml:exposes>iCa2</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensity -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensity">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">Specifies a time varying ohmic conductance density, _gDensity, which is distributed on an area of the _cell (specified in _membraneProperties_) with fixed reversal potential _erev producing a current density _iDensity</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensity</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensity"/>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityGHK -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityGHK">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, _gDensity, which is distributed on an area of the cell, producing a current density _iDensity and whose reversal potential is calculated from the Goldman Hodgkin Katz equation. Hard coded for Ca only! See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityGHK</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityGHK"/>
+        <neuroml:hasParameter>permeability</neuroml:hasParameter>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityGHK2 -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityGHK2">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">Time varying conductance density, _gDensity, which is distributed on an area of the cell, producing a current density _iDensity. Modified version of Jaffe et al. 1994 (used also in Lawrence et al. 2006). See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityGHK2</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityGHK2"/>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNernst -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNernst">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, _gDensity, which is distributed on an area of the _cell, producing a current density _iDensity and whose reversal potential is calculated from the Nernst equation. Hard coded for Ca only! See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNernst</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNernst"/>
+        <neuroml:exposes>erev</neuroml:exposes>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNernstCa2 -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNernstCa2">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensityCond"/>
+        <terms:description xml:lang="en">This component is similar to the original component type _channelDensityNernst_ but it is changed in order to have a reversal potential that depends on a second independent Ca++ pool (ca2). See https://github.com/OpenSourceBrain/ghk-nernst.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNernstCa2</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNernstCa2"/>
+        <neuroml:exposes>erev</neuroml:exposes>
+        <neuroml:requires>caConc2</neuroml:requires>
+        <neuroml:requires>caConcExt2</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNonUniform -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNonUniform">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying ohmic conductance density, which is distributed on a region of the _cell. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNonUniform</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNonUniform"/>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNonUniformGHK -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNonUniformGHK">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, which is distributed on a region of the _cell, and whose current is calculated from the Goldman-Hodgkin-Katz equation. Hard coded for Ca only!. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNonUniformGHK</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNonUniformGHK"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityNonUniformNernst -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityNonUniformNernst">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelDensity"/>
+        <terms:description xml:lang="en">Specifies a time varying conductance density, which is distributed on a region of the _cell, and whose reversal potential is calculated from the Nernst equation. Hard coded for Ca only!. The conductance density of the channel is not uniform, but is set using the _variableParameter_. Note, there is no dynamical description of this in LEMS yet, as this type only makes sense for multicompartmental cells. A ComponentType for this needs to be present to enable export of NeuroML 2 multicompartmental cells via LEMS/jNeuroML to NEURON</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityNonUniformNernst</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityNonUniformNernst"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelDensityVShift -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelDensityVShift">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/channelDensity"/>
+        <terms:description xml:lang="en">Same as _channelDensity_, but with a _vShift parameter to change voltage activation of gates. The exact usage of _vShift in expressions for rates is determined by the individual gates.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelDensityVShift</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelDensityVShift"/>
+        <neuroml:hasParameter>vShift</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelPopulation -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelPopulation">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelPopulation"/>
+        <terms:description xml:lang="en">Population of a _number of ohmic ion channels. These each produce a conductance _channelg across a reversal potential _erev, giving a total current _i. Note that active membrane currents are more frequently specified as a density over an area of the _cell_ using _channelDensity_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelPopulation</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelPopulation"/>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>number</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/channelPopulationNernst -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/channelPopulationNernst">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseChannelPopulation"/>
+        <terms:description xml:lang="en">Population of a _number of channels with a time varying reversal potential _erev determined by Nernst equation. Note: hard coded for Ca only!</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">channelPopulationNernst</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#channelPopulationNernst"/>
+        <neuroml:exposes>erev</neuroml:exposes>
+        <neuroml:hasParameter>number</neuroml:hasParameter>
+        <neuroml:requires>caConc</neuroml:requires>
+        <neuroml:requires>caConcExt</neuroml:requires>
+        <neuroml:requires>temperature</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/closedState -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/closedState">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSState"/>
+        <terms:description xml:lang="en">A _KSState_ with _relativeConductance of 0</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">closedState</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#closedState"/>
+        <neuroml:hasParameter>relativeConductance</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/compoundInput -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/compoundInput">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a current which is the sum of all its child _basePointCurrent_ element, e.g. can be a combination of _pulseGenerator_, _sineGenerator_ elements producing a single _i. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">compoundInput</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#compoundInput"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/compoundInputDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/compoundInputDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Generates a current which is the sum of all its child _basePointCurrentDL_ elements, e.g. can be a combination of _pulseGeneratorDL_, _sineGeneratorDL_ elements producing a single _i. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">compoundInputDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#compoundInputDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/concentrationModel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/concentrationModel">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base for any model of an _ion concentration which changes with time. Internal (_concentration) and external (_extConcentration) values for the concentration of the ion are given.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">concentrationModel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#concentrationModel"/>
+        <neuroml:exposes>concentration</neuroml:exposes>
+        <neuroml:exposes>extConcentration</neuroml:exposes>
+        <neuroml:requires>initialConcentration</neuroml:requires>
+        <neuroml:requires>initialExtConcentration</neuroml:requires>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/connection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/connection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Event connection directly between named components, which gets processed via a new instance of a _synapse component which is created on the target component. Normally contained inside a _projection_ element.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">connection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#connection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/connectionWD -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/connectionWD">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/connection"/>
+        <terms:description xml:lang="en">Event connection between named components, which gets processed via a new instance of a synapse component which is created on the target component, includes setting of _weight and _delay for the synaptic connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">connectionWD</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#connectionWD"/>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousConnection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Can be used for analog synapses.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousConnectionInstance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousConnectionInstance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Can be used for analog synapses.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousConnectionInstance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousConnectionInstance"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousConnectionInstanceW -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousConnectionInstanceW">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/continuousConnectionInstance"/>
+        <terms:description xml:lang="en">An instance of a connection in a _continuousProjection_ between _presynapticPopulation to another _postsynapticPopulation through a _preComponent at the start and _postComponent at the end. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Can be used for analog synapses. Includes setting of _weight for the connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousConnectionInstanceW</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousConnectionInstanceW"/>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/continuousProjection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/continuousProjection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A projection between _presynapticPopulation and _postsynapticPopulation through components _preComponent at the start and _postComponent at the end of a _continuousConnection_ or _continuousConnectionInstance_. Can be used for analog synapses.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">continuousProjection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#continuousProjection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/decayingPoolConcentrationModel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/decayingPoolConcentrationModel">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/concentrationModel"/>
+        <terms:description xml:lang="en">Model of an intracellular buffering mechanism for _ion (currently hard Coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course _decayConstant. The ion is assumed to occupy a shell inside the membrane of thickness _shellThickness.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">decayingPoolConcentrationModel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#decayingPoolConcentrationModel"/>
+        <neuroml:hasParameter>decayConstant</neuroml:hasParameter>
+        <neuroml:hasParameter>restingConc</neuroml:hasParameter>
+        <neuroml:hasParameter>shellThickness</neuroml:hasParameter>
+        <neuroml:requires>iCa</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/distal -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/distal">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/point3DWithDiam"/>
+        <terms:description xml:lang="en">Point on a _segment_ furthest from the soma. Should always be present in the description of a _segment_, unlike _proximal_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">distal</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#distal"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/distalDetails -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/distalDetails">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">What to do at the distal point when creating an inhomogeneous parameter</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">distalDetails</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#distalDetails"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/doubleSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/doubleSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepSynapse"/>
+        <terms:description xml:lang="en">Synapse consisting of two independent synaptic mechanisms (e.g. AMPA-R and NMDA-R), which can be easily colocated in connections</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">doubleSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#doubleSynapse"/>
+        <neuroml:eventPort>relay</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalConnection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">To enable connections between populations through gap junctions.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalConnectionInstance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalConnectionInstance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">To enable connections between populations through gap junctions. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalConnectionInstance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalConnectionInstance"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalConnectionInstanceW -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalConnectionInstanceW">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/electricalConnectionInstance"/>
+        <terms:description xml:lang="en">To enable connections between populations through gap junctions. Populations need to be of type _populationList_ and contain _instance_ and _location_ elements. Includes setting of _weight for the connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalConnectionInstanceW</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalConnectionInstanceW"/>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/electricalProjection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/electricalProjection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A projection between _presynapticPopulation to another _postsynapticPopulation through gap junctions.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">electricalProjection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#electricalProjection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expCondSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expCondSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Conductance based synapse with instantaneous rise and single exponential decay (with time constant tau_syn)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expCondSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expCondSynapse"/>
+        <neuroml:exposes>g</neuroml:exposes>
+        <neuroml:hasParameter>e_rev</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expCurrSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expCurrSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePynnSynapse"/>
+        <terms:description xml:lang="en">Current based synapse with instantaneous rise and single exponential decay (with time constant tau_syn)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expCurrSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expCurrSynapse"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expOneSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expOneSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse"/>
+        <terms:description xml:lang="en">Ohmic synapse model whose conductance rises instantaneously by (_gbase * _weight) on receiving an event, and which decays exponentially to zero with time course _tauDecay</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expOneSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expOneSynapse"/>
+        <neuroml:hasParameter>tauDecay</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expThreeSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expThreeSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapseTwo"/>
+        <terms:description xml:lang="en">Ohmic synapse similar to expTwoSynapse but consisting of two components that can differ in decay times and max conductances but share the same rise time.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expThreeSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expThreeSynapse"/>
+        <neuroml:hasParameter>tauDecay1</neuroml:hasParameter>
+        <neuroml:hasParameter>tauDecay2</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRise</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/expTwoSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/expTwoSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceBasedSynapse"/>
+        <terms:description xml:lang="en">Ohmic synapse model whose conductance waveform on receiving an event has a rise time of _tauRise and a decay time of _tauDecay. Max conductance reached during this time (assuming zero conductance before) is _gbase * _weight.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">expTwoSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#expTwoSynapse"/>
+        <neuroml:hasParameter>tauDecay</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRise</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/explicitConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/explicitConnection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Explicit event connection between components</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">explicitConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#explicitConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/explicitInput -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/explicitInput">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An explicit input (anything which extends _basePointCurrent_) to a target cell in a population</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">explicitInput</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#explicitInput"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fitzHughNagumo1969Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fitzHughNagumo1969Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotDL"/>
+        <terms:description xml:lang="en">The Fitzhugh Nagumo model is a two-dimensional simplification of the Hodgkin-Huxley model of spike generation in squid giant axons.  This system was suggested by FitzHugh (FitzHugh R. [1961]: Impulses and physiological states in theoretical models of nerve membrane.  Biophysical J.  1:445-466), who called it &quot; Bonhoeffer-van der Pol model &quot;, and the equivalent circuit by Nagumo et al.  (Nagumo J., Arimoto S., and Yoshizawa S. [1962] An active pulse transmission line simulating nerve axon. Proc IRE. 50:2061-2070.1962). This version corresponds to the one described in FitzHugh R.[1969]: Mathematical models of excitation and propagation in nerve.  Chapter 1 (pp. 1-85 in H.P. Schwan, ed. Biological Engineering, McGraw-Hill Book Co., N.Y.)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fitzHughNagumo1969Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fitzHughNagumo1969Cell"/>
+        <neuroml:exposes>F</neuroml:exposes>
+        <neuroml:exposes>W</neuroml:exposes>
+        <neuroml:hasParameter>I</neuroml:hasParameter>
+        <neuroml:hasParameter>V0</neuroml:hasParameter>
+        <neuroml:hasParameter>W0</neuroml:hasParameter>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>phi</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fitzHughNagumoCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fitzHughNagumoCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotDL"/>
+        <terms:description xml:lang="en">Simple dimensionless model of spiking cell from FitzHugh and Nagumo. Superseded by _fitzHughNagumo1969Cell (See https://github.com/NeuroML/NeuroML2/issues/42)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fitzHughNagumoCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fitzHughNagumoCell"/>
+        <neuroml:exposes>W</neuroml:exposes>
+        <neuroml:hasParameter>I</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModel">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/concentrationModel"/>
+        <terms:description xml:lang="en">Model of buffering of concentration of an ion (currently hard coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course _decayConstant. A fixed factor _rho is used to scale the incoming current *independently of the size of the compartment* to produce a concentration change.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fixedFactorConcentrationModel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fixedFactorConcentrationModel"/>
+        <neuroml:hasParameter>decayConstant</neuroml:hasParameter>
+        <neuroml:hasParameter>restingConc</neuroml:hasParameter>
+        <neuroml:hasParameter>rho</neuroml:hasParameter>
+        <neuroml:requires>iCa</neuroml:requires>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModelTraub -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fixedFactorConcentrationModelTraub">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/concentrationModel"/>
+        <terms:description xml:lang="en">Model of buffering of concentration of an ion (currently hard coded to be calcium, due to requirement for _iCa) which has a baseline level _restingConc and tends to this value with time course 1 / _beta. A fixed factor _phi is used to scale the incoming current *independently of the size of the compartment* to produce a concentration change. Not recommended for use in models other than Traub et al. 2005!</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fixedFactorConcentrationModelTraub</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fixedFactorConcentrationModelTraub"/>
+        <neuroml:hasParameter>beta</neuroml:hasParameter>
+        <neuroml:hasParameter>phi</neuroml:hasParameter>
+        <neuroml:hasParameter>restingConc</neuroml:hasParameter>
+        <neuroml:requires>iCa</neuroml:requires>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/fixedTimeCourse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/fixedTimeCourse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepTime"/>
+        <terms:description xml:lang="en">Time course of a fixed magnitude _tau which can be used for the time course in _gateHHtauInf_, _gateHHratesTau_ or _gateHHratesTauInf_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">fixedTimeCourse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#fixedTimeCourse"/>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_account -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_account">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_account</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_account"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_fundedBy -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_fundedBy">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_fundedBy</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_fundedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_homepage -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_homepage">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_homepage</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_homepage"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_mbox -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_mbox">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_mbox</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_mbox"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_name -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_name">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_name</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_name"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_publications -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_publications">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_publications</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_publications"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_thumbnail -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_thumbnail">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_thumbnail</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_thumbnail"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/foaf_weblog -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/foaf_weblog">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">foaf_weblog</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#foaf_weblog"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/forwardTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/forwardTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">A forward only _KSTransition_ for a _gateKS_ which specifies a _rate (type _baseHHRate_) which follows one of the standard Hodgkin Huxley forms (e.g. _HHExpRate_, _HHSigmoidRate_, _HHExpLinearRate_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">forwardTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#forwardTransition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/from -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/from">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">In a _path_ or _subTree_, specifies which _segment (inclusive) from which to calculate the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">from</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#from"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gapJunction -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gapJunction">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSynapse"/>
+        <terms:description xml:lang="en">Gap junction/single electrical connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gapJunction</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gapJunction"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gate">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGate"/>
+        <terms:description xml:lang="en">Conveniently named baseGate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gate"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateFractional -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateFractional">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate composed of subgates contributing with fractional conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateFractional</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateFractional"/>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHInstantaneous -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHInstantaneous">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism but is instantaneous, so tau = 0 and gate follows exactly inf value</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHInstantaneous</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHInstantaneous"/>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHrates -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHrates">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHrates</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHrates"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHratesInf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHratesInf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHratesInf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHratesInf"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHratesTau -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHratesTau">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHratesTau</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHratesTau"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHratesTauInf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHratesTauInf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHratesTauInf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHratesTauInf"/>
+        <neuroml:exposes>alpha</neuroml:exposes>
+        <neuroml:exposes>beta</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateHHtauInf -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateHHtauInf">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/gate"/>
+        <terms:description xml:lang="en">Gate which follows the general Hodgkin Huxley formalism</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateHHtauInf</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateHHtauInf"/>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gateKS -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gateKS">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGate"/>
+        <terms:description xml:lang="en">A gate which consists of multiple _KSState_s and _KSTransition_s giving the rates of transition between them</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gateKS</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gateKS"/>
+        <neuroml:exposes>rateScale</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/gradedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/gradedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGradedSynapse"/>
+        <terms:description xml:lang="en">Graded/analog synapse. Based on synapse in Methods of http://www.nature.com/neuro/journal/v7/n12/abs/nn1352.html</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">gradedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#gradedSynapse"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+        <neuroml:hasParameter>Vth</neuroml:hasParameter>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:hasParameter>delta</neuroml:hasParameter>
+        <neuroml:hasParameter>erev</neuroml:hasParameter>
+        <neuroml:hasParameter>k</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/hindmarshRose1984Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/hindmarshRose1984Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">         The Hindmarsh Rose model is a simplified point cell model which         captures complex firing patterns of single neurons, such as         periodic and chaotic bursting. It has a fast spiking subsystem,         which is a generalization of the FitzHugh-Nagumo system, coupled         to a slower subsystem which allows the model to fire bursts. The         dynamical variables x,y,z correspond to the membrane potential, a         recovery variable, and a slower adaptation current, respectively.          See Hindmarsh J. L., and Rose R. M. (1984) A model of neuronal         bursting using three coupled first order differential equations.         Proc. R. Soc. London, Ser. B 221:87–102.         </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">hindmarshRose1984Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#hindmarshRose1984Cell"/>
+        <neuroml:exposes>chi</neuroml:exposes>
+        <neuroml:exposes>phi</neuroml:exposes>
+        <neuroml:exposes>rho</neuroml:exposes>
+        <neuroml:exposes>spiking</neuroml:exposes>
+        <neuroml:exposes>x</neuroml:exposes>
+        <neuroml:exposes>y</neuroml:exposes>
+        <neuroml:exposes>z</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>c</neuroml:hasParameter>
+        <neuroml:hasParameter>d</neuroml:hasParameter>
+        <neuroml:hasParameter>r</neuroml:hasParameter>
+        <neuroml:hasParameter>s</neuroml:hasParameter>
+        <neuroml:hasParameter>v_scaling</neuroml:hasParameter>
+        <neuroml:hasParameter>x0</neuroml:hasParameter>
+        <neuroml:hasParameter>x1</neuroml:hasParameter>
+        <neuroml:hasParameter>y0</neuroml:hasParameter>
+        <neuroml:hasParameter>z0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIafCapCell"/>
+        <terms:description xml:lang="en">Integrate and fire cell with capacitance _C, _leakConductance and _leakReversal</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafCell"/>
+        <neuroml:hasParameter>leakConductance</neuroml:hasParameter>
+        <neuroml:hasParameter>leakReversal</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafRefCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafRefCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/iafCell"/>
+        <terms:description xml:lang="en">Integrate and fire cell  with capacitance _C, _leakConductance, _leakReversal and refractory period _refract</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafRefCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafRefCell"/>
+        <neuroml:hasParameter>refract</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafTauCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafTauCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIaf"/>
+        <terms:description xml:lang="en">Integrate and fire cell which returns to its leak reversal potential of _leakReversal with a time constant _tau</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafTauCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafTauCell"/>
+        <neuroml:hasParameter>leakReversal</neuroml:hasParameter>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/iafTauRefCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/iafTauRefCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/iafTauCell"/>
+        <terms:description xml:lang="en">Integrate and fire cell which returns to its leak reversal potential of _leakReversal with a time course _tau. It has a refractory period of _refract after spiking</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">iafTauRefCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#iafTauRefCell"/>
+        <neuroml:hasParameter>refract</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/include -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/include">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Include all members of another _segmentGroup_ in this group</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">include</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#include"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inhomogeneousParameter -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inhomogeneousParameter">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An inhomogeneous parameter specified across the _segmentGroup_ (see _variableParameter_ for usage).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inhomogeneousParameter</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inhomogeneousParameter"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inhomogeneousValue -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inhomogeneousValue">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies the _value of an _inhomogeneousParameter. For usage see _variableParameter_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inhomogeneousValue</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inhomogeneousValue"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/initMembPotential -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/initMembPotential">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Explicitly set initial membrane potential for the cell</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">initMembPotential</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#initMembPotential"/>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/input -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/input">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies a single input to a _target, optionally giving the _segmentId (default 0) and _fractionAlong the segment (default 0.5).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">input</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#input"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inputList -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inputList">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">An explicit list of _input_s to a _population.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inputList</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inputList"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/inputW -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/inputW">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/input"/>
+        <terms:description xml:lang="en">Specifies input lists. Can set _weight to scale individual inputs.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">inputW</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#inputW"/>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/instance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/instance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies a single instance of a component in a _population_ (placed at _location_).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">instance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#instance"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/intracellularProperties -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/intracellularProperties">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Biophysical properties related to the intracellular space within the _cell_, such as the _resistivity_ and the list of ionic _species_ present. _caConc and _caConcExt are explicitly exposed here to facilitate accessing these values from other Components, even though _caConcExt is clearly not an intracellular property</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">intracellularProperties</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#intracellularProperties"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>caConcExt</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/intracellularProperties2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/intracellularProperties2CaPools">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/intracellularProperties"/>
+        <terms:description xml:lang="en">Variant of intracellularProperties with 2 independent Ca pools</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">intracellularProperties2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#intracellularProperties2CaPools"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>caConc2</neuroml:exposes>
+        <neuroml:exposes>caConcExt</neuroml:exposes>
+        <neuroml:exposes>caConcExt2</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannel -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannel">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/ionChannelHH"/>
+        <terms:description xml:lang="en">Note _ionChannel_ and _ionChannelHH_ are currently functionally identical. This is needed since many existing examples use ionChannel, some use ionChannelHH. NeuroML v2beta4 should remove one of these, probably ionChannelHH.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannel</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannel"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelHH -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelHH">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIonChannel"/>
+        <terms:description xml:lang="en">Note _ionChannel_ and _ionChannelHH_ are currently functionally identical. This is needed since many existing examples use ionChannel, some use ionChannelHH. NeuroML v2beta4 should remove one of these, probably ionChannelHH.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelHH</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelHH"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelKS -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelKS">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseIonChannel"/>
+        <terms:description xml:lang="en">A kinetic scheme based ion channel with multiple _gateKS_s, each of which consists of multiple _KSState_s and _KSTransition_s giving the rates of transition between them</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelKS</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelKS"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelPassive -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelPassive">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/ionChannel"/>
+        <terms:description xml:lang="en">Simple passive ion channel where the constant conductance through the channel is equal to _conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelPassive</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelPassive"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/ionChannelVShift -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/ionChannelVShift">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/ionChannel"/>
+        <terms:description xml:lang="en">Same as _ionChannel_, but with a _vShift parameter to change voltage activation of gates. The exact usage of _vShift in expressions for rates is determined by the individual gates.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">ionChannelVShift</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#ionChannelVShift"/>
+        <neuroml:hasParameter>vShift</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/izhikevich2007Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/izhikevich2007Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Cell based on the modified Izhikevich model in Izhikevich 2007, Dynamical systems in neuroscience, MIT Press</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">izhikevich2007Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#izhikevich2007Cell"/>
+        <neuroml:exposes>u</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>c</neuroml:hasParameter>
+        <neuroml:hasParameter>d</neuroml:hasParameter>
+        <neuroml:hasParameter>k</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+        <neuroml:hasParameter>vpeak</neuroml:hasParameter>
+        <neuroml:hasParameter>vr</neuroml:hasParameter>
+        <neuroml:hasParameter>vt</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/izhikevichCell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/izhikevichCell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Cell based on the 2003 model of Izhikevich, see http://izhikevich.org/publications/spikes.htm</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">izhikevichCell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#izhikevichCell"/>
+        <neuroml:exposes>U</neuroml:exposes>
+        <neuroml:hasParameter>a</neuroml:hasParameter>
+        <neuroml:hasParameter>b</neuroml:hasParameter>
+        <neuroml:hasParameter>c</neuroml:hasParameter>
+        <neuroml:hasParameter>d</neuroml:hasParameter>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/linearGradedSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/linearGradedSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGradedSynapse"/>
+        <terms:description xml:lang="en">Behaves just like a one way gap junction.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">linearGradedSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#linearGradedSynapse"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:hasParameter>conductance</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/location -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/location">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies the (x,y,z) location of a single _instance_ of a component in a _population_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">location</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#location"/>
+        <neuroml:hasParameter>x</neuroml:hasParameter>
+        <neuroml:hasParameter>y</neuroml:hasParameter>
+        <neuroml:hasParameter>z</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/member -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/member">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A single identified _segment which is part of the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">member</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#member"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/membraneProperties -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/membraneProperties">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Properties specific to the membrane, such as the _populations of channels, _channelDensities, _specificCapacitance, etc.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">membraneProperties</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#membraneProperties"/>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:exposes>totChanCurrent</neuroml:exposes>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/membraneProperties2CaPools -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/membraneProperties2CaPools">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/membraneProperties"/>
+        <terms:description xml:lang="en">Variant of membraneProperties with 2 independent Ca pools</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">membraneProperties2CaPools</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#membraneProperties2CaPools"/>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:exposes>iCa2</neuroml:exposes>
+        <neuroml:exposes>totChanCurrent</neuroml:exposes>
+        <neuroml:exposes>totSpecCap</neuroml:exposes>
+        <neuroml:requires>surfaceArea</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/morphology -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/morphology">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The collection of _segment_s which specify the 3D structure of the cell, along with a number of _segmentGroup_s</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">morphology</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#morphology"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/network -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/network">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseStandalone"/>
+        <terms:description xml:lang="en">Network containing: _population_s (potentially of type _populationList_, and so specifying a list of cell _location_s); _projection_s (with lists of _connection_s) and/or _explicitConnection_s; and _inputList_s (with lists of _input_s) and/or _explicitInput_s. Note: often in NeuroML this will be of type _networkWithTemperature_ if there are temperature dependent elements (e.g. ion channels).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">network</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#network"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/networkWithTemperature -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/networkWithTemperature">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/network"/>
+        <terms:description xml:lang="en">Same as _network_, but with an explicit _temperature for temperature dependent elements (e.g. ion channels)</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">networkWithTemperature</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#networkWithTemperature"/>
+        <neuroml:hasParameter>temperature</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/openState -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/openState">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSState"/>
+        <terms:description xml:lang="en">A _KSState_ with _relativeConductance of 1</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">openState</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#openState"/>
+        <neuroml:hasParameter>relativeConductance</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/orcid_id -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/orcid_id">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">https://docs.biosimulations.org/concepts/conventions/simulation-project-metadata/</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">orcid_id</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#orcid_id"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/parent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/parent">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies the _segment_ which is this segment&apos;s parent. The _fractionAlong specifies where it is connected, usually 1 (the default value), meaning the _distal_ point of the parent, or 0, meaning the _proximal_ point. If it is between these, a linear interpolation between the 2 points should be used.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">parent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#parent"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/path -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/path">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Include all the _segment_s between those specified by _from_ and _to_, inclusive</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">path</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#path"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pinskyRinzelCA3Cell -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pinskyRinzelCA3Cell">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPot"/>
+        <terms:description xml:lang="en">Reduced CA3 cell model from Pinsky, P.F., Rinzel, J. Intrinsic and network rhythmogenesis in a reduced traub model for CA3 neurons. J Comput Neurosci 1, 39-60 (1994). See https://github.com/OpenSourceBrain/PinskyRinzelModel</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pinskyRinzelCA3Cell</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pinskyRinzelCA3Cell"/>
+        <neuroml:exposes>Cad</neuroml:exposes>
+        <neuroml:exposes>ICad</neuroml:exposes>
+        <neuroml:exposes>Si</neuroml:exposes>
+        <neuroml:exposes>Vd</neuroml:exposes>
+        <neuroml:exposes>Vs</neuroml:exposes>
+        <neuroml:exposes>Wi</neuroml:exposes>
+        <neuroml:exposes>cd</neuroml:exposes>
+        <neuroml:exposes>hs</neuroml:exposes>
+        <neuroml:exposes>ns</neuroml:exposes>
+        <neuroml:exposes>qd</neuroml:exposes>
+        <neuroml:exposes>sd</neuroml:exposes>
+        <neuroml:hasParameter>alphac</neuroml:hasParameter>
+        <neuroml:hasParameter>betac</neuroml:hasParameter>
+        <neuroml:hasParameter>cm</neuroml:hasParameter>
+        <neuroml:hasParameter>eCa</neuroml:hasParameter>
+        <neuroml:hasParameter>eK</neuroml:hasParameter>
+        <neuroml:hasParameter>eL</neuroml:hasParameter>
+        <neuroml:hasParameter>eNa</neuroml:hasParameter>
+        <neuroml:hasParameter>gAmpa</neuroml:hasParameter>
+        <neuroml:hasParameter>gCa</neuroml:hasParameter>
+        <neuroml:hasParameter>gKC</neuroml:hasParameter>
+        <neuroml:hasParameter>gKahp</neuroml:hasParameter>
+        <neuroml:hasParameter>gKdr</neuroml:hasParameter>
+        <neuroml:hasParameter>gLd</neuroml:hasParameter>
+        <neuroml:hasParameter>gLs</neuroml:hasParameter>
+        <neuroml:hasParameter>gNa</neuroml:hasParameter>
+        <neuroml:hasParameter>gNmda</neuroml:hasParameter>
+        <neuroml:hasParameter>gc</neuroml:hasParameter>
+        <neuroml:hasParameter>iDend</neuroml:hasParameter>
+        <neuroml:hasParameter>iSoma</neuroml:hasParameter>
+        <neuroml:hasParameter>pp</neuroml:hasParameter>
+        <neuroml:hasParameter>qd0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/point3DWithDiam -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/point3DWithDiam">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Base type for ComponentTypes which specify an ( _x, _y, _z ) coordinate along with a _diameter. Note: no dimension used in the attributes for these coordinates! These are assumed to have dimension micrometer (10^-6 m). This is due to micrometers being the default option for the majority of neuronal morphology formats, and dimensions are omitted here to facilitate reading and writing of morphologies in NeuroML.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">point3DWithDiam</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#point3DWithDiam"/>
+        <neuroml:hasParameter>diameter</neuroml:hasParameter>
+        <neuroml:hasParameter>x</neuroml:hasParameter>
+        <neuroml:hasParameter>y</neuroml:hasParameter>
+        <neuroml:hasParameter>z</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pointCellCondBased -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pointCellCondBased">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">Simple model of a conductance based cell, with no separate _morphology_ element, just an absolute capacitance _C, and a set of channel _populations. Note: use of _cell_ is generally preferable (and more widely supported), even for a single compartment cell.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pointCellCondBased</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pointCellCondBased"/>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pointCellCondBasedCa -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pointCellCondBasedCa">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseCellMembPotCap"/>
+        <terms:description xml:lang="en">TEMPORARY: Point cell with conductances and Ca concentration info. Not yet fully tested!!! TODO: Remove in favour of _cell_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pointCellCondBasedCa</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pointCellCondBasedCa"/>
+        <neuroml:exposes>caConc</neuroml:exposes>
+        <neuroml:exposes>iCa</neuroml:exposes>
+        <neuroml:hasParameter>thresh</neuroml:hasParameter>
+        <neuroml:hasParameter>v0</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/poissonFiringSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/poissonFiringSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking"/>
+        <terms:description xml:lang="en">Poisson spike generator firing at _averageRate, which is connected to single _synapse that is triggered every time a spike is generated, producing an input current. See also _transientPoissonFiringSynapse_.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">poissonFiringSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#poissonFiringSynapse"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:exposes>tsince</neuroml:exposes>
+        <neuroml:hasParameter>averageRate</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/population -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/population">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePopulation"/>
+        <terms:description xml:lang="en">A population of components, with just one parameter for the _size, i.e. number of components to create. Note: quite often this is used with type=_populationList_ which means the size is determined by the number of _instance_s (with _location_s) in the list. The _size attribute is still set, and there will be a validation error if this does not match the number in the list.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">population</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#population"/>
+        <neuroml:hasParameter>size</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/populationList -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/populationList">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePopulation"/>
+        <terms:description xml:lang="en">An explicit list of _instance_s (with _location_s) of components in the population. </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">populationList</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#populationList"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/projection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/projection">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Projection from one population, _presynapticPopulation to another, _postsynapticPopulation, through _synapse. Contains lists of _connection_ or _connectionWD_ elements.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">projection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#projection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/proximal -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/proximal">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/point3DWithDiam"/>
+        <terms:description xml:lang="en">Point on a _segment_ closest to the soma. Note, the proximal point can be omitted, and in this case is defined as being the point _fractionAlong between the proximal and _distal_ point of the _parent_, i.e. if _fractionAlong = 1 (as it is by default) it will be the _distal on the parent, or if _fractionAlong = 0, it will be the proximal point. If between 0 and 1, it is the linear interpolation between the two points.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">proximal</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#proximal"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/proximalDetails -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/proximalDetails">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">What to do at the proximal point when creating an inhomogeneous parameter</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">proximalDetails</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#proximalDetails"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pulseGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pulseGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a constant current pulse of a certain _amplitude for a specified _duration after a _delay. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pulseGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pulseGenerator"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/pulseGeneratorDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/pulseGeneratorDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Dimensionless equivalent of _pulseGenerator_. Generates a constant current pulse of a certain _amplitude for a specified _duration after a _delay. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">pulseGeneratorDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#pulseGeneratorDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/q10ConductanceScaling -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/q10ConductanceScaling">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseConductanceScaling"/>
+        <terms:description xml:lang="en">A value for the conductance scaling which varies as a standard function of the difference between the current temperature, _temperature, and the temperature at which the conductance was originally determined, _experimentalTemp</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">q10ConductanceScaling</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#q10ConductanceScaling"/>
+        <neuroml:hasParameter>experimentalTemp</neuroml:hasParameter>
+        <neuroml:hasParameter>q10Factor</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/q10ExpTemp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/q10ExpTemp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseQ10Settings"/>
+        <terms:description xml:lang="en">A value for the Q10 scaling which varies as a standard function of the difference between the current temperature, _temperature, and the temperature at which the gating variable equations were determined, _experimentalTemp</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">q10ExpTemp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#q10ExpTemp"/>
+        <neuroml:hasParameter>experimentalTemp</neuroml:hasParameter>
+        <neuroml:hasParameter>q10Factor</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/q10Fixed -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/q10Fixed">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseQ10Settings"/>
+        <terms:description xml:lang="en">A fixed value, _fixedQ10, for the scaling of the time course of the gating variable</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">q10Fixed</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#q10Fixed"/>
+        <neuroml:hasParameter>fixedQ10</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/rampGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/rampGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a ramping current after a time _delay, for a fixed _duration. During this time the current steadily changes from _startAmplitude to _finishAmplitude. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">rampGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#rampGenerator"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>baselineAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>finishAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>startAmplitude</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/rampGeneratorDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/rampGeneratorDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Dimensionless equivalent of _rampGenerator_. Generates a ramping current after a time _delay, for a fixed _duration. During this time the dimensionless current steadily changes from _startAmplitude to _finishAmplitude. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">rampGeneratorDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#rampGeneratorDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>baselineAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>finishAmplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>startAmplitude</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/rectangularExtent -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/rectangularExtent">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">For defining a 3D rectangular box</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">rectangularExtent</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#rectangularExtent"/>
+        <neuroml:hasParameter>xLength</neuroml:hasParameter>
+        <neuroml:hasParameter>xStart</neuroml:hasParameter>
+        <neuroml:hasParameter>yLength</neuroml:hasParameter>
+        <neuroml:hasParameter>yStart</neuroml:hasParameter>
+        <neuroml:hasParameter>zLength</neuroml:hasParameter>
+        <neuroml:hasParameter>zStart</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/region -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/region">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Initial attempt to specify 3D region for placing cells. Work in progress...</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">region</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#region"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/resistivity -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/resistivity">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">The resistivity, or specific axial resistance, of the cytoplasm</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">resistivity</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#resistivity"/>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/reverseTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/reverseTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">A reverse only _KSTransition_ for a _gateKS_ which specifies a _rate (type _baseHHRate_) which follows one of the standard Hodgkin Huxley forms (e.g. _HHExpRate_, _HHSigmoidRate_, _HHExpLinearRate_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">reverseTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#reverseTransition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/segment -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/segment">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A segment defines the smallest unit within a possibly branching structure (_morphology_), such as a dendrite or axon. Its _id should be a nonnegative integer (usually soma/root = 0). Its end points are given by the _proximal_ and _distal_ points. The _proximal_ point can be omitted, usually because it is the same as a point on the _parent_ segment, see _proximal_ for details. _parent_ specifies the parent segment. The first segment of a _cell_ (with no _parent_) usually represents the soma. The shape is normally a cylinder (radii of the _proximal_ and _distal_ equal, but positions different) or a conical frustum (radii and positions different). If the x,y,x positions of the _proximal_ and _distal_ are equal, the segment can be interpreted as a sphere, and in this case the radii of these points must be equal. NOTE: LEMS does not yet support multicompartmental modelling, so the Dynamics here is only appropriate for single compartment modelling. </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">segment</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#segment"/>
+        <neuroml:exposes>length</neuroml:exposes>
+        <neuroml:exposes>radDist</neuroml:exposes>
+        <neuroml:exposes>surfaceArea</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/segmentGroup -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/segmentGroup">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">A method to describe a group of _segment_s in a _morphology_, e.g. soma_group, dendrite_group, axon_group. While a name is useful to describe the group, the _neuroLexId attribute can be used to explicitly specify the meaning of the group, e.g. sao1044911821 for &apos;Neuronal Cell Body&apos;, sao1211023249 for &apos;Dendrite&apos;. The _segment_s in this group can be specified as: a list of individual _member_ segments; a _path_, all of the segments along which should be included; a _subTree_ of the _cell_ to include; other segmentGroups to _include_ (so all segments from those get included here). An _inhomogeneousParameter_ can be defined on the region of the cell specified by this group (see _variableParameter_ for usage).</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">segmentGroup</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#segmentGroup"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/silentSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/silentSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseGradedSynapse"/>
+        <terms:description xml:lang="en">Dummy synapse which emits no current. Used as presynaptic endpoint for analog synaptic connection.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">silentSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#silentSynapse"/>
+        <neuroml:exposes>i</neuroml:exposes>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/sineGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/sineGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrent"/>
+        <terms:description xml:lang="en">Generates a sinusoidally varying current after a time _delay, for a fixed _duration. The _period and maximum _amplitude of the current can be set as well as the _phase at which to start. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">sineGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#sineGenerator"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>period</neuroml:hasParameter>
+        <neuroml:hasParameter>phase</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/sineGeneratorDL -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/sineGeneratorDL">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePointCurrentDL"/>
+        <terms:description xml:lang="en">Dimensionless equivalent of _sineGenerator_. Generates a sinusoidally varying current after a time _delay, for a fixed _duration. The _period and maximum _amplitude of the current can be set as well as the _phase at which to start. Scaled by _weight, if set</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">sineGeneratorDL</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#sineGeneratorDL"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>amplitude</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>period</neuroml:hasParameter>
+        <neuroml:hasParameter>phase</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/species -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/species">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Description of a chemical species identified by _ion, which has internal, _concentration, and external, _extConcentration values for its concentration</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">species</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#species"/>
+        <neuroml:exposes>concentration</neuroml:exposes>
+        <neuroml:exposes>extConcentration</neuroml:exposes>
+        <neuroml:hasParameter>initialConcentration</neuroml:hasParameter>
+        <neuroml:hasParameter>initialExtConcentration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/specificCapacitance -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/specificCapacitance">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Capacitance per unit area</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">specificCapacitance</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#specificCapacitance"/>
+        <neuroml:exposes>specCap</neuroml:exposes>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spike -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spike">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Emits a single spike at the specified _time</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spike</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spike"/>
+        <neuroml:exposes>spiked</neuroml:exposes>
+        <neuroml:hasParameter>time</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeArray -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeArray">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Set of spike ComponentTypes, each emitting one spike at a certain time. Can be used to feed a predetermined spike train into a cell</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeArray</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeArray"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGenerator -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGenerator">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Simple generator of spikes at a regular interval set by _period</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGenerator</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGenerator"/>
+        <neuroml:exposes>tnext</neuroml:exposes>
+        <neuroml:hasParameter>period</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGeneratorPoisson -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGeneratorPoisson">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Generator of spikes whose ISI is distributed according to an exponential PDF with scale: 1 / _averageRate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGeneratorPoisson</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGeneratorPoisson"/>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:hasParameter>averageRate</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGeneratorRandom -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGeneratorRandom">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseSpikeSource"/>
+        <terms:description xml:lang="en">Generator of spikes with a random interspike interval of at least _minISI and at most _maxISI</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGeneratorRandom</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGeneratorRandom"/>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnext</neuroml:exposes>
+        <neuroml:hasParameter>maxISI</neuroml:hasParameter>
+        <neuroml:hasParameter>minISI</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeGeneratorRefPoisson -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeGeneratorRefPoisson">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/spikeGeneratorPoisson"/>
+        <terms:description xml:lang="en">Generator of spikes whose ISI distribution is the maximum entropy distribution over [ _minimumISI, +infinity ) with mean: 1 / _averageRate</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeGeneratorRefPoisson</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeGeneratorRefPoisson"/>
+        <neuroml:hasParameter>minimumISI</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/spikeThresh -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/spikeThresh">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Membrane potential at which to emit a spiking event. Note, usually the spiking event will not be emitted again until the membrane potential has fallen below this value and rises again to cross it in a positive direction</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">spikeThresh</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#spikeThresh"/>
+        <neuroml:hasParameter>value</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/stdpSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/stdpSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/expTwoSynapse"/>
+        <terms:description xml:lang="en">Spike timing dependent plasticity mechanism,  NOTE: EXAMPLE NOT YET WORKING!!!! cno_0000034</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">stdpSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#stdpSynapse"/>
+        <neuroml:exposes>M</neuroml:exposes>
+        <neuroml:exposes>P</neuroml:exposes>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/subGate -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/subGate">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Gate composed of subgates contributing with fractional conductance</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">subGate</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#subGate"/>
+        <neuroml:exposes>inf</neuroml:exposes>
+        <neuroml:exposes>q</neuroml:exposes>
+        <neuroml:exposes>qfrac</neuroml:exposes>
+        <neuroml:exposes>tau</neuroml:exposes>
+        <neuroml:hasParameter>fractionalConductance</neuroml:hasParameter>
+        <neuroml:requires>rateScale</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/subTree -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/subTree">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Include all the _segment_s distal to that specified by _from_ in the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">subTree</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#subTree"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/synapticConnection -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/synapticConnection">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/explicitConnection"/>
+        <terms:description xml:lang="en">Explicit event connection between named components, which gets processed via a new instance of a _synapse component which is created on the target component</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">synapticConnection</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#synapticConnection"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/synapticConnectionWD -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/synapticConnectionWD">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/synapticConnection"/>
+        <terms:description xml:lang="en">Explicit event connection between named components, which gets processed via a new instance of a _synapse component which is created on the target component, includes setting of _weight and _delay for the synaptic connection</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">synapticConnectionWD</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#synapticConnectionWD"/>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>weight</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/tauInfTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/tauInfTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">KS Transition specified in terms of time constant _tau_ and steady state _inf_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">tauInfTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#tauInfTransition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/timedSynapticInput -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/timedSynapticInput">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking"/>
+        <terms:description xml:lang="en">Spike array connected to a single _synapse, producing a current triggered by each _spike_ in the array.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">timedSynapticInput</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#timedSynapticInput"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:exposes>tsince</neuroml:exposes>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/to -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/to">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">In a _path_, specifies which _segment (inclusive) up to which to calculate the _segmentGroup_</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">to</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#to"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/transientPoissonFiringSynapse -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/transientPoissonFiringSynapse">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrentSpiking"/>
+        <terms:description xml:lang="en">Poisson spike generator firing at _averageRate after a _delay and for a _duration, connected to single _synapse that is triggered every time a spike is generated, providing an input current.                       Similar to ComponentType _poissonFiringSynapse_.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">transientPoissonFiringSynapse</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#transientPoissonFiringSynapse"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:eventPort>spike</neuroml:eventPort>
+        <neuroml:exposes>isi</neuroml:exposes>
+        <neuroml:exposes>tnextIdeal</neuroml:exposes>
+        <neuroml:exposes>tnextUsed</neuroml:exposes>
+        <neuroml:exposes>tsince</neuroml:exposes>
+        <neuroml:hasParameter>averageRate</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/tsodyksMarkramDepFacMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/tsodyksMarkramDepFacMechanism">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePlasticityMechanism"/>
+        <terms:description xml:lang="en">Full Tsodyks-Markram STP model with both depression and facilitation, as in Tsodyks, Pawelzik and Markram 1998.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">tsodyksMarkramDepFacMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#tsodyksMarkramDepFacMechanism"/>
+        <neuroml:hasParameter>initReleaseProb</neuroml:hasParameter>
+        <neuroml:hasParameter>tauFac</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRec</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/tsodyksMarkramDepMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/tsodyksMarkramDepMechanism">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/basePlasticityMechanism"/>
+        <terms:description xml:lang="en">Depression-only Tsodyks-Markram model, as in Tsodyks and Markram 1997.</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">tsodyksMarkramDepMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#tsodyksMarkramDepMechanism"/>
+        <neuroml:hasParameter>initReleaseProb</neuroml:hasParameter>
+        <neuroml:hasParameter>tauRec</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/vHalfTransition -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/vHalfTransition">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/KSTransition"/>
+        <terms:description xml:lang="en">Transition which specifies both the forward and reverse rates of transition</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">vHalfTransition</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#vHalfTransition"/>
+        <neuroml:hasParameter>gamma</neuroml:hasParameter>
+        <neuroml:hasParameter>tau</neuroml:hasParameter>
+        <neuroml:hasParameter>tauMin</neuroml:hasParameter>
+        <neuroml:hasParameter>vHalf</neuroml:hasParameter>
+        <neuroml:hasParameter>z</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/variableParameter -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/variableParameter">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <terms:description xml:lang="en">Specifies a _parameter (e.g. condDensity) which can vary its value across a _segmentGroup. The value is calculated from _value attribute of the _inhomogeneousValue_ subelement. This element is normally a child of _channelDensityNonUniform_, _channelDensityNonUniformNernst_ or _channelDensityNonUniformGHK_ and is used to calculate the value of the conductance, etc. which will vary on different parts of the cell. The _segmentGroup specified here needs to define an _inhomogeneousParameter_ (referenced from _inhomogeneousParameter in the _inhomogeneousValue_), which calculates a _variable (e.g. p) varying across the cell (e.g. based on the path length from soma), which is then used in the _value attribute of the _inhomogeneousValue_ (so for example condDensity = f(p))</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">variableParameter</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#variableParameter"/>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/voltageClamp -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/voltageClamp">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Voltage clamp. Applies a variable current _i to try to keep parent at _targetVoltage. Not yet fully tested!!! Consider using voltageClampTriple!!</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">voltageClamp</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#voltageClamp"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>simpleSeriesResistance</neuroml:hasParameter>
+        <neuroml:hasParameter>targetVoltage</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/voltageClampTriple -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/voltageClampTriple">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseVoltageDepPointCurrent"/>
+        <terms:description xml:lang="en">Voltage clamp with 3 clamp levels. Applies a variable current _i (through _simpleSeriesResistance) to try to keep parent cell at _conditioningVoltage until time _delay, _testingVoltage until _delay + _duration, and _returnVoltage afterwards. Only enabled if _active = 1. </terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">voltageClampTriple</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#voltageClampTriple"/>
+        <neuroml:eventPort>in</neuroml:eventPort>
+        <neuroml:hasParameter>active</neuroml:hasParameter>
+        <neuroml:hasParameter>conditioningVoltage</neuroml:hasParameter>
+        <neuroml:hasParameter>delay</neuroml:hasParameter>
+        <neuroml:hasParameter>duration</neuroml:hasParameter>
+        <neuroml:hasParameter>returnVoltage</neuroml:hasParameter>
+        <neuroml:hasParameter>simpleSeriesResistance</neuroml:hasParameter>
+        <neuroml:hasParameter>testingVoltage</neuroml:hasParameter>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/tvbo/neuroml/voltageConcDepBlockMechanism -->
+
+    <owl:Class rdf:about="https://w3id.org/tvbo/neuroml/voltageConcDepBlockMechanism">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/tvbo/neuroml/baseBlockMechanism"/>
+        <terms:description xml:lang="en">Synaptic blocking mechanism which varys with membrane potential across the synapse, e.g. in NMDA receptor mediated synapses</terms:description>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/tvbo/neuroml"/>
+        <rdfs:label xml:lang="en">voltageConcDepBlockMechanism</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.neuroml.org/schema/neuroml2#voltageConcDepBlockMechanism"/>
+        <neuroml:hasParameter>blockConcentration</neuroml:hasParameter>
+        <neuroml:hasParameter>scalingConc</neuroml:hasParameter>
+        <neuroml:hasParameter>scalingVolt</neuroml:hasParameter>
+        <neuroml:requires>v</neuroml:requires>
     </owl:Class>
     
 
@@ -50874,6 +54143,7 @@ to a task-appropriate range (e.g. omega in Hz).
         <skos:exactMatch rdf:resource="https://w3id.org/tvbo/CouplingInput"/>
         <skos:inScheme rdf:resource="https://w3id.org/tvbo"/>
         <skos:prefLabel xml:lang="en">CouplingInput</skos:prefLabel>
+        <skos:relatedMatch rdf:resource="http://www.neuroml.org/lems/0.7.6#Requirement"/>
     </rdf:Description>
     <rdf:Description rdf:about="https://w3id.org/tvbo/Deterministic">
         <rdfs:label xml:lang="en">Deterministic</rdfs:label>

--- a/tvbo/templates/neuroml/tvbo-neuroml-lems.xml.mako
+++ b/tvbo/templates/neuroml/tvbo-neuroml-lems.xml.mako
@@ -370,12 +370,14 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
   ct_parse_piecewise = ct['_parse_piecewise']
   ct_lems_dim = ct.get('lems_dim', lems_dim)
   ct_lems_sym = ct.get('lems_sym', lems_sym)
-  ct_has_i = ct.get('has_i_exposure', False)
   ct_has_v = ct.get('has_v_req', False)
   ct_ext_evs = set(ct.get('external_event_names', []))
   ct_synapse_extends = ct.get('synapse_extends', 'baseSynapse')
   ct_syn_inherited = set(ct.get('synapse_inherited_params', ()))
   ct_exposure_names = set(ct.get('synapse_exposure_names', ('i',)))
+  # A state or derived variable named for one of the base type's exposures
+  # fulfils that exposure (LEMS requires the subtype to provide it).
+  ct_expose = lambda n: ' exposure="%s"' % n if n in ct_exposure_names else ''
 %>\
 
   <!-- ── Synapse ComponentType: ${ct_dyn_id} (extends ${ct_synapse_extends}) ── -->
@@ -397,7 +399,7 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
 
     <Dynamics>
 % for sv_name, sv in ct_svs.items():
-      <StateVariable name="${sv_name}" dimension="${ct_lems_dim(getattr(sv, 'unit', None))}"/>
+      <StateVariable name="${sv_name}" dimension="${ct_lems_dim(getattr(sv, 'unit', None))}"${ct_expose(sv_name)}/>
 % endfor
 % for dv_name, dv in ct_dvs.items():
 <%
@@ -405,14 +407,13 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
   rhs = getattr(eq, 'rhs', None) if eq else None
   dv_dim = ct_lems_dim(getattr(dv, 'unit', None))
   pw_cases = ct_parse_piecewise(rhs) if rhs else None
-  dv_exposure = ' exposure="%s"' % dv_name if dv_name in ct_exposure_names else ''
 %>\
 % if rhs:
 % if pw_cases:
 % if len(pw_cases) == 1 and pw_cases[0][0] is None:
-      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${dv_exposure} value="${pw_cases[0][1]}"/>
+      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${ct_expose(dv_name)} value="${pw_cases[0][1]}"/>
 % else:
-      <ConditionalDerivedVariable name="${dv_name}" dimension="${dv_dim}"${dv_exposure}>
+      <ConditionalDerivedVariable name="${dv_name}" dimension="${dv_dim}"${ct_expose(dv_name)}>
 % for (cond_str, val_str) in pw_cases:
 % if cond_str is not None:
         <Case condition="${cond_str}" value="${val_str}"/>
@@ -423,7 +424,7 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
       </ConditionalDerivedVariable>
 % endif
 % else:
-      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${dv_exposure} value="${ct_lems_expr(rhs)}"/>
+      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${ct_expose(dv_name)} value="${ct_lems_expr(rhs)}"/>
 % endif
 % endif
 % endfor

--- a/tvbo/templates/neuroml/tvbo-neuroml-lems.xml.mako
+++ b/tvbo/templates/neuroml/tvbo-neuroml-lems.xml.mako
@@ -373,12 +373,17 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
   ct_has_i = ct.get('has_i_exposure', False)
   ct_has_v = ct.get('has_v_req', False)
   ct_ext_evs = set(ct.get('external_event_names', []))
+  ct_synapse_extends = ct.get('synapse_extends', 'baseSynapse')
+  ct_syn_inherited = set(ct.get('synapse_inherited_params', ()))
+  ct_exposure_names = set(ct.get('synapse_exposure_names', ('i',)))
 %>\
 
-  <!-- ── Synapse ComponentType: ${ct_dyn_id} (extends baseSynapse) ── -->
-  <ComponentType name="${ct_dyn_id}" extends="baseSynapse">
+  <!-- ── Synapse ComponentType: ${ct_dyn_id} (extends ${ct_synapse_extends}) ── -->
+  <ComponentType name="${ct_dyn_id}" extends="${ct_synapse_extends}">
 % for pname, p in ct_params.items():
+% if pname not in ct_syn_inherited:
     <Parameter name="${pname}" dimension="${ct_lems_dim(getattr(p, 'unit', None))}"/>
+% endif
 % endfor
 % for sv_name in ct_svs:
     <Parameter name="${sv_name}_0" dimension="${ct_lems_dim(getattr(ct_svs[sv_name], 'unit', None))}"/>
@@ -400,14 +405,14 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
   rhs = getattr(eq, 'rhs', None) if eq else None
   dv_dim = ct_lems_dim(getattr(dv, 'unit', None))
   pw_cases = ct_parse_piecewise(rhs) if rhs else None
-  is_i = (dv_name == 'i')
+  dv_exposure = ' exposure="%s"' % dv_name if dv_name in ct_exposure_names else ''
 %>\
 % if rhs:
 % if pw_cases:
 % if len(pw_cases) == 1 and pw_cases[0][0] is None:
-      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${ ' exposure="i"' if is_i else ''} value="${pw_cases[0][1]}"/>
+      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${dv_exposure} value="${pw_cases[0][1]}"/>
 % else:
-      <ConditionalDerivedVariable name="${dv_name}" dimension="${dv_dim}"${ ' exposure="i"' if is_i else ''}>
+      <ConditionalDerivedVariable name="${dv_name}" dimension="${dv_dim}"${dv_exposure}>
 % for (cond_str, val_str) in pw_cases:
 % if cond_str is not None:
         <Case condition="${cond_str}" value="${val_str}"/>
@@ -418,7 +423,7 @@ Variables available: dyn, dyn_id, params, svs, dvs, events,
       </ConditionalDerivedVariable>
 % endif
 % else:
-      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${ ' exposure="i"' if is_i else ''} value="${ct_lems_expr(rhs)}"/>
+      <DerivedVariable name="${dv_name}" dimension="${dv_dim}"${dv_exposure} value="${ct_lems_expr(rhs)}"/>
 % endif
 % endif
 % endfor


### PR DESCRIPTION
## What this does

Aligns tvbo with LEMS/NeuroML by ingesting the NeuroML2 core type definitions into the ontology and grounding the NeuroML adapter's emission in it. The headline capability it unlocks: tvbo can now emit **custom conductance-based synapses** (it previously could only emit current-based ones), demonstrated on the faithful Deco (2014) saturating NMDA gate.

## Three layers, one source of truth

1. **Ingest** — `scripts/ontology/gen_neuroml.py` walks the jNeuroML core types (pylems) and emits, in one deterministic pass:
   - `ontology/tvb-o-neuroml.ttl` — one OWL class per `ComponentType` (225 domain types), `extends` → `rdfs:subClassOf`, each `skos:exactMatch`-linked to its canonical NeuroML IRI. The reference from `tvbo.owl` to NeuroML-core, beside the GO link.
   - `tvbo/data/ontology/neuroml_contracts.json` — the `extends`-accumulated contract index the adapter loads (stdlib `json`, no owlready2/rdflib/pylems on the emit path).

   Wired into `make gen-neuroml`; merged into `tvbo.owl` by `gen-merged` (verified ELK-clean, no unsatisfiable classes).

2. **Bridge** — `ontology/tvb-o-neuroml-mappings.ttl` records the tvbo-core ↔ NeuroML/LEMS overlaps via SKOS mapping relations: meta-model correspondences (`Dynamics ↔ ComponentType`, `StateVariable`/`Parameter`/`DerivedVariable`/`Event ↔` LEMS peers) and role correspondences (synapse/cell/population/input branches).

3. **Ground the emitter** — the hardcoded `_BASE_TYPE_META` registry is replaced by `_base_type_meta()`, derived from the ontology contract index. Any base type resolves; a Dynamics may reference it by the `extends:` shorthand, the tvbo-scoped IRI, or the direct NeuroML IRI (all interchangeable). Adding a new NeuroML type needs ingestion + at most a mapping entry — no adapter code.

## The synapse win

The synapse path previously hardcoded `extends="baseSynapse"` (current-based, exposes only `i`). It now derives the base type + exposures from the ontology, so a synapse extending `baseConductanceBasedSynapse` inherits `gbase`/`erev`/`v` (not redeclared) and exposes `g`. The acceptance test authors the *faithful* Deco Eqs 3-4 saturating NMDA — two-ODE gate `ds/dt = -s/τ + α·x·(1-s)`, `dx/dt = -x/τ_rise`, spike-driven `OnEvent`, Mg²⁺ voltage block, conductance exposure — and verifies it emits as a conductance-based ComponentType that **PyLEMS validates against the real `baseConductanceBasedSynapse`**. No linear proxy.

## Scope note

The 4 builtin cell/channel/gate/rate base types keep their fixed emission structure (byte-identical) — NeuroML declares their synapse-hosting / gate-children / init structure on concrete descendants, not the abstract base, so that structure stays adapter-side while their semantic contracts derive from the ontology. Migrating those to generic hierarchy rules is a follow-up.

## Tests

- `tests/test_neuroml_ontology.py` — class hierarchy, synapse `subClassOf` chain, NeuroML cross-reference, accumulated contracts, generator determinism.
- `tests/functional/test_neuroml_custom_synapse.py` — the saturating-NMDA acceptance test (structure + PyLEMS validity).
- Existing NeuroML suite unchanged: **349 passed, 3 skipped**. The one failure (`test_run_brian2`) is a pre-existing environmental pyNeuroML-runner issue, not a regression.
