### PR TITLE
fix(codegen): lower both forms of a transform Function, from one declaration

### DIFF
--- a/tests/test_weight_transform_codegen.py
+++ b/tests/test_weight_transform_codegen.py
@@ -87,3 +87,108 @@ def test_rendered_tvboptim_source_inlines_the_transform():
     assert "jnp.log(1 + W)" in builder  # transform inlined in the builder
     assert "weights_matrix" not in builder  # not delegated to tvbo runtime
     assert "_apply_transform" not in builder
+
+
+# ── A transform is a Function: callable and equation are both lowered ───────────────────
+
+
+def _apply_emitted(net, weights, distances=None):
+    """Run the emitted const_env + per-transform env exactly as `create_network` does."""
+    transforms, const_env = weight_transform_codegen(net)
+    scope = {"jnp": jnp, "weights": jnp.asarray(weights),
+             "distances": None if distances is None else jnp.asarray(distances)}
+    for line in const_env:
+        exec(line, scope)
+    for expr, matrix_env in transforms:
+        for line in matrix_env:
+            exec(line, scope)
+        scope["weights"] = eval(expr, scope)
+    return np.asarray(scope["weights"])
+
+
+def test_a_callable_transform_reaches_the_kit():
+    """`Function.callable` lowers to an import and a call, matching the runtime.
+
+    Hopf_Pareto_ParallelOpt declares `normalized_graph_laplacian` this way. The codegen
+    used to skip any transform without an `equation:`, so with `experiment.py` handing over
+    raw weights the kit integrated the un-normalised SC — wrong numbers, no error.
+    """
+    from tvbo.datamodel.schema import Callable as CallableRef, Function
+
+    W = np.array([[0, 2.0, 1.0], [4.0, 0, 3.0], [1.0, 5.0, 0]])
+    net = Network.from_matrix(weights=W, lengths=np.zeros_like(W))
+    net.transforms = [Function(name="weight", callable=CallableRef(
+        module="tvbo.classes.network", name="normalized_graph_laplacian"))]
+
+    transforms, const_env = weight_transform_codegen(net)
+    assert len(transforms) == 1
+    assert any(line.startswith("from tvbo.classes.network import") for line in const_env)
+    assert np.allclose(_apply_emitted(net, W), np.asarray(net.weights_matrix))
+
+
+def test_equation_parameters_are_substituted_like_the_runtime():
+    """A scalar declared under `Equation.parameters` folds in, as `_apply_transform` does.
+
+    Reading only `Function.arguments` emitted the bare name into the kit, where it is
+    undefined.
+    """
+    from tvbo.datamodel.schema import Equation, Function
+
+    W = np.array([[0, 2.0], [4.0, 0]])
+    net = Network.from_matrix(weights=W, lengths=np.zeros_like(W))
+    net.transforms = [Function(name="weight",
+                               equation=Equation(rhs="W / k", parameters={"k": {"value": 4.0}}))]
+
+    (expr, _), = weight_transform_codegen(net)[0]
+    assert "k" not in expr
+    assert np.allclose(_apply_emitted(net, W), np.asarray(net.weights_matrix))
+
+
+def test_an_undeclared_symbol_fails_at_render_time():
+    """Better a render-time error than an undefined name in a kit that dies on the cluster."""
+    import pytest
+
+    net = Network.from_matrix(weights=np.array([[0, 1.0], [1.0, 0]]), lengths=np.zeros((2, 2)))
+    net.add_transform("weight", "W / k_undeclared")
+    with pytest.raises(ValueError, match="k_undeclared"):
+        weight_transform_codegen(net)
+
+
+def test_a_reduction_is_bound_once():
+    """`W_rowsum_safe` reuses one `_rs` binding instead of re-reducing per mention.
+
+    `create_network` runs eagerly, so XLA never gets to CSE the duplicate.
+    """
+    net = Network.from_matrix(weights=np.array([[0, 2.0], [4.0, 0]]), lengths=np.zeros((2, 2)))
+    net.add_transform("weight", "W / W_rowsum_safe")
+    _, matrix_env = weight_transform_codegen(net)[0][0]
+    assert sum(line.count("sum(axis=1") for line in matrix_env) == 1
+
+
+def test_transforms_for_matches_the_length_alias():
+    """One selector owns the `length`/`lengths` spelling for runtime and codegen alike."""
+    from tvbo.datamodel.schema import Equation, Function
+
+    net = Network.from_matrix(weights=np.zeros((2, 2)), lengths=np.zeros((2, 2)))
+    net.transforms = [
+        Function(name="lengths", equation=Equation(rhs="M * 2")),
+        Function(name="weight", equation=Equation(rhs="W * 3")),
+    ]
+    assert len(net.transforms_for("length")) == 1
+    assert len(net.transforms_for("lengths")) == 1
+    assert len(net.transforms_for("weight")) == 1
+
+
+def test_a_masked_expression_is_validated_by_its_base_symbol():
+    """`mean(W[W > 0])` is a use of `W`, not of a symbol literally named `W[W > 0]`.
+
+    Delay_Speed_Synchronization declares exactly that. Checking the raw free-symbol text
+    rejected it as undeclared and refused to render the recipe at all.
+    """
+    net = Network.from_matrix(weights=np.array([[0, 2.0, 0], [4.0, 0, 3.0], [0, 5.0, 0]]),
+                              lengths=np.zeros((3, 3)))
+    net.add_transform("weight", "W / mean(W[W > 0])")
+    (expr, matrix_env), = weight_transform_codegen(net)[0]
+    assert "W = weights" in matrix_env
+    assert np.allclose(_apply_emitted(net, np.asarray(net.raw_weights_matrix)),
+                       np.asarray(net.weights_matrix))

--- a/tests/test_weight_transform_codegen.py
+++ b/tests/test_weight_transform_codegen.py
@@ -95,8 +95,7 @@ def test_rendered_tvboptim_source_inlines_the_transform():
 def _apply_emitted(net, weights, distances=None):
     """Run the emitted const_env + per-transform env exactly as `create_network` does."""
     transforms, const_env = weight_transform_codegen(net)
-    scope = {"jnp": jnp, "weights": jnp.asarray(weights),
-             "distances": None if distances is None else jnp.asarray(distances)}
+    scope = {"jnp": jnp, "weights": jnp.asarray(weights), "distances": None if distances is None else jnp.asarray(distances)}
     for line in const_env:
         exec(line, scope)
     for expr, matrix_env in transforms:
@@ -117,8 +116,9 @@ def test_a_callable_transform_reaches_the_kit():
 
     W = np.array([[0, 2.0, 1.0], [4.0, 0, 3.0], [1.0, 5.0, 0]])
     net = Network.from_matrix(weights=W, lengths=np.zeros_like(W))
-    net.transforms = [Function(name="weight", callable=CallableRef(
-        module="tvbo.classes.network", name="normalized_graph_laplacian"))]
+    net.transforms = [
+        Function(name="weight", callable=CallableRef(module="tvbo.classes.network", name="normalized_graph_laplacian"))
+    ]
 
     transforms, const_env = weight_transform_codegen(net)
     assert len(transforms) == 1
@@ -136,10 +136,9 @@ def test_equation_parameters_are_substituted_like_the_runtime():
 
     W = np.array([[0, 2.0], [4.0, 0]])
     net = Network.from_matrix(weights=W, lengths=np.zeros_like(W))
-    net.transforms = [Function(name="weight",
-                               equation=Equation(rhs="W / k", parameters={"k": {"value": 4.0}}))]
+    net.transforms = [Function(name="weight", equation=Equation(rhs="W / k", parameters={"k": {"value": 4.0}}))]
 
-    (expr, _), = weight_transform_codegen(net)[0]
+    ((expr, _),) = weight_transform_codegen(net)[0]
     assert "k" not in expr
     assert np.allclose(_apply_emitted(net, W), np.asarray(net.weights_matrix))
 
@@ -185,10 +184,8 @@ def test_a_masked_expression_is_validated_by_its_base_symbol():
     Delay_Speed_Synchronization declares exactly that. Checking the raw free-symbol text
     rejected it as undeclared and refused to render the recipe at all.
     """
-    net = Network.from_matrix(weights=np.array([[0, 2.0, 0], [4.0, 0, 3.0], [0, 5.0, 0]]),
-                              lengths=np.zeros((3, 3)))
+    net = Network.from_matrix(weights=np.array([[0, 2.0, 0], [4.0, 0, 3.0], [0, 5.0, 0]]), lengths=np.zeros((3, 3)))
     net.add_transform("weight", "W / mean(W[W > 0])")
-    (expr, matrix_env), = weight_transform_codegen(net)[0]
+    ((expr, matrix_env),) = weight_transform_codegen(net)[0]
     assert "W = weights" in matrix_env
-    assert np.allclose(_apply_emitted(net, np.asarray(net.raw_weights_matrix)),
-                       np.asarray(net.weights_matrix))
+    assert np.allclose(_apply_emitted(net, np.asarray(net.raw_weights_matrix)), np.asarray(net.weights_matrix))

--- a/tvbo/classes/network.py
+++ b/tvbo/classes/network.py
@@ -2867,9 +2867,8 @@ class Network(tvbo_datamodel.Network):
             return None
 
         if apply_transforms:
-            for t in self.transforms or []:
-                if t.name == "weight":
-                    W = self._apply_transform(W, t)
+            for t in self.transforms_for("weight"):
+                W = self._apply_transform(W, t)
         return W
 
     @property
@@ -2938,9 +2937,8 @@ class Network(tvbo_datamodel.Network):
 
         # Apply transforms targeting "length" (mirrors weights_matrix; the
         # add_transform contract lists "length" as a valid edge-property target).
-        for t in self.transforms or []:
-            if t.name in ("length", "lengths"):
-                L = self._apply_transform(L.toarray() if _sp.issparse(L) else np.asarray(L), t)
+        for t in self.transforms_for("length"):
+            L = self._apply_transform(L.toarray() if _sp.issparse(L) else np.asarray(L), t)
         return L
 
     @property
@@ -4575,12 +4573,11 @@ class Network(tvbo_datamodel.Network):
             return None
 
         # Apply transforms targeting this matrix
-        for t in self.transforms or []:
-            if t.name == name:
-                mat = self._apply_transform(
-                    mat.toarray() if sparse.issparse(mat) else np.asarray(mat),
-                    t,
-                )
+        for t in self.transforms_for(name):
+            mat = self._apply_transform(
+                mat.toarray() if sparse.issparse(mat) else np.asarray(mat),
+                t,
+            )
 
         if format is None:
             return mat
@@ -4722,6 +4719,54 @@ class Network(tvbo_datamodel.Network):
                 return e
         return None
 
+    def transforms_for(self, target: str):
+        """The declared `transforms:` that retarget *target*, in declaration order.
+
+        The one place the target name is matched, so `length` and its `lengths` spelling
+        stay equivalent everywhere and a new alias is added once. Both the runtime and the
+        emitters that inline a transform into a generated script select through this.
+
+        Args:
+            target: Edge property a transform retargets, e.g. `"weight"` or `"length"`.
+
+        Returns:
+            List of `Function` transforms declared against *target*.
+        """
+        names = ("length", "lengths") if target in ("length", "lengths") else (target,)
+        return [t for t in (self.transforms or []) if getattr(t, "name", None) in names]
+
+    def transform_expression(self, func):
+        """A transform's equation as a sympy expression, with its arguments substituted.
+
+        Shared by the runtime and by codegen so a spec resolves to the same expression on
+        both paths. Scalar values come from `Function.arguments`, falling back to
+        `Equation.parameters` for legacy specs.
+
+        Args:
+            func: The `Function` transform.
+
+        Returns:
+            The substituted expression, or `None` when *func* declares no equation
+            (a callable-based transform) or the equation does not parse.
+        """
+        eq = getattr(func, "equation", None)
+        if eq is None:
+            return None
+        from tvbo.codegen.code import parse_eq
+
+        arg_values: dict = {}
+        for name, a in (getattr(func, "arguments", {}) or {}).items():
+            arg_values[name] = getattr(a, "value", None)
+        if getattr(eq, "parameters", None):
+            for pname, pval in eq.parameters.items():
+                arg_values.setdefault(pname, getattr(pval, "value", pval))
+
+        exp = parse_eq(eq)
+        if exp is None:
+            return None
+        subs_map = {s: arg_values[str(s)] for s in exp.free_symbols if str(s) in arg_values}
+        return exp.subs(subs_map) if subs_map else exp
+
     def _apply_transform(self, M, func):
         """Apply a Function transform to matrix *M*.
 
@@ -4756,48 +4801,14 @@ class Network(tvbo_datamodel.Network):
                 return fn(M, **kwargs)
 
         # Equation-based transform
-        eq = getattr(func, "equation", None)
-        if eq is None:
+        exp = self.transform_expression(func)
+        if exp is None:
             return M
-        from tvbo.codegen.code import parse_eq, render_expression
+        from tvbo.codegen.code import render_expression
+        from tvbo.codegen.transforms import runtime_env
 
-        # Substitute scalar argument values: prefer Function.arguments, fall
-        # back to Equation.parameters for legacy specs.
-        arg_values: dict = {}
-        for name, a in func.arguments.items():  # arguments keyed by name
-            arg_values[name] = getattr(a, "value", None)
-        if hasattr(eq, "parameters") and eq.parameters:
-            for pname, pval in eq.parameters.items():
-                arg_values.setdefault(pname, getattr(pval, "value", pval))
-
-        exp = parse_eq(eq)
-        if exp is not None:
-            subs_map = {s: arg_values[str(s)] for s in exp.free_symbols if str(s) in arg_values}
-            if subs_map:
-                exp = exp.subs(subs_map)
-
-        # Generic primitives available to any equation transform.
-        # *_safe variants substitute 1 for zero entries so isolated nodes
-        # do not produce NaNs under row/column normalisation.
-        L = self.lengths_matrix
-        _rs = M.sum(axis=1, keepdims=True)
-        _cs = M.sum(axis=0, keepdims=True)
-        env = {
-            "M": M,
-            "W": M,
-            "L": L,
-            "M_min": jnp.nanmin(M),
-            "W_min": jnp.nanmin(M),
-            "M_max": jnp.nanmax(M),
-            "W_max": jnp.nanmax(M),
-            "W_rowsum": _rs,
-            "W_colsum": _cs,
-            "W_rowsum_safe": jnp.where(_rs > 0, _rs, 1.0),
-            "W_colsum_safe": jnp.where(_cs > 0, _cs, 1.0),
-            "jnp": jnp,
-            "np": jnp,
-            "jsp": jsp,
-        }
+        _is_length = getattr(func, "name", None) in ("length", "lengths")
+        env = runtime_env(M, M if _is_length else self.lengths_matrix, jnp, jsp)
         # Expose declared per-node parameters as (n, 1) column vectors, so a symbolic
         # weight transform can normalise per target region — e.g. ``W / roi_size`` divides
         # each target row by that region's size (Deco's fibers-per-neuron SC). Column

--- a/tvbo/codegen/transforms.py
+++ b/tvbo/codegen/transforms.py
@@ -1,0 +1,102 @@
+"""The matrix-transform vocabulary, declared once for the runtime and for codegen.
+
+A `transforms:` entry is a `Function`, so it is either equation-based or callable-based, and
+a symbolic one is written against a small vocabulary of primitives — `W`, `W_max`,
+`W_rowsum_safe`, `L`, plus the network's per-node parameter vectors. Both the runtime
+evaluator (`Network._apply_transform`) and the emitters that inline a transform into a
+generated script need that vocabulary, and a second hand-written copy of it drifts: the
+runtime is where a transform author adds a primitive, so the emitted kit is the side that
+silently goes wrong.
+
+Each primitive is therefore declared once, as a source expression over two base names —
+`_M`, the matrix being transformed, and `_L`, the lengths. The runtime evaluates those
+strings; an emitter prints them. Neither can define a primitive the other lacks.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+BASE_MATRIX = "_M"
+BASE_LENGTHS = "_L"
+
+PRELUDE: Tuple[Tuple[str, str], ...] = (
+    ("_rs", f"{BASE_MATRIX}.sum(axis=1, keepdims=True)"),
+    ("_cs", f"{BASE_MATRIX}.sum(axis=0, keepdims=True)"),
+)
+
+PRIMITIVES: Dict[str, str] = {
+    "M": BASE_MATRIX,
+    "W": BASE_MATRIX,
+    "M_min": f"jnp.nanmin({BASE_MATRIX})",
+    "W_min": f"jnp.nanmin({BASE_MATRIX})",
+    "M_max": f"jnp.nanmax({BASE_MATRIX})",
+    "W_max": f"jnp.nanmax({BASE_MATRIX})",
+    "W_rowsum": "_rs",
+    "W_colsum": "_cs",
+    "W_rowsum_safe": "jnp.where(_rs > 0, _rs, 1.0)",
+    "W_colsum_safe": "jnp.where(_cs > 0, _cs, 1.0)",
+    "L": BASE_LENGTHS,
+}
+
+DATA_DERIVED = frozenset({"L"})
+"""Primitives that do not depend on the matrix under transform.
+
+An emitter binds these once; everything else is rebound per transform so a chain of
+transforms sees the preceding one's output.
+"""
+
+
+def required_prelude(symbols: Iterable[str]) -> List[Tuple[str, str]]:
+    """The prelude bindings *symbols* transitively need, in declaration order."""
+    wanted = {s for s in symbols if s in PRIMITIVES}
+    exprs = " ".join(PRIMITIVES[s] for s in wanted)
+    return [(name, expr) for name, expr in PRELUDE if name in exprs]
+
+
+def runtime_env(matrix, lengths, jnp, jsp=None) -> Dict[str, object]:
+    """Evaluate every primitive against live arrays.
+
+    Args:
+        matrix: The matrix under transform, bound to `M`/`W`.
+        lengths: The network's length matrix, bound to `L`.
+        jnp: The array module the primitive expressions are written against.
+        jsp: Optional scipy namespace, exposed to transform equations that use it.
+
+    Returns:
+        Mapping of every primitive name to its value, plus the array modules.
+    """
+    scope: Dict[str, object] = {BASE_MATRIX: matrix, BASE_LENGTHS: lengths, "jnp": jnp}
+    for name, expr in PRELUDE:
+        scope[name] = eval(expr, dict(scope))
+    env = {name: eval(expr, dict(scope)) for name, expr in PRIMITIVES.items()}
+    env.update(jnp=jnp, np=jnp, jsp=jsp)
+    return env
+
+
+def emit_env(symbols: Sequence[str], matrix: str, lengths: str) -> Tuple[List[str], List[str]]:
+    """Source lines binding the primitives *symbols* uses, for an emitted script.
+
+    Args:
+        symbols: Free symbols of the transform expression; anything outside
+            `PRIMITIVES` is ignored here and handled by the caller.
+        matrix: Expression the emitted code calls the matrix under transform.
+        lengths: Expression the emitted code calls the length matrix.
+
+    Returns:
+        A `(matrix_lines, data_lines)` pair. `matrix_lines` must be re-emitted for
+        each transform in a chain; `data_lines` are bound once.
+    """
+    used = [s for s in dict.fromkeys(symbols) if s in PRIMITIVES]
+    if not used:
+        return [], []
+
+    def _bind(expr: str) -> str:
+        return expr.replace(BASE_MATRIX, matrix).replace(BASE_LENGTHS, lengths)
+
+    matrix_lines = [f"{name} = {_bind(expr)}" for name, expr in required_prelude(used)]
+    data_lines: List[str] = []
+    for s in used:
+        line = f"{s} = {_bind(PRIMITIVES[s])}"
+        (data_lines if s in DATA_DERIVED else matrix_lines).append(line)
+    return matrix_lines, data_lines

--- a/tvbo/templates/tvboptim/tvbo-tvboptim-experiment.py.mako
+++ b/tvbo/templates/tvboptim/tvbo-tvboptim-experiment.py.mako
@@ -259,6 +259,7 @@ conduction_speed = float(_cs.value if hasattr(_cs, 'value') else _cs) if _cs is 
 from tvbo.templates.tvboptim.utils import weight_transform_codegen as _weight_transform_codegen
 weight_transform_jax, weight_transform_const_env = _weight_transform_codegen(network)
 has_weight_transforms = bool(weight_transform_jax)
+weight_transform_needs_lengths = any(_l.startswith("L = ") for _l in weight_transform_const_env)
 
 # Simulation parameters
 assert integration.duration, "integration.duration required in YAML"
@@ -1578,9 +1579,10 @@ _TVBO_DYNAMICS_CLS = ${dynamics_class}
 
 def create_network(
     weights: jnp.ndarray,
-    % if use_length_graph:
+    % if use_length_graph or weight_transform_needs_lengths:
     distances: jnp.ndarray = None,
-    % elif use_delay_graph:
+    % endif
+    % if use_delay_graph and not use_length_graph:
     delays: jnp.ndarray = None,
     % endif
     region_labels: list = None,
@@ -1593,6 +1595,10 @@ def create_network(
 ) -> Network:
 % if has_weight_transforms:
     # Declared weight `transforms:` applied to the raw weights (kit stays self-contained).
+% if weight_transform_needs_lengths:
+    if distances is None:
+        distances = jnp.zeros_like(weights)
+% endif
 % for _line in weight_transform_const_env:
     ${_line}
 % endfor
@@ -4641,7 +4647,8 @@ if __name__ == "__main__":
         observational_measures=${observational_measures},
 % endif
     )
-    weights = _network.weights_matrix
+    # weights RAW — create_network applies the declared transforms.
+    weights = _network.raw_weights_matrix
     distances = _network.lengths_matrix
     # Get region labels safely (may not be available in all BIDS datasets)
     try:

--- a/tvbo/templates/tvboptim/utils.py
+++ b/tvbo/templates/tvboptim/utils.py
@@ -824,10 +824,7 @@ def weight_transform_codegen(network) -> Tuple[List[Tuple[str, List[str]]], List
         if c is not None:
             alias = f"_tf_{c.name}"
             _add_const(alias, f"from {c.module} import {c.name} as {alias}")
-            args = "".join(
-                f", {n}={getattr(a, 'value', None)!r}"
-                for n, a in (getattr(t, "arguments", {}) or {}).items()
-            )
+            args = "".join(f", {n}={getattr(a, 'value', None)!r}" for n, a in (getattr(t, "arguments", {}) or {}).items())
             transforms.append((f"{alias}(weights{args})", []))
             continue
 

--- a/tvbo/templates/tvboptim/utils.py
+++ b/tvbo/templates/tvboptim/utils.py
@@ -776,73 +776,81 @@ def get_node_param_overrides(network: Any, n_nodes: int, dyn_param_defaults: Dic
     return overrides
 
 
-_WEIGHT_TRANSFORM_ENV = {
-    "W": "W = weights",
-    "M": "M = weights",
-    "W_min": "W_min = jnp.nanmin(weights)",
-    "M_min": "M_min = jnp.nanmin(weights)",
-    "W_max": "W_max = jnp.nanmax(weights)",
-    "M_max": "M_max = jnp.nanmax(weights)",
-    "W_rowsum": "W_rowsum = weights.sum(axis=1, keepdims=True)",
-    "W_colsum": "W_colsum = weights.sum(axis=0, keepdims=True)",
-    "W_rowsum_safe": "W_rowsum_safe = jnp.where(weights.sum(axis=1, keepdims=True) > 0, weights.sum(axis=1, keepdims=True), 1.0)",
-    "W_colsum_safe": "W_colsum_safe = jnp.where(weights.sum(axis=0, keepdims=True) > 0, weights.sum(axis=0, keepdims=True), 1.0)",
-    "L": "L = distances",
-}
-
-
 def weight_transform_codegen(network) -> Tuple[List[Tuple[str, List[str]]], List[str]]:
     """Render `transforms:` targeting weight to JAX for inlining in the generated script.
 
-    Mirrors ``Network._apply_transform`` (same ``parse_eq`` + JaxPrinter path), so the code
-    the kit ships applies the declared transform byte-identically to the runtime — but
-    visibly, with pure ``jnp``, on the RAW weights the generated ``create_network`` is
-    handed. Keeps a frozen/standalone kit self-contained and tvbo-independent at run time:
-    raw SC stays in the network file, the transform stays declared in the spec, and the
-    exact op is in the script rather than hidden in tvbo runtime. This helper itself runs
-    only at render time (in the tvbo environment).
+    A transform is a `Function`, so both of its forms are lowered: an `equation:` renders
+    through the same expression resolver and primitive table the runtime evaluates
+    (`Network.transform_expression`, `tvbo.codegen.transforms`), and a `callable:` renders
+    as an import of that callable plus a call. The kit therefore applies the declared
+    transform exactly as the runtime does, but visibly, on the RAW weights the generated
+    `create_network` is handed — raw SC stays in the network file, the transform stays
+    declared in the spec, and the operation is in the script rather than hidden in the tvbo
+    runtime. This helper runs only at render time, inside the tvbo environment.
 
-    Returns ``(transforms, const_env)``: ``transforms`` is a list of
-    ``(jax_expr, matrix_env)`` where ``matrix_env`` recomputes matrix-derived symbols
-    (``W``, ``W_min`` …) from the current ``weights`` so sequential transforms compose;
-    ``const_env`` defines data-derived symbols (``L``, per-node parameter vectors) once.
+    Args:
+        network: The `Network` whose transforms are being lowered.
+
+    Returns:
+        A `(transforms, const_env)` pair. `transforms` is a list of
+        `(jax_expr, matrix_env)`; `matrix_env` rebinds matrix-derived primitives from the
+        current `weights` so a chain of transforms composes. `const_env` binds
+        data-derived symbols — `L`, per-node parameter vectors, imported callables — once.
+
+    Raises:
+        ValueError: If a transform equation names a symbol that is neither a primitive,
+            a declared per-node parameter, nor a substituted argument. Failing here beats
+            emitting an undefined name into a kit that only dies once it reaches a cluster.
+            Symbols are checked by base identifier, so a masked expression such as
+            `mean(W[W > 0])` is validated — and bound — as `W`.
     """
     import numpy as np
 
     from tvbo.codegen.code import render_expression
-    from tvbo.parse.expression import parse_eq
+    from tvbo.codegen.transforms import PRIMITIVES, emit_env
 
     node_vectors = getattr(network, "node_parameter_vectors", {}) or {}
     transforms: List[Tuple[str, List[str]]] = []
     const_env: List[str] = []
     const_seen: Set[str] = set()
-    for t in getattr(network, "transforms", None) or []:
-        if getattr(t, "name", None) != "weight":
+
+    def _add_const(name: str, line: str) -> None:
+        if name not in const_seen:
+            const_env.append(line)
+            const_seen.add(name)
+
+    for t in network.transforms_for("weight"):
+        c = getattr(t, "callable", None)
+        if c is not None:
+            alias = f"_tf_{c.name}"
+            _add_const(alias, f"from {c.module} import {c.name} as {alias}")
+            args = "".join(
+                f", {n}={getattr(a, 'value', None)!r}"
+                for n, a in (getattr(t, "arguments", {}) or {}).items()
+            )
+            transforms.append((f"{alias}(weights{args})", []))
             continue
-        eq = getattr(t, "equation", None)
-        if eq is None:
-            continue
-        exp = parse_eq(eq)
+
+        exp = network.transform_expression(t)
         if exp is None:
             continue
-        args = {name: getattr(a, "value", None) for name, a in (getattr(t, "arguments", {}) or {}).items()}
-        subs = {s: args[str(s)] for s in exp.free_symbols if str(s) in args}
-        if subs:
-            exp = exp.subs(subs)
         expr = render_expression(exp, format="jax")
-        matrix_env: List[str] = []
-        for s in sorted(str(sym) for sym in exp.free_symbols):
-            if s in _WEIGHT_TRANSFORM_ENV:
-                if s == "L":
-                    if s not in const_seen:
-                        const_env.append(_WEIGHT_TRANSFORM_ENV[s])
-                        const_seen.add(s)
-                else:
-                    matrix_env.append(_WEIGHT_TRANSFORM_ENV[s])
-            elif s in node_vectors and s not in const_seen:
+        if "jsp." in expr:
+            _add_const("jsp", "import jax.scipy as jsp")
+        symbols = sorted({str(sym).split("[", 1)[0] for sym in exp.free_symbols})
+        matrix_env, data_env = emit_env(symbols, "weights", "distances")
+        for line in data_env:
+            _add_const(line.split(" = ", 1)[0], line)
+        for s in symbols:
+            if s in node_vectors:
                 vals = ", ".join(repr(float(v)) for v in np.asarray(node_vectors[s]).ravel())
-                const_env.append(f"{s} = jnp.asarray([{vals}]).reshape(-1, 1)")
-                const_seen.add(s)
+                _add_const(s, f"{s} = jnp.asarray([{vals}]).reshape(-1, 1)")
+            elif s not in PRIMITIVES:
+                raise ValueError(
+                    f"weight transform {getattr(t, 'name', '?')!r} references {s!r}, which is "
+                    f"neither a transform primitive nor a declared per-node parameter of this "
+                    f"network. Declare it as a Function argument, or add it to the network."
+                )
         transforms.append((expr, matrix_env))
     return transforms, const_env
 


### PR DESCRIPTION
**Stacked on #84** — review that first; this PR's diff is the two commits on top.

## The bug

A `transforms:` entry is a `Function`, so per the schema it is *"equation-based (symbolic) or software-based (callable)"*. The tvboptim emitter handled only `equation:` and skipped anything else — while `experiment.py` now hands the generated `create_network` the **raw** weights.

So `Hopf_Pareto_ParallelOpt.yaml`, whose weight transform is `callable: normalized_graph_laplacian`, integrated the **un-normalised connectome**. No error, no warning, wrong numbers — on a capability previously verified byte-identical.

## The root cause

The vocabulary a symbolic transform is written against (`W`, `W_max`, `W_rowsum_safe`, `L`, per-node vectors) was declared **twice**: as live values in `Network._apply_transform`, and as JAX source strings in the tvboptim template util. Nothing tied them together but a docstring claiming they mirrored each other, and they had already drifted — the copy lost the node-vector shape guard and the no-shadow rule, bound `L` to `distances` rather than the length matrix, and omitted the `jsp` import an `erf` transform needs.

`tvbo/codegen/transforms.py` now declares each primitive **once**, as a source expression over two base names (`_M`, `_L`). The runtime evaluates those strings; the emitter prints them. Neither side can define a primitive the other lacks.

Two helpers on `Network` back it:

- `transforms_for(target)` — owns the `length`/`lengths` alias and replaces **four** duplicated selection loops
- `transform_expression(func)` — resolves arguments, including the `Equation.parameters` fallback the emitter lacked

## Also fixed

- An unknown free symbol emitted an undefined name into the kit; it now fails at **render** time. Checked by base identifier, so `mean(W[W > 0])` is validated and bound as `W`.
- `distances` was a `create_network` parameter only under `use_length_graph`, so any length-dependent transform emitted `L = distances` against a name that did not exist — and the binding preceded the `None`-normalisation.
- The BIDS branch passed already-transformed weights, so a kit applied the transform **twice**.
- `W_rowsum_safe` recomputed its reduction two or three times per expression; `create_network` runs eagerly, so XLA never CSEs it.
- The equation branch bound `L` unconditionally, which **recursed** on a length-target transform.

## Verification

Emitted code compared against the runtime, not just asserted:

| case | result |
|---|---|
| `callable:` transform | matches runtime exactly — was silently dropped |
| 4 equation forms | match (`W/W_max`, `W/W_rowsum_safe`, `W/(L+1)`, min–max) |
| `Equation.parameters` | `W / k` becomes `0.25*W`, was an undefined name |
| unknown symbol | raises at render time |
| `erf` transform | emits `import jax.scipy as jsp`, was unrunnable |
| `W_rowsum_safe` | one `_rs` binding |

Six new tests. Full affected suite including `test_tvboptim_byte_identity.py`: **143 passed, 6 skipped**.

## Out of scope, worth its own issue

`render_expression` **drops the mask**: `W / mean(W[W > 0])` renders as `W/jnp.mean(W)`. Runtime and codegen agree because they share the printer, so nothing fails — but `Delay_Speed_Synchronization.yaml` says *"normalize so the mean non-zero weight is 1"* and that is not what runs. It lives in the sympy parse/print layer, not here.
