### PR TITLE
refactor(dynamics): the symbolic layer is an object, and every model carries it

### DIFF
--- a/tests/test_symbolic_layer.py
+++ b/tests/test_symbolic_layer.py
@@ -140,10 +140,10 @@ def test_the_cache_never_reaches_the_serialised_record(model: Dynamics):
     fails loudly — but a filter that stopped working would be caught by nothing else.
     """
     model.get_equations()
-    assert "_symbolic_cache" in model.__dict__
+    assert "_symbolic_system" in model.__dict__
 
     dumped = model.to_yaml()
-    assert "_symbolic_cache" not in dumped
+    assert "_symbolic_system" not in dumped
     assert "sympy" not in dumped
 
 
@@ -322,3 +322,93 @@ def test_the_parameter_map_substitutes_into_its_own_equations(model: Dynamics):
     substituted = symbolic["state"][0].rhs.subs(symbolic["parameters"])
     remaining = {str(s) for s in substituted.free_symbols}
     assert not (remaining & set(model.parameters)), f"parameters left unsubstituted: {remaining}"
+
+
+_RECIPE = {
+    "name": "TwoState",
+    "parameters": {"a": {"value": 2.0}},
+    "functions": {"f": {"arguments": {"u": {}}, "equation": {"rhs": "u * u"}}},
+    "derived_variables": {"g": {"equation": {"rhs": "f(x)"}}},
+    "state_variables": {
+        "x": {"equation": {"rhs": "a * y"}},
+        "y": {"equation": {"rhs": "-g"}},
+    },
+}
+
+
+@pytest.mark.backend_core
+def test_the_layer_is_on_a_dynamics_from_either_generator():
+    """A model gets the same equations whichever generator built it.
+
+    The layer is attached to the generated classes, not to a runtime subclass, so a model
+    an edge resolved or Pydantic validated answers as the runtime one does. Consumers used
+    to ask which kind they held and parse the metadata themselves when it was the plain
+    one — three copies of that dispatch, and a second parse of the same equation against a
+    namespace assembled differently.
+    """
+    from tvbo.datamodel import pydantic as pyd
+    from tvbo.datamodel import schema
+    from tvbo.utils import pydantic_loader
+
+    runtime = Dynamics(**_RECIPE)
+    built = (schema.Dynamics(**_RECIPE), pydantic_loader.validate(dict(_RECIPE), pyd.Dynamics))
+    forms = [model._symbolic_form() for model in built]
+
+    for form in forms:
+        for group, equations in runtime._symbolic_form().items():
+            assert {k: str(v) for k, v in form[group].items()} == {
+                k: str(v) for k, v in equations.items()
+            }, group
+
+
+@pytest.mark.backend_core
+def test_an_unfilled_model_answers_rather_than_raising():
+    """The two generators disagree on what an unfilled collection is, and the layer does not.
+
+    LinkML's dataclass defaults one to an empty collection and Pydantic's model to `None`,
+    so a layer written against either alone raises `AttributeError` on the other for a
+    model that simply declares nothing yet.
+    """
+    from tvbo.datamodel import pydantic as pyd
+    from tvbo.datamodel import schema
+
+    for cls in (schema.Dynamics, pyd.Dynamics):
+        bare = cls(name="empty")
+        assert sorted(bare.get_symbolic_elements()) == ["e", "t"], cls
+        assert all(group == {} for group in bare._symbolic_form().values()), cls
+        assert bare.symbol_map() == {} and bare.keyed_parameters == {}, cls
+
+
+@pytest.mark.backend_core
+def test_a_copy_gets_its_own_layer(model: Dynamics):
+    """A layer holds the model it was built for, so it must not travel to a copy.
+
+    Carried over, the clone's edits would neither invalidate the cache nor reach the scope:
+    it would be answering questions about the original.
+
+    Every copy protocol is checked, not only the runtime model's own `__copy__`: the layer
+    lives on the generated classes now, and `copy.copy` on one of those — or Pydantic's
+    `model_copy` — carries the attribute across with no hook to exclude it.
+    """
+    import copy
+
+    from tvbo.datamodel import pydantic as pyd
+    from tvbo.datamodel import schema
+    from tvbo.utils import pydantic_loader
+
+    model.get_equations()
+    clones = [copy.copy(model)]
+
+    for cls in (schema.Dynamics, pyd.Dynamics):
+        original = (
+            cls(**copy.deepcopy(_RECIPE))
+            if cls is schema.Dynamics
+            else pydantic_loader.validate(copy.deepcopy(_RECIPE), cls)
+        )
+        original._symbolic_form()
+        clones.append(original.model_copy() if hasattr(original, "model_copy") else copy.copy(original))
+
+    for clone in clones:
+        assert clone.symbolic_system.model is clone, type(clone)
+
+    assert clones[0].symbolic_system is not model.symbolic_system

--- a/tvbo/adapters/julia_model.py
+++ b/tvbo/adapters/julia_model.py
@@ -64,19 +64,11 @@ def symbol_names(model):
 def parse_namespace(model) -> dict:
     """How this model's equations parse, as keyword arguments for `parse_eq`.
 
-    Both flavours of model reach this adapter: the runtime `Dynamics` in `tvbo.classes`,
-    which carries the symbolic layer, and the generated `tvbo.datamodel.schema.Dynamics`
-    that a heterogeneous node's inline dynamics is, which has the collections but no layer
-    and must be parsed against its own names. Mirrors the dispatch in `function_bodies`.
+    Both flavours of model reach this adapter — the runtime `Dynamics` in `tvbo.classes`
+    and the generated one a heterogeneous node's inline dynamics is — and both carry the
+    symbolic layer, so both are parsed against the table that model's own equations were.
     """
-    elements = getattr(model, "get_symbolic_elements", None)
-    if elements is not None:
-        return {"local_dict": elements()}
-    sv, params, coupling, dvars, dparams = symbol_names(model)
-    return {
-        "parameters": sv + params + coupling + dvars + dparams,
-        "functions": [str(f) for f in model.functions],
-    }
+    return {"local_dict": model.get_symbolic_elements()}
 
 
 def equation_rhs_text(model) -> str:

--- a/tvbo/adapters/neuroml.py
+++ b/tvbo/adapters/neuroml.py
@@ -3161,7 +3161,7 @@ def build_lems_context(experiment):
     else:
         _lems_subs = {}
 
-    _bodies = function_bodies(dyn, parameters=all_names)
+    _bodies = function_bodies(dyn)
 
     def lems_expr(e):
         """Parse (if needed), inline model functions, then print as LEMS.
@@ -3327,7 +3327,7 @@ def build_lems_context(experiment):
             _LEMS_CMP_RE = re.compile(r"\.(gt|lt|geq|leq|eq|neq)\.", re.IGNORECASE)
 
             def _make_ct_lems_expr(ct_dyn, ct_all_names, ct_fn_names):
-                ct_bodies = function_bodies(ct_dyn, parameters=ct_all_names)
+                ct_bodies = function_bodies(ct_dyn)
 
                 def ct_lems_expr(e):
                     """Render *e* as LEMS, passing through text already written in it.

--- a/tvbo/analysis/units.py
+++ b/tvbo/analysis/units.py
@@ -265,13 +265,16 @@ class DimensionalClash(Exception):
     """Two quantities that must agree dimensionally do not."""
 
 
-def declared_units(model) -> dict:
+def declared_units(model, scope: dict | None = None) -> dict:
     """The third projection of the symbolic layer: `{scope symbol: declared unit}`.
 
     Keyed by the scope's own symbols, like `Dynamics.symbolic["parameters"]` — rebuilt
-    keys look identical, compare unequal, and would silently match nothing.
+    keys look identical, compare unequal, and would silently match nothing. A caller that
+    already holds the analysis scope passes it, so the map is keyed by the very table its
+    equations were parsed against rather than by whichever one the model resolves to.
     """
-    scope = model.get_symbolic_elements(time_dependent=True)
+    if scope is None:
+        scope = model.get_symbolic_elements(time_dependent=True)
     collections = (
         getattr(model, "parameters", None) or {},
         getattr(model, "state_variables", None) or {},

--- a/tvbo/behaviour/dynamics.py
+++ b/tvbo/behaviour/dynamics.py
@@ -1,0 +1,155 @@
+"""The symbolic layer, on every :class:`Dynamics` however it was built.
+
+Attached to the generated classes by name (``DynamicsBehaviour`` -> ``Dynamics``), so a
+model loaded through LinkML, validated through Pydantic or resolved onto an edge answers
+the same symbolic questions as one constructed through :mod:`tvbo.classes.dynamics`.
+
+That reach is the point. Consumers used to ask whether the model in hand had a symbolic
+layer and fall back to parsing its metadata directly when it did not — three copies of one
+dispatch, and two parses of the same equation against namespaces built differently.
+
+The equations themselves live on a [`SymbolicSystem`](../parse/system.qmd), one per model,
+held under a private attribute: both generated forms accept one without a slot and neither
+serializes it (``tests/test_spec_model_contract.py``).
+"""
+
+from __future__ import annotations
+
+
+class DynamicsBehaviour:
+    """A model's SymPy view of itself: one symbol table, one parse of each equation."""
+
+    @property
+    def symbolic_system(self):
+        """This model's [`SymbolicSystem`](../parse/system.qmd), built once and kept.
+
+        The symbolic layer is a service object rather than a further set of methods here: a
+        scope and the equations parsed against it must agree, and holding both in one place
+        makes that agreement — and the single point the cache is invalidated at — visible.
+
+        A layer holds the model it was built for, so one that arrived on a *different* model
+        is discarded and rebuilt. Every copy protocol carries the attribute across —
+        `copy.copy`, Pydantic's `model_copy`, unpickling — and a carried layer would answer
+        the clone's questions about the original: the clone's edits would neither invalidate
+        the cache nor reach the scope. Checking ownership here fixes all of them at once,
+        rather than one exclusion rule per copy hook.
+        """
+        system = self.__dict__.get("_symbolic_system")
+        if system is None or system.model is not self:
+            from tvbo.parse.system import SymbolicSystem
+
+            system = SymbolicSystem(self)
+            object.__setattr__(self, "_symbolic_system", system)
+        return system
+
+    def get_symbolic_elements(self, include_time_symbol: bool = True, time_dependent: bool = False):
+        """The symbol table this model's expressions are parsed against.
+
+        See [`SymbolicSystem.scope`](../parse/system.qmd#scope). Returns a copy, so a
+        caller may keep or adapt it.
+        """
+        return self.symbolic_system.scope(
+            include_time_symbol=include_time_symbol, time_dependent=time_dependent
+        )
+
+    def _symbolic_form(self, notation: str = "symbol", evaluate: bool = True):
+        """This model's parsed equations. See [`SymbolicSystem.form`](../parse/system.qmd#form)."""
+        return self.symbolic_system.form(notation=notation, evaluate=evaluate)
+
+    def get_equations(self, format: str = "metadata", evaluate: bool = True):
+        """Collect the model's equations as SymPy `Eq` objects.
+
+        The flat projection of [`SymbolicSystem.form`](../parse/system.qmd#form): derived
+        parameters, functions, derived variables, state equations (as time derivatives, or
+        plain maps for discrete systems), and output transformations.
+
+        It rides on the layer rather than on the runtime `Dynamics` because the consumers
+        that ask for it hold either flavour — a report's per-node model on a heterogeneous
+        network is the generated one, and promoting it to a runtime model just to ask
+        re-parsed every equation the layer already held.
+
+        Args:
+            format: Shape of the result. `"dict"` groups equations by category;
+                `"state-equations"` returns only state equations keyed by variable name;
+                any other value (e.g. `"metadata"`) returns a single flat mapping of
+                variable name to `Eq`.
+            evaluate: If `True`, let SymPy evaluate/simplify parsed right-hand sides; if
+                `False`, preserve authored term order.
+
+        Returns:
+            A mapping of equations whose structure depends on `format`.
+
+        Raises:
+            ValueError: If an entry in `output` names neither a derived nor a state
+                variable.
+        """
+        form = self._symbolic_form(notation="symbol", evaluate=evaluate)
+
+        if format == "state-equations":
+            return dict(form["state-equations"])
+        if format == "dict":
+            return {group: list(equations.values()) for group, equations in form.items()}
+        return {name: equation for group in form.values() for name, equation in group.items()}
+
+    @property
+    def symbolic(self):
+        """Full symbolic ODE system using proper SymPy conventions.
+
+        See [`SymbolicSystem.view`](../parse/system.qmd#view).
+
+        Example:
+            ```python
+            model.symbolic['state']    # [Eq(Derivative(theta(t), t), I + omega)]
+            model.symbolic['derived']  # [Eq(signal(t), sin(theta(t)))]
+            model.symbolic['units']    # {omega: 'per_ms', I: None}
+            ```
+        """
+        return self.symbolic_system.view()
+
+    @property
+    def keyed_parameters(self):
+        """Each parameter's symbol mapped to its value, keyed for the codegen view.
+
+        See [`SymbolicSystem.keyed_parameters`](../parse/system.qmd#keyed_parameters); this
+        is the view `get_equations` returns, which is what such a map is substituted into.
+        """
+        return self.symbolic_system.keyed_parameters()
+
+    def symbol_map(self):
+        """Display-symbol overrides for report rendering: ``{identifier Symbol: LaTeX str}``.
+
+        See [`SymbolicSystem.symbol_map`](../parse/system.qmd#symbol_map).
+        """
+        return self.symbolic_system.symbol_map()
+
+    def check_units(self, strictness: str = "dimensional", time_unit: str | None = None):
+        """Per-equation dimensional verdicts for this model.
+
+        See [`tvbo.analysis.units.check_units`](../analysis/units.qmd#check_units). Each
+        verdict is `consistent`, `inconsistent` or `underdetermined`; the third is a
+        distinct answer, not a soft failure, because 24 of the 39 curated models declare
+        no units and calling those wrong would pressure fake declarations into the
+        published record.
+        """
+        from tvbo.analysis.units import check_units
+
+        return check_units(self, strictness=strictness, time_unit=time_unit)
+
+    def _items(self):
+        """What the LinkML dumpers see: schema slots only.
+
+        Mirrors the guard on `Network`. `_symbolic_system` holds SymPy objects that
+        `yaml.SafeDumper` cannot represent, and LinkML slot names are never
+        underscore-prefixed, so excluding every leading-underscore key keeps this correct
+        as further caches are added rather than depending on a maintained denylist.
+
+        Only the LinkML form has slots to filter — Pydantic serializes through its own
+        machinery and offers nothing to delegate to — so the mixin yields nothing there
+        rather than raising on a `super()` that does not exist.
+        """
+        inherited = getattr(super(), "_items", None)
+        if inherited is None:
+            return
+        for k, v in inherited():
+            if not str(k).startswith("_"):
+                yield k, v

--- a/tvbo/classes/dynamics.py
+++ b/tvbo/classes/dynamics.py
@@ -10,10 +10,14 @@
 
 Defines [`DynamicalSystem`](#tvbo.classes.dynamics.DynamicalSystem) — the base
 class that augments the generated LinkML `Dynamics` datamodel with model
-construction and ontology resolution, a symbolic (SymPy) representation,
-equation normalization and dependency-ordered sorting, multi-backend code
-generation, simulation and bifurcation runs, plotting, and report export —
-together with the `Model` and `Dynamics` convenience subclasses.
+construction and ontology resolution, equation normalization and
+dependency-ordered sorting, multi-backend code generation, simulation and
+bifurcation runs, plotting, and report export — together with the `Model` and
+`Dynamics` convenience subclasses.
+
+The SymPy view of a model is not here. It is attached to the generated classes by
+[`DynamicsBehaviour`](../behaviour/dynamics.qmd), so a model answers symbolically however
+it was built, and the equations themselves live on a [`SymbolicSystem`](../parse/system.qmd).
 """
 
 import logging
@@ -31,7 +35,7 @@ import numpy as np
 import owlready2
 from tvbo.utils import initial_value, yaml_loader
 from matplotlib import colormaps
-from sympy import Derivative, Eq, Function, Symbol, latex
+from sympy import Eq, Symbol
 
 from tvbo import templates
 from tvbo.analysis import BifurcationResult
@@ -44,8 +48,7 @@ from tvbo.datamodel import schema as tvbo_datamodel
 from tvbo.datamodel.schema import Case, ConditionalBlock, DerivedVariable, Equation
 from tvbo.ontology import owl as ontology
 from tvbo.ontology import query
-from tvbo.parse.expression import function_bodies, parse_eq, states_an_expression
-from tvbo.parse.symbols import assumptions_of, symbol_in
+from tvbo.parse.expression import function_bodies, parse_eq
 from tvbo.utils import report
 
 logger = logging.getLogger(__name__)
@@ -641,9 +644,10 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
     """Enhanced base class for `Dynamics` adding Python-side behaviour.
 
     Wraps the generated LinkML `Dynamics` datamodel with the methods that
-    make a model usable: ontology resolution (`use_ontology=True`), symbolic
-    representation via SymPy, equation reordering, backend code generation,
-    YAML / JSON / Pydantic round-tripping, and matplotlib plotting hooks.
+    make a model usable: ontology resolution (`use_ontology=True`), equation
+    reordering, backend code generation, YAML / JSON / Pydantic round-tripping,
+    and matplotlib plotting hooks. The symbolic view comes from
+    [`DynamicsBehaviour`](../behaviour/dynamics.qmd), which every `Dynamics` carries.
 
     Most users should construct via [`Dynamics`](#tvbo.classes.dynamics.Dynamics)
     or `Dynamics.from_db(name)` — this class is the implementation base.
@@ -1049,459 +1053,6 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
             The ontology search matches for `search_str` within this model.
         """
         return ontology.search_in_model(search_str, self.ontology, **kwargs)
-
-    @property
-    def keyed_parameters(self):
-        """Mapping of each parameter as a SymPy `Symbol` to its numeric value."""
-        return {
-            Symbol(p.name): p.value for p in self.parameters.values()
-        }
-
-    @property
-    def symbolic(self):
-        """Full symbolic ODE system using proper SymPy conventions.
-
-        State variables are represented as ``Function(name)(t)`` so that
-        ``Derivative(theta(t), t)`` stays unevaluated.  Derived variables
-        and derived parameters are included as algebraic equations.
-
-        Returns
-        -------
-        dict
-            ``{'state': [...], 'derived': [...], 'parameters': {...}}``
-            where each list contains ``sympy.Eq`` objects and parameters
-            maps ``Symbol → value``. That map is keyed by the scope's own
-            symbols: rebuilt keys look identical, compare unequal, and make
-            substituting it into these equations silently replace nothing.
-
-        Example
-        -------
-        >>> model.symbolic['state']
-        [Eq(Derivative(theta(t), t), I + omega)]
-        >>> model.symbolic['derived']
-        [Eq(signal(t), sin(theta(t)))]
-        >>> model.symbolic['units']
-        {omega: 'per_ms', I: None}
-        """
-        from tvbo.analysis.units import declared_units
-
-        form = self._symbolic_form(notation="function")
-        scope = self.get_symbolic_elements(time_dependent=True)
-        return {
-            "state": list(form["state-equations"].values()),
-            "functions": list(form["functions"].values()),
-            "derived_parameters": list(form["derived-parameters"].values()),
-            "derived": list(form["derived-variables"].values()),
-            "parameters": {
-                scope[str(p.name)]: p.value
-                for p in self.parameters.values()
-                if str(p.name) in scope
-            },
-            "units": declared_units(self),
-        }
-
-    def check_units(self, strictness: str = "dimensional", time_unit: str | None = None):
-        """Per-equation dimensional verdicts for this model.
-
-        See [`tvbo.analysis.units.check_units`](../analysis/units.qmd#check_units). Each
-        verdict is `consistent`, `inconsistent` or `underdetermined`; the third is a
-        distinct answer, not a soft failure, because 24 of the 39 curated models declare
-        no units and calling those wrong would pressure fake declarations into the
-        published record.
-        """
-        from tvbo.analysis.units import check_units
-
-        return check_units(self, strictness=strictness, time_unit=time_unit)
-
-    def get_symbolic_elements(self, include_time_symbol: bool = True, time_dependent: bool = False):
-        """Build a unified local_dict for parsing model expressions.
-
-        Includes symbols for parameters, coupling terms, derived parameters, derived
-        variables, output transforms, state variables, event names, function names, and
-        (optionally) the time symbol 't'.
-
-        Every declared name must appear here so it shadows SymPy's own global namespace:
-        `Q` is SymPy's assumptions object, `S` its sympify shortcut, `O` big-O, `N`
-        numeric evaluation and `I` the imaginary unit, so a model that names a quantity
-        after any of them would otherwise fail to parse.
-
-        Args:
-            include_time_symbol: Bind `t` to `Symbol("t")`.
-            time_dependent: Bind state and derived variables to `Function(name)(t)` rather
-                than `Symbol(name)`, so `Derivative(x(t), t)` stays unevaluated and the
-                result reads as a system of ODEs. This is the only difference between the
-                two symbolic views of a model — everything downstream of the scope is
-                shared, which is why it is a parameter here and not a second builder.
-
-        Returns
-        -------
-        dict
-            Mapping of names to SymPy objects suitable for parse_eq(local_dict=...).
-            A copy, so a caller may keep or adapt it; the model's own is cached.
-        """
-        key = (bool(include_time_symbol), bool(time_dependent))
-        scopes = self._symbolic_state()["scopes"]
-        if key not in scopes:
-            scopes[key] = self._build_symbolic_elements(include_time_symbol, time_dependent)
-        return dict(scopes[key])
-
-    def _build_symbolic_elements(self, include_time_symbol: bool, time_dependent: bool):
-        """Assemble the symbol table. See `get_symbolic_elements`.
-
-        Holds only the names the *model* declares. A function's formal arguments are bound by
-        that function, exactly as a lambda binds its parameters, and are supplied as an
-        overlay while its body is parsed — see `_assemble_equations`. Registering them here
-        let a formal shadow a variable of the same name: `ReducedWongWangTvboptim` declares
-        both `H(x)` and a derived variable `x`, and the formal won, so the analysis view held
-        `x` constant and dropped the chain-rule term from every Jacobian through `H`.
-
-        Assumptions ride on the time-dependent view only. They are what SymPy's analysis
-        machinery needs — without `real=True` the fixed points of a two-variable model do
-        not come back inside a minute — but they also enter `Symbol.sort_key`, so the same
-        product prints as `q*alpha` instead of `alpha*q`. That is no gain for a backend
-        that parses, inlines and prints without ever simplifying, and every emitted file is
-        compared against a frozen reference. The codegen view therefore stays plain, and
-        the two are never mixed: a `Symbol` from one does not compare equal to the same name
-        from the other, so nothing can substitute across them by accident.
-
-        Function heads are the exception, and carry `assumptions_of()` in both views: a head
-        is notation-independent — `Sigm` is the same function whether the variables around it
-        are Symbols or Functions of `t`. Building it per view made `Function("Sigm", real=True)`
-        and `Function("Sigm")`, which print identically, compare unequal, and make
-        `expr.has(Sigm)` False on an expression that visibly calls it, so every inliner
-        matched nothing, silently.
-        """
-
-        def _assume(element=None):
-            return assumptions_of(element) if time_dependent else {}
-
-        def _symbol(name, element=None):
-            return Symbol(str(name), **_assume(element))
-
-        t = _symbol("t")
-        scope: dict[str, object] = {}
-
-        def _variable(name, element=None):
-            if time_dependent:
-                return Function(str(name), **_assume(element))(t)
-            return _symbol(name, element)
-
-        if include_time_symbol:
-            scope["t"] = t
-
-        for p in self.parameters.values():
-            scope[str(p.name)] = _symbol(p.name, p)
-
-        # Coupling inputs (named inputs from coupling function)
-        for ci in self.coupling_inputs.keys():
-            scope[str(ci)] = _symbol(ci)
-
-        # A derived parameter is constant in time, so it stays a Symbol in both views.
-        for name in self.derived_parameters.keys():
-            scope[str(name)] = _symbol(name)
-        for name, dv in self.derived_variables.items():
-            scope[str(name)] = _variable(name, dv)
-
-        # Output is a list of string references
-        for name in self.output:
-            scope[str(name)] = _variable(name, self.derived_variables.get(str(name)))
-
-        for name, sv in self.state_variables.items():
-            scope[str(name)] = _variable(name, sv)
-
-        for fname in self.functions:
-            scope[str(fname)] = Function(str(fname), **assumptions_of())
-
-        for name in self.events:
-            scope[str(name)] = _symbol(name)
-
-        if "e" not in scope:
-            from sympy import E
-
-            scope["e"] = E
-
-        return scope
-
-    _GROUP_COLLECTIONS = {
-        "derived-parameters": "derived_parameters",
-        "functions": "functions",
-        "derived-variables": "derived_variables",
-        "state-equations": "state_variables",
-        "output-transformations": "output",
-    }
-    """Which collection each equation group is built from, and takes its order from."""
-
-    def _equation_inputs(self):
-        """What `_build_symbolic_form` reads, split into content and order.
-
-        The cache is sound only if *content* changes whenever a built equation would, so it
-        walks the same collections the builder walks rather than a hand-listed subset: a
-        slot the builder starts reading without being added here would serve a stale
-        equation forever. Content is compared as dicts, which ignore key order.
-
-        *order* is tracked separately because `sort_equations` reorders collections into
-        dependency order without changing a single equation — five times over one load.
-        Treating that as a content change would re-parse everything to produce the same
-        expressions in a different sequence.
-        """
-
-        def _equation(element):
-            equation = getattr(element, "equation", None)
-            if equation is None:
-                return None
-            return (
-                equation.rhs,
-                tuple((c.condition, c.expression) for c in equation.conditionals),
-                bool(equation.latex),
-            )
-
-        def _assumed(element):
-            """Keyed on `assumptions_of` itself, so the key cannot drift from what it reads.
-
-            A `domain` is not an equation, but it decides whether a symbol is `positive` or
-            merely `real`, and `Symbol('a', positive=True) != Symbol('a', real=True)`. Naming
-            the fields here instead would leave the key stale the day `assumptions_of` starts
-            reading one more of them.
-            """
-            return tuple(sorted(assumptions_of(element).items()))
-
-        content = (
-            self.system_type,
-            {str(name): _assumed(p) for name, p in self.parameters.items()},
-            frozenset(str(name) for name in self.coupling_inputs),
-            frozenset(str(name) for name in self.events),
-            frozenset(str(name) for name in self.output),
-            {str(k): _equation(v) for k, v in self.derived_parameters.items()},
-            {str(k): (_equation(v), _assumed(v)) for k, v in self.derived_variables.items()},
-            {
-                str(k): (
-                    _equation(v),
-                    int(v.equation_order or 1) if v.equation_order else 1,
-                    _assumed(v),
-                )
-                for k, v in self.state_variables.items()
-            },
-            {
-                str(k): (tuple(str(a) for a in v.arguments), _equation(v))
-                for k, v in self.functions.items()
-            },
-        )
-        order = tuple(
-            tuple(str(name) for name in getattr(self, collection))
-            for collection in self._GROUP_COLLECTIONS.values()
-        )
-        return content, order
-
-    def _reordered(self, form):
-        """The same equations, re-keyed into their collections' current order."""
-        return {
-            group: {
-                name: equations[name]
-                for name in (str(n) for n in getattr(self, self._GROUP_COLLECTIONS[group]))
-                if name in equations
-            }
-            for group, equations in form.items()
-        }
-
-    def _symbolic_form(self, notation: str = "symbol", evaluate: bool = True):
-        """The model's equations, parsed once per (notation, evaluate) and remembered.
-
-        The single symbolic layer between a model's metadata and everything rendered from
-        it. Both public views — [`get_equations`](#tvbo.classes.dynamics.Dynamics.get_equations)
-        and [`symbolic`](#tvbo.classes.dynamics.Dynamics.symbolic) — are projections of
-        this, as is the function-body table the inliner consumes, so an equation is parsed
-        once no matter how many consumers ask for it.
-
-        Before this existed each caller re-derived from metadata: loading
-        `ZerlautAdaptationSecondOrder` parsed its 27 equations 264 times, and every
-        `render_code` and `generate_report` parsed all 27 again because nothing was kept.
-
-        The cache is discarded whole whenever `_equation_inputs` changes, which is what
-        makes it safe on a mutable model. Rendering is a query — `render_code` no longer
-        runs `update_metadata` — so no consumer can invalidate it mid-use.
-
-        Args:
-            notation: `"symbol"` binds variables to `Symbol(name)`; `"function"` binds
-                them to `Function(name)(t)`.
-            evaluate: Let SymPy evaluate right-hand sides, or preserve authored term order.
-
-        Returns:
-            `{group: {name: Eq}}` over the five groups, each keyed by the variable it
-            defines so no consumer has to recover a name from an `Eq`'s left-hand side.
-        """
-        forms = self._symbolic_state()["forms"]
-        key = (notation, bool(evaluate))
-        if key not in forms:
-            forms[key] = self._build_symbolic_form(notation, evaluate)
-        return forms[key]
-
-    def _symbolic_state(self):
-        """The per-content cache the symbol table and the equations share.
-
-        One invalidation point for both, because they have to agree: a scope built from one
-        set of names and equations parsed against another is precisely the drift this layer
-        exists to remove.
-
-        A reorder keeps the parsed equations and re-keys them; the scopes are dropped
-        instead, since rebuilding a symbol table is a few hundred `Symbol` constructions
-        while reparsing is the expensive half.
-        """
-        content, order = self._equation_inputs()
-        cache = self.__dict__.get("_symbolic_cache")
-        if cache is None or cache[0] != content:
-            cache = (content, order, {"scopes": {}, "forms": {}})
-        elif cache[1] != order:
-            reordered = {key: self._reordered(form) for key, form in cache[2]["forms"].items()}
-            cache = (content, order, {"scopes": {}, "forms": reordered})
-        else:
-            return cache[2]
-        object.__setattr__(self, "_symbolic_cache", cache)
-        return cache[2]
-
-    def _build_symbolic_form(self, notation: str, evaluate: bool):
-        """Parse every equation the model states, once. See `_symbolic_form`.
-
-        The two views differ in what they are for, and the evaluation policy follows from
-        that rather than the other way round.
-
-        `"symbol"` feeds codegen, which parses, inlines and prints. It honours the caller's
-        *evaluate* so a backend can keep the term order its author wrote.
-
-        `"function"` is the analysis view — the one `Matrix.jacobian`, `solve` and `dsolve`
-        act on — so it is canonical. It used to suppress evaluation globally, which kept
-        `Derivative(theta(t), t)` from collapsing but also left the right-hand sides in a
-        nested unevaluated form that SymPy's solvers cannot make progress on: asked for the
-        fixed points of `Generic2dOscillator` in that form, `solve` returns nothing in 45 s;
-        canonical and with real symbols it answers in under one. `Derivative` is built
-        explicitly here, so nothing needs the global suppression to survive.
-        """
-        time_dependent = notation == "function"
-        return self._assemble_equations(
-            time_dependent=time_dependent,
-            evaluate=True if time_dependent else evaluate,
-        )
-
-    def _assemble_equations(self, time_dependent: bool, evaluate: bool):
-        """Build the five equation groups against one scope. See `_build_symbolic_form`.
-
-        Every symbol an equation's left-hand side names is resolved through `scope` — the
-        same table the right-hand sides were parsed against. Minting one here instead
-        produces a name that prints identically and compares unequal once the analysis view
-        attaches assumptions, and `subs` across that mismatch replaces nothing rather than
-        raising: a derivative taken w.r.t. a freshly built `t` leaves `doit()` returning 0,
-        and a derived parameter's definition substitutes into none of its own equations.
-        """
-        scope = self.get_symbolic_elements(time_dependent=time_dependent)
-        t = symbol_in(scope, "t")
-        discrete = self.system_type == "discrete"
-
-        def _lhs(name):
-            return symbol_in(scope, name)
-
-        def _states(element):
-            """Whether the element has anything to parse — see `states_an_expression`.
-
-            An element declared with no `rhs` and no conditionals is skipped rather than
-            parsed. Every rendering path now funnels through here, so one such element used
-            to break all of them at once instead of only `get_equations`.
-            """
-            return states_an_expression(getattr(element, "equation", None))
-
-        def _parse(element, namespace=None):
-            return parse_eq(element.equation, local_dict=namespace or scope, evaluate=evaluate)
-
-        def _formal(name):
-            """A function's bound argument — a quantity, never a state, so never `name(t)`."""
-            return Symbol(str(name), **(assumptions_of() if time_dependent else {}))
-
-        def _function_scope(function):
-            """The model's names with this function's formals bound over them."""
-            return {**scope, **{str(a): _formal(a) for a in function.arguments}}
-
-        form = {
-            "derived-parameters": {
-                str(k): Eq(lhs=_lhs(k), rhs=_parse(dp))
-                for k, dp in self.derived_parameters.items()
-                if _states(dp)
-            },
-            "functions": {
-                str(k): Eq(
-                    lhs=_lhs(k)(*[_formal(a) for a in f.arguments]),
-                    rhs=_parse(f, _function_scope(f)),
-                )
-                for k, f in self.functions.items()
-                if _states(f) and f.arguments
-            },
-            "derived-variables": {
-                str(k): Eq(lhs=_lhs(k), rhs=_parse(dv))
-                for k, dv in self.derived_variables.items()
-                if _states(dv)
-            },
-            "state-equations": {},
-            "output-transformations": {},
-        }
-
-        for k, sv in self.state_variables.items():
-            if not _states(sv):
-                continue
-            order = int(sv.equation_order or 1)
-            lhs = _lhs(k) if discrete else Derivative(_lhs(k), *([t] * order))
-            form["state-equations"][str(k)] = Eq(lhs=lhs, rhs=_parse(sv))
-
-        # An identity equation for an output that IS a state variable overwrites its real one.
-        for name in self.output:
-            name = str(name)
-            if name in self.derived_variables:
-                if _states(self.derived_variables[name]):
-                    form["output-transformations"][name] = Eq(
-                        lhs=_lhs(name), rhs=_parse(self.derived_variables[name])
-                    )
-            elif name not in self.state_variables:
-                raise ValueError(
-                    f"Output variable '{name}' not found in derived_variables or state_variables"
-                )
-
-        return form
-
-    def _items(self):
-        """What the LinkML dumpers see: schema slots only.
-
-        Mirrors the guard on `Network`. `_symbolic_cache` holds SymPy objects that
-        `yaml.SafeDumper` cannot represent, and LinkML slot names are never
-        underscore-prefixed, so excluding every leading-underscore key keeps this correct
-        as further caches are added rather than depending on a maintained denylist.
-        """
-        for k, v in super()._items():
-            if not str(k).startswith("_"):
-                yield k, v
-
-    def symbol_map(self):
-        """Display-symbol overrides for report rendering: ``{identifier Symbol: LaTeX str}``.
-
-        For each element that declares a ``symbol`` (e.g. ``w_+`` for the identifier
-        ``w_plus``, or ``S^{(E)}`` for ``S_e``), map its identifier Symbol to the LaTeX
-        of that override, so ``sympy.latex(expr, symbol_names=model.symbol_map())``
-        renders the source's own notation. Elements without an override are omitted (they
-        render from their identifier). Fully sympy-native: the override is itself rendered
-        through ``sympy.latex(Symbol(...))``, inheriting Greek/sub/superscript handling.
-
-        Keyed by the canonical collection keys (the identifiers used in the equations),
-        over the same element collections as
-        [`get_symbolic_elements`](#tvbo.classes.dynamics.Dynamics.get_symbolic_elements).
-        """
-        collections = (
-            self.parameters,
-            self.state_variables,
-            self.derived_variables,
-            self.derived_parameters,
-            self.coupling_inputs,
-        )
-        return {
-            Symbol(str(key)): latex(Symbol(str(el.symbol)))
-            for coll in collections
-            for key, el in (coll or {}).items()
-            if getattr(el, "symbol", None)
-        }
 
     def update_metadata(self):
         """Normalize the model's equation metadata in place.
@@ -2107,40 +1658,6 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
             inline_funcs=inline_funcs,
             **kwargs,
         )
-
-    def get_equations(self, format="metadata", evaluate=True):
-        """Collect the model's equations as SymPy `Eq` objects.
-
-        Builds equations for derived parameters, functions, derived variables,
-        state equations (as time derivatives, or plain maps for discrete
-        systems), and output transformations.
-
-        Args:
-            format: Shape of the result. `"dict"` groups equations by
-                category; `"state-equations"` returns only state equations
-                keyed by variable name; any other value (e.g. `"metadata"`)
-                returns a single flat mapping of variable name to `Eq`.
-            evaluate: If `True`, let SymPy evaluate/simplify parsed
-                right-hand sides; if `False`, preserve authored term order.
-
-        Returns:
-            A mapping of equations whose structure depends on `format`.
-
-        Raises:
-            ValueError: If an entry in `output` names neither a derived nor a
-                state variable.
-        """
-        form = self._symbolic_form(notation="symbol", evaluate=evaluate)
-
-        if format == "state-equations":
-            return dict(form["state-equations"])
-        if format == "dict":
-            return {group: list(equations.values()) for group, equations in form.items()}
-        return {
-            name: equation
-            for group in form.values()
-            for name, equation in group.items()
-        }
 
     def fill_in_equations(self, **kwargs):
         """Substitute parameter values (and any overrides) into every equation.

--- a/tvbo/codegen/code.py
+++ b/tvbo/codegen/code.py
@@ -153,8 +153,8 @@ def inline_functions(expr, func_defs):
     The one inliner in TVBO. Backends with no user-function mechanism (LEMS, PyRates)
     must expand every call before printing, and the generic printers expand on request;
     all of them arrive here. Build *func_defs* with
-    [`Dynamics.function_bodies`](../classes/dynamics.qmd#Dynamics.function_bodies), which
-    parses each body once against the model's own scope.
+    [`function_bodies`](../parse/expression.qmd#function_bodies), which reads each body
+    from the model's symbolic layer, parsed once against the model's own scope.
 
     A body may itself call a function — the call graph is a DAG, e.g. Zerlaut's ``TF_e``
     calls ``sigmaV`` calls ``muV`` — so the bodies are first expanded into *each other*,

--- a/tvbo/parse/expression.py
+++ b/tvbo/parse/expression.py
@@ -173,51 +173,27 @@ ARRAY_FUNCTIONS = {
 }
 
 
-def function_bodies(model, parameters=None):
+def function_bodies(model):
     """A model's function definitions as ``{name: (arg_names, body)}``.
 
     The table [`inline_functions`](../codegen/code.qmd#inline_functions) consumes, for the
     backends that have no user-function mechanism and must expand every call before
     printing.
 
-    Read from the model's symbolic layer when it has one, so a body is parsed once however
-    many backends inline it. A free function rather than a `Dynamics` method because both
-    flavours of model need it: the runtime `Dynamics` in `tvbo.classes`, which carries that
-    layer, and the generated `Dynamics` in `tvbo.datamodel.schema` that an edge's
-    `resolved_dyn` is, which has the collections but no layer and is parsed against
-    *parameters* instead.
+    Read from the model's symbolic layer, so a body is parsed once however many backends
+    inline it. A free function rather than a `Dynamics` method because both flavours of
+    model need it: the runtime `Dynamics` in `tvbo.classes` and the generated one an edge's
+    `resolved_dyn` is. Both carry the layer, so both answer from the same parse — the
+    caller no longer supplies a namespace of its own, which is what let a body be parsed
+    against names the model does not declare.
 
-    On that second path every function name is registered as a function while parsing, so a
-    call to one inside another's body parses as an application rather than a product —
-    Zerlaut's `sigmaV` calls `muV`. Functions with no arguments or no equation are skipped
-    on both: there is nothing to substitute into, and a call to one is left for the printer
-    to emit verbatim.
+    Functions with no arguments or no equation are skipped: there is nothing to substitute
+    into, and a call to one is left for the printer to emit verbatim.
     """
-    symbolic_form = getattr(model, "_symbolic_form", None)
-    if symbolic_form is not None:
-        return {
-            name: ([str(argument) for argument in equation.lhs.args], equation.rhs)
-            for name, equation in symbolic_form()["functions"].items()
-        }
-
-    functions = model.functions
-    if not functions:
-        return {}
-    names = list(functions)
-    bodies = {}
-    for name, fn in functions.items():
-        arg_names = [str(arg) for arg in fn.arguments]
-        if not arg_names or not fn.equation:
-            continue
-        bodies[str(name)] = (
-            arg_names,
-            parse_eq(
-                fn.equation,
-                parameters=list(parameters or []) + arg_names,
-                functions=names,
-            ),
-        )
-    return bodies
+    return {
+        name: ([str(argument) for argument in equation.lhs.args], equation.rhs)
+        for name, equation in model.symbolic_system.form()["functions"].items()
+    }
 
 
 def states_an_expression(equation) -> bool:

--- a/tvbo/parse/system.py
+++ b/tvbo/parse/system.py
@@ -1,0 +1,486 @@
+#
+# Module: system.py
+#
+# Author: Leon Martin
+# Copyright © 2024 Charité Universitätsmedizin Berlin.
+# Licensed under the EUPL-1.2-or-later
+#
+"""The symbolic layer between a model's metadata and everything rendered from it.
+
+[`SymbolicSystem`](#tvbo.parse.system.SymbolicSystem) parses a model's equations once and
+holds them, together with the symbol tables they were parsed against. Every consumer —
+code generation, the analysis views, the report — is a projection of it, so an equation is
+parsed once no matter how many of them ask.
+
+It is a service object rather than a set of methods on `Dynamics` because a scope and the
+equations parsed against it have to agree, and that agreement is what the cache is keyed
+on. Owning both here makes the one invalidation point visible instead of leaving it as an
+attribute convention spread across a model class.
+"""
+
+from __future__ import annotations
+
+from sympy import Derivative, Eq, Function, Symbol, latex
+
+from tvbo.parse.expression import parse_eq, states_an_expression
+from tvbo.parse.symbols import assumptions_of, symbol_in
+
+
+def _declared(element, collection: str):
+    """*element*'s named collection, empty when it holds nothing.
+
+    LinkML's dataclasses default an unfilled collection to an empty one and Pydantic's
+    models default it to `None`, so a layer written against either alone raises on the
+    other for a model that simply declares nothing yet. Stating that difference once here
+    is what lets this layer read a model — or one of its elements — from either generator,
+    rather than as an `or {}` at each of the two dozen reads below.
+
+    An empty mapping stands in for an empty list as well: every list slot read here is
+    either iterated or tested for membership, and both answer the same on either.
+    """
+    return getattr(element, collection, None) or {}
+
+
+class SymbolicSystem:
+    """A model's equations in SymPy form, parsed against a symbol table built from its names.
+
+    Built for a model by
+    [`Dynamics.symbolic_system`](../behaviour/dynamics.qmd#symbolic_system), which keeps one
+    per model; construct it directly only to work against a model that does not.
+
+    Before this layer existed each caller re-derived from metadata: loading
+    `ZerlautAdaptationSecondOrder` parsed its 27 equations 264 times, and every
+    `render_code` and `generate_report` parsed all 27 again because nothing was kept.
+    """
+
+    _GROUP_COLLECTIONS = {
+        "derived-parameters": "derived_parameters",
+        "functions": "functions",
+        "derived-variables": "derived_variables",
+        "state-equations": "state_variables",
+        "output-transformations": "output",
+    }
+    """Which collection each equation group is built from, and takes its order from."""
+
+    def __init__(self, model):
+        self.model = model
+        self._cache = None
+
+    def scope(self, include_time_symbol: bool = True, time_dependent: bool = False):
+        """Build a unified local_dict for parsing model expressions.
+
+        Includes symbols for parameters, coupling terms, derived parameters, derived
+        variables, output transforms, state variables, event names, function names, and
+        (optionally) the time symbol 't'.
+
+        Every declared name must appear here so it shadows SymPy's own global namespace:
+        `Q` is SymPy's assumptions object, `S` its sympify shortcut, `O` big-O, `N`
+        numeric evaluation and `I` the imaginary unit, so a model that names a quantity
+        after any of them would otherwise fail to parse.
+
+        Args:
+            include_time_symbol: Bind `t` to `Symbol("t")`.
+            time_dependent: Bind state and derived variables to `Function(name)(t)` rather
+                than `Symbol(name)`, so `Derivative(x(t), t)` stays unevaluated and the
+                result reads as a system of ODEs. This is the only difference between the
+                two symbolic views of a model — everything downstream of the scope is
+                shared, which is why it is a parameter here and not a second builder.
+
+        Returns
+        -------
+        dict
+            Mapping of names to SymPy objects suitable for parse_eq(local_dict=...).
+            A copy, so a caller may keep or adapt it; the model's own is cached.
+        """
+        key = (bool(include_time_symbol), bool(time_dependent))
+        scopes = self._state()["scopes"]
+        if key not in scopes:
+            scopes[key] = self._build_scope(include_time_symbol, time_dependent)
+        return dict(scopes[key])
+
+    def form(self, notation: str = "symbol", evaluate: bool = True):
+        """The model's equations, parsed once per (notation, evaluate) and remembered.
+
+        Both public views — [`get_equations`](../behaviour/dynamics.qmd#get_equations) and
+        [`view`](#tvbo.parse.system.SymbolicSystem.view) — are projections of this, as is
+        the function-body table the inliner consumes.
+
+        The cache is discarded whole whenever [`_inputs`](#tvbo.parse.system.SymbolicSystem)
+        changes, which is what makes it safe on a mutable model. Rendering is a query —
+        `render_code` does not run `update_metadata` — so no consumer can invalidate it
+        mid-use.
+
+        Args:
+            notation: `"symbol"` binds variables to `Symbol(name)`; `"function"` binds
+                them to `Function(name)(t)`.
+            evaluate: Let SymPy evaluate right-hand sides, or preserve authored term order.
+
+        Returns:
+            `{group: {name: Eq}}` over the five groups, each keyed by the variable it
+            defines so no consumer has to recover a name from an `Eq`'s left-hand side.
+        """
+        forms = self._state()["forms"]
+        key = (notation, bool(evaluate))
+        if key not in forms:
+            forms[key] = self._build_form(notation, evaluate)
+        return forms[key]
+
+    def view(self):
+        """Full symbolic ODE system using proper SymPy conventions.
+
+        State variables are represented as ``Function(name)(t)`` so that
+        ``Derivative(theta(t), t)`` stays unevaluated.  Derived variables
+        and derived parameters are included as algebraic equations.
+
+        Returns
+        -------
+        dict
+            ``{'state': [...], 'derived': [...], 'parameters': {...}}``
+            where each list contains ``sympy.Eq`` objects and parameters
+            maps ``Symbol → value``. That map is keyed by the scope's own
+            symbols: rebuilt keys look identical, compare unequal, and make
+            substituting it into these equations silently replace nothing.
+
+        Example
+        -------
+        >>> model.symbolic['state']
+        [Eq(Derivative(theta(t), t), I + omega)]
+        >>> model.symbolic['derived']
+        [Eq(signal(t), sin(theta(t)))]
+        >>> model.symbolic['units']
+        {omega: 'per_ms', I: None}
+        """
+        from tvbo.analysis.units import declared_units
+
+        form = self.form(notation="function")
+        return {
+            "state": list(form["state-equations"].values()),
+            "functions": list(form["functions"].values()),
+            "derived_parameters": list(form["derived-parameters"].values()),
+            "derived": list(form["derived-variables"].values()),
+            "parameters": self.keyed_parameters(time_dependent=True),
+            "units": declared_units(self.model, scope=self.scope(time_dependent=True)),
+        }
+
+    def keyed_parameters(self, time_dependent: bool = False):
+        """Each declared parameter's symbol mapped to its value, for substitution.
+
+        Keyed through the scope rather than by minting `Symbol(name)`, because the analysis
+        view carries assumptions and a rebuilt key would print identically, compare unequal,
+        and make `subs` replace nothing. *time_dependent* selects which view's symbols the
+        map is keyed by, and must match the equations it will be substituted into.
+        """
+        scope = self.scope(time_dependent=time_dependent)
+        return {
+            scope[str(p.name)]: p.value
+            for p in _declared(self.model, "parameters").values()
+            if str(p.name) in scope
+        }
+
+    def symbol_map(self):
+        """Display-symbol overrides for report rendering: ``{identifier Symbol: LaTeX str}``.
+
+        For each element that declares a ``symbol`` (e.g. ``w_+`` for the identifier
+        ``w_plus``, or ``S^{(E)}`` for ``S_e``), map its identifier Symbol to the LaTeX
+        of that override, so ``sympy.latex(expr, symbol_names=model.symbol_map())``
+        renders the source's own notation. Elements without an override are omitted (they
+        render from their identifier). Fully sympy-native: the override is itself rendered
+        through ``sympy.latex(Symbol(...))``, inheriting Greek/sub/superscript handling.
+
+        Keyed by the canonical collection keys (the identifiers used in the equations),
+        over the same element collections as [`scope`](#tvbo.parse.system.SymbolicSystem.scope).
+        """
+        collections = (
+            "parameters",
+            "state_variables",
+            "derived_variables",
+            "derived_parameters",
+            "coupling_inputs",
+        )
+        return {
+            Symbol(str(key)): latex(Symbol(str(el.symbol)))
+            for collection in collections
+            for key, el in _declared(self.model, collection).items()
+            if getattr(el, "symbol", None)
+        }
+
+    def _state(self):
+        """The per-content cache the symbol table and the equations share.
+
+        One invalidation point for both, because they have to agree: a scope built from one
+        set of names and equations parsed against another is precisely the drift this layer
+        exists to remove.
+
+        A reorder keeps the parsed equations and re-keys them; the scopes are dropped
+        instead, since rebuilding a symbol table is a few hundred `Symbol` constructions
+        while reparsing is the expensive half.
+        """
+        content, order = self._inputs()
+        cache = self._cache
+        if cache is None or cache[0] != content:
+            cache = (content, order, {"scopes": {}, "forms": {}})
+        elif cache[1] != order:
+            reordered = {key: self._reordered(form) for key, form in cache[2]["forms"].items()}
+            cache = (content, order, {"scopes": {}, "forms": reordered})
+        else:
+            return cache[2]
+        self._cache = cache
+        return cache[2]
+
+    def _inputs(self):
+        """What `_build_form` reads, split into content and order.
+
+        The cache is sound only if *content* changes whenever a built equation would, so it
+        walks the same collections the builder walks rather than a hand-listed subset: a
+        slot the builder starts reading without being added here would serve a stale
+        equation forever. Content is compared as dicts, which ignore key order.
+
+        *order* is tracked separately because `sort_equations` reorders collections into
+        dependency order without changing a single equation — five times over one load.
+        Treating that as a content change would re-parse everything to produce the same
+        expressions in a different sequence.
+        """
+        def _equation(element):
+            equation = getattr(element, "equation", None)
+            if equation is None:
+                return None
+            return (
+                equation.rhs,
+                tuple((c.condition, c.expression) for c in _declared(equation, "conditionals")),
+                bool(equation.latex),
+            )
+
+        def _assumed(element):
+            """Keyed on `assumptions_of` itself, so the key cannot drift from what it reads.
+
+            A `domain` is not an equation, but it decides whether a symbol is `positive` or
+            merely `real`, and `Symbol('a', positive=True) != Symbol('a', real=True)`. Naming
+            the fields here instead would leave the key stale the day `assumptions_of` starts
+            reading one more of them.
+            """
+            return tuple(sorted(assumptions_of(element).items()))
+
+        content = (
+            self.model.system_type,
+            {str(name): _assumed(p) for name, p in _declared(self.model, "parameters").items()},
+            frozenset(str(name) for name in _declared(self.model, "coupling_inputs")),
+            frozenset(str(name) for name in _declared(self.model, "events")),
+            frozenset(str(name) for name in _declared(self.model, "output")),
+            {str(k): _equation(v) for k, v in _declared(self.model, "derived_parameters").items()},
+            {
+                str(k): (_equation(v), _assumed(v))
+                for k, v in _declared(self.model, "derived_variables").items()
+            },
+            {
+                str(k): (
+                    _equation(v),
+                    int(v.equation_order) if v.equation_order else 1,
+                    _assumed(v),
+                )
+                for k, v in _declared(self.model, "state_variables").items()
+            },
+            {
+                str(k): (tuple(str(a) for a in _declared(v, "arguments")), _equation(v))
+                for k, v in _declared(self.model, "functions").items()
+            },
+        )
+        order = tuple(
+            tuple(str(name) for name in _declared(self.model, collection))
+            for collection in self._GROUP_COLLECTIONS.values()
+        )
+        return content, order
+
+    def _reordered(self, form):
+        """The same equations, re-keyed into their collections' current order."""
+        return {
+            group: {
+                name: equations[name]
+                for name in (str(n) for n in _declared(self.model, self._GROUP_COLLECTIONS[group]))
+                if name in equations
+            }
+            for group, equations in form.items()
+        }
+
+    def _build_scope(self, include_time_symbol: bool, time_dependent: bool):
+        """Assemble the symbol table. See `scope`.
+
+        Holds only the names the *model* declares. A function's formal arguments are bound by
+        that function, exactly as a lambda binds its parameters, and are supplied as an
+        overlay while its body is parsed — see `_assemble`. Registering them here
+        let a formal shadow a variable of the same name: `ReducedWongWangTvboptim` declares
+        both `H(x)` and a derived variable `x`, and the formal won, so the analysis view held
+        `x` constant and dropped the chain-rule term from every Jacobian through `H`.
+
+        Assumptions ride on the time-dependent view only. They are what SymPy's analysis
+        machinery needs — without `real=True` the fixed points of a two-variable model do
+        not come back inside a minute — but they also enter `Symbol.sort_key`, so the same
+        product prints as `q*alpha` instead of `alpha*q`. That is no gain for a backend
+        that parses, inlines and prints without ever simplifying, and every emitted file is
+        compared against a frozen reference. The codegen view therefore stays plain, and
+        the two are never mixed: a `Symbol` from one does not compare equal to the same name
+        from the other, so nothing can substitute across them by accident.
+
+        Function heads are the exception, and carry `assumptions_of()` in both views: a head
+        is notation-independent — `Sigm` is the same function whether the variables around it
+        are Symbols or Functions of `t`. Building it per view made `Function("Sigm", real=True)`
+        and `Function("Sigm")`, which print identically, compare unequal, and make
+        `expr.has(Sigm)` False on an expression that visibly calls it, so every inliner
+        matched nothing, silently.
+        """
+        def _assume(element=None):
+            return assumptions_of(element) if time_dependent else {}
+
+        def _symbol(name, element=None):
+            return Symbol(str(name), **_assume(element))
+
+        t = _symbol("t")
+        scope: dict[str, object] = {}
+
+        def _variable(name, element=None):
+            if time_dependent:
+                return Function(str(name), **_assume(element))(t)
+            return _symbol(name, element)
+
+        if include_time_symbol:
+            scope["t"] = t
+
+        for p in _declared(self.model, "parameters").values():
+            scope[str(p.name)] = _symbol(p.name, p)
+
+        # Coupling inputs (named inputs from coupling function)
+        for ci in _declared(self.model, "coupling_inputs"):
+            scope[str(ci)] = _symbol(ci)
+
+        # A derived parameter is constant in time, so it stays a Symbol in both views.
+        for name in _declared(self.model, "derived_parameters"):
+            scope[str(name)] = _symbol(name)
+        derived_variables = _declared(self.model, "derived_variables")
+        for name, dv in derived_variables.items():
+            scope[str(name)] = _variable(name, dv)
+
+        # Output is a list of string references
+        for name in _declared(self.model, "output"):
+            scope[str(name)] = _variable(name, derived_variables.get(str(name)))
+
+        for name, sv in _declared(self.model, "state_variables").items():
+            scope[str(name)] = _variable(name, sv)
+
+        for fname in _declared(self.model, "functions"):
+            scope[str(fname)] = Function(str(fname), **assumptions_of())
+
+        for name in _declared(self.model, "events"):
+            scope[str(name)] = _symbol(name)
+
+        if "e" not in scope:
+            from sympy import E
+
+            scope["e"] = E
+
+        return scope
+
+    def _build_form(self, notation: str, evaluate: bool):
+        """Parse every equation the model states, once. See `form`.
+
+        The two views differ in what they are for, and the evaluation policy follows from
+        that rather than the other way round.
+
+        `"symbol"` feeds codegen, which parses, inlines and prints. It honours the caller's
+        *evaluate* so a backend can keep the term order its author wrote.
+
+        `"function"` is the analysis view — the one `Matrix.jacobian`, `solve` and `dsolve`
+        act on — so it is canonical. It used to suppress evaluation globally, which kept
+        `Derivative(theta(t), t)` from collapsing but also left the right-hand sides in a
+        nested unevaluated form that SymPy's solvers cannot make progress on: asked for the
+        fixed points of `Generic2dOscillator` in that form, `solve` returns nothing in 45 s;
+        canonical and with real symbols it answers in under one. `Derivative` is built
+        explicitly here, so nothing needs the global suppression to survive.
+        """
+        time_dependent = notation == "function"
+        return self._assemble(
+            time_dependent=time_dependent,
+            evaluate=True if time_dependent else evaluate,
+        )
+
+    def _assemble(self, time_dependent: bool, evaluate: bool):
+        """Build the five equation groups against one scope. See `_build_form`.
+
+        Every symbol an equation's left-hand side names is resolved through `scope` — the
+        same table the right-hand sides were parsed against. Minting one here instead
+        produces a name that prints identically and compares unequal once the analysis view
+        attaches assumptions, and `subs` across that mismatch replaces nothing rather than
+        raising: a derivative taken w.r.t. a freshly built `t` leaves `doit()` returning 0,
+        and a derived parameter's definition substitutes into none of its own equations.
+        """
+        scope = self.scope(time_dependent=time_dependent)
+        t = symbol_in(scope, "t")
+        discrete = self.model.system_type == "discrete"
+        derived_variables = _declared(self.model, "derived_variables")
+        state_variables = _declared(self.model, "state_variables")
+
+        def _lhs(name):
+            return symbol_in(scope, name)
+
+        def _states(element):
+            """Whether the element has anything to parse — see `states_an_expression`.
+
+            An element declared with no `rhs` and no conditionals is skipped rather than
+            parsed. Every rendering path funnels through here, so one such element used
+            to break all of them at once instead of only `get_equations`.
+            """
+            return states_an_expression(getattr(element, "equation", None))
+
+        def _parse(element, namespace=None):
+            return parse_eq(element.equation, local_dict=namespace or scope, evaluate=evaluate)
+
+        def _formal(name):
+            """A function's bound argument — a quantity, never a state, so never `name(t)`."""
+            return Symbol(str(name), **(assumptions_of() if time_dependent else {}))
+
+        def _function_scope(function):
+            """The model's names with this function's formals bound over them."""
+            return {**scope, **{str(a): _formal(a) for a in _declared(function, "arguments")}}
+
+        form = {
+            "derived-parameters": {
+                str(k): Eq(lhs=_lhs(k), rhs=_parse(dp))
+                for k, dp in _declared(self.model, "derived_parameters").items()
+                if _states(dp)
+            },
+            "functions": {
+                str(k): Eq(
+                    lhs=_lhs(k)(*[_formal(a) for a in _declared(f, "arguments")]),
+                    rhs=_parse(f, _function_scope(f)),
+                )
+                for k, f in _declared(self.model, "functions").items()
+                if _states(f) and _declared(f, "arguments")
+            },
+            "derived-variables": {
+                str(k): Eq(lhs=_lhs(k), rhs=_parse(dv))
+                for k, dv in derived_variables.items()
+                if _states(dv)
+            },
+            "state-equations": {},
+            "output-transformations": {},
+        }
+
+        for k, sv in state_variables.items():
+            if not _states(sv):
+                continue
+            order = int(sv.equation_order or 1)
+            lhs = _lhs(k) if discrete else Derivative(_lhs(k), *([t] * order))
+            form["state-equations"][str(k)] = Eq(lhs=lhs, rhs=_parse(sv))
+
+        # An identity equation for an output that IS a state variable overwrites its real one.
+        for name in _declared(self.model, "output"):
+            name = str(name)
+            if name in derived_variables:
+                if _states(derived_variables[name]):
+                    form["output-transformations"][name] = Eq(
+                        lhs=_lhs(name), rhs=_parse(derived_variables[name])
+                    )
+            elif name not in state_variables:
+                raise ValueError(
+                    f"Output variable '{name}' not found in derived_variables or state_variables"
+                )
+
+        return form

--- a/tvbo/utils/report.py
+++ b/tvbo/utils/report.py
@@ -1485,19 +1485,19 @@ def experiment_models(experiment):
 
 
 def _equations_of(model):
-    """A model's symbolic equations, resolving a bare declaration into a real model first.
+    """A model's symbolic equations, however it was built.
 
-    A per-node model on a heterogeneous network arrives as the plain datamodel object,
-    which carries the declaration but not ``Dynamics``'s symbolic machinery. Treating
-    that as "no equations" printed a Methods section with **no mathematics at all** for
-    every heterogeneous study: Mongillo2008's twenty-nine experiments got symbol tables
-    and nothing else, and Deco2014 lost both of its spiking families.
+    Every ``Dynamics`` answers ``get_equations`` — the generated forms carry it from
+    ``DynamicsBehaviour`` — so a per-node model on a heterogeneous network is read where
+    it stands, against the same parse the backend integrates. Treating it as "no
+    equations" printed a Methods section with **no mathematics at all** for every
+    heterogeneous study: Mongillo2008's twenty-nine experiments got symbol tables and
+    nothing else, and Deco2014 lost both of its spiking families.
 
-    So promote it. ``Dynamics.from_datamodel`` copies the already-normalised state and
-    gives back the same resolution the backend uses — which is the point, because the
-    authored right-hand sides must not be re-parsed here against a hand-assembled
-    vocabulary (see :func:`equation_latex`). A model that still cannot resolve is a
-    legitimate miss, not a crash.
+    The promotion below is for something that is not a ``Dynamics`` at all: the authored
+    right-hand sides must not be re-parsed here against a hand-assembled vocabulary (see
+    :func:`equation_latex`), so ``Dynamics.from_datamodel`` gives back the same resolution
+    instead. A model that still cannot resolve is a legitimate miss, not a crash.
     """
     if hasattr(model, "get_equations"):
         return model.get_equations() or {}


### PR DESCRIPTION
Part C of #69 — the symbolic layer becomes an object, and the generated `Dynamics` carries it.

Stacked on `test/codegen-golden-corpus` (#70), so this diff is the single commit.

## What moves

`DynamicalSystem` held a model's SymPy view as eleven methods plus a cache keyed on a tuple of everything it read — a scope builder, an equation parser, and the invalidation that must agree with both, spread across a 3,400-line class. They are one thing: equations are sound only while the symbol table they were parsed against is still the one in use, and that agreement is exactly what the cache is keyed on. `tvbo/parse/system.py` holds it as `SymbolicSystem`.

The layer then attaches to the generated classes as `DynamicsBehaviour`, so a model answers symbolically however it was built — LinkML-loaded, Pydantic-validated, or resolved onto an edge.

`tvbo/classes/dynamics.py`: **−511 lines**.

## Three copies of one dispatch, removed

Each asked whether the model in hand had a symbolic layer and parsed its metadata itself when the answer was no:

| Site | What it did instead |
|---|---|
| `parse.expression.function_bodies` | parsed bodies against a namespace the **caller** supplied |
| `julia_model.parse_namespace` | rebuilt a name list from `symbol_names` |
| `report._equations_of` | promoted every per-node model via `Dynamics.from_datamodel` — a full re-parse, once per node model per report |

The first is why the dispatch mattered rather than merely duplicated: `neuroml` passed `all_names`, so a function body was parsed against names the model does not declare. All three now read the model's own scope.

## Copy semantics

A layer holds the model it was built for. Every copy protocol carries the attribute across — `copy.copy`, Pydantic's `model_copy`, unpickling — and a carried layer answers the clone's questions about the *original*: its edits reach neither the cache nor the scope. `symbolic_system` checks ownership where the layer is read, which settles all of them at once; an exclusion rule per copy hook would have covered only the hooks someone remembered.

## The two generators disagree about "empty"

LinkML defaults an unfilled collection to an empty one, Pydantic to `None`, so a layer written against either alone raises on the other for a model that simply declares nothing yet. `_declared` states that difference once — for a model and for its elements — rather than as an `or {}` at each of two dozen reads. For the same reason `_items` yields nothing where there is no `super()` to delegate to, so a capability probe that finds the attribute does not find it uncallable.

## Verification

- **1545** golden-corpus and database-dump references **byte-identical**
- **63** heterogeneous-network tests green — the path where an inline node dynamics is a generated `Dynamics`, and the only place the collapsed dispatch changes which namespace is used
- **389** focused tests (symbolic layer, spec-model contract, units, report, linear response, package structure)
- ruff blocking subset clean; comment-style gate exit 0

Four tests pin the new contract: both generated forms give the same equations, an unfilled model answers rather than raising, and a copy gets its own layer — on the runtime class and on both generated ones.

## Known gap, not fixed here

`pydantic_loader` does not key a *list-spelled* keyed collection: `arguments: [u]` validates to `{}`, silently dropping the function. The curated database uses the mapping spelling, so nothing published is affected, and the loader is what #69 A.2 plans to delete. Recorded rather than widened into this change.

## Not in scope

#29's title also covers moving the remaining ~60 methods onto the behaviour. That is gated on a design decision: `DynamicalSystem.__init__` does pre-construction work (the `iri=` registry backfill, the `use_ontology=` flag) that a mixin structurally cannot do, since `@dataclass` writes `__init__` on the generated class. `IntegratorBehaviour` set the precedent by making ontology population an explicit idempotent call; following it here would drop `use_ontology=` from the constructor, which has no callers outside `dynamics.py`'s own factories. `todo.md:1173` already tracks retiring those flags.
