### PR TITLE
feat(dialect): a recipe may name an entity by iri, and the dialect expands it

### DIFF
--- a/tests/test_iri_expansion.py
+++ b/tests/test_iri_expansion.py
@@ -1,0 +1,100 @@
+"""Naming an entity by ``iri`` is a spelling the dialect expands, before validation.
+
+A recipe may point at a curated entity instead of spelling it out. That expansion has to
+happen while the *authored* keys are still distinguishable from schema defaults, because
+after construction every slot carrying a default reads as though it had been written — and
+"the recipe did not say this" is exactly the question the merge has to answer.
+
+Two properties follow, and both are pinned here: the recipe always wins over the entry, and
+a record that states its own ``name`` is a definition rather than a reference, so its
+``iri`` is grounding and expands nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tvbo.datamodel import pydantic as pyd
+from tvbo.datamodel import schema
+
+GENERATED_FORMS = pytest.mark.parametrize("model", (schema, pyd), ids=("dataclass", "pydantic"))
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_reference_adopts_the_curated_record(model):
+    """An entity named solely by ``iri`` arrives carrying what that entry declares."""
+    coupling = model.Coupling(iri="tvbo:FastLinearCoupling")
+
+    assert coupling.name == "FastLinearCoupling"
+    assert coupling.pre_expression is not None
+    assert "G" in coupling.parameters
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_curated_delayed_is_applied(model):
+    """The reason this belongs before validation, and not in a post-init hook.
+
+    ``delayed`` carries a schema default of ``True``. After construction, an explicit
+    ``true`` and an absent key are the same value, so the guard that would have applied the
+    entry could never fire and no curated ``delayed:`` was ever honoured.
+    ``FastLinearCoupling`` describes itself as instantaneous and declares ``delayed: false``;
+    TVBO ran it delayed anyway.
+    """
+    assert model.Coupling(iri="tvbo:FastLinearCoupling").delayed is False
+    assert model.Coupling(iri="tvbo:Linear").delayed is True
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_the_recipe_wins_over_the_entry(model):
+    """The entry is the base; anything the recipe states supervenes, leaf by leaf."""
+    coupling = model.Coupling(iri="tvbo:FastLinearCoupling", delayed=True)
+    assert coupling.delayed is True
+
+    refined = model.Coupling(iri="tvbo:Linear", parameters={"a": {"value": 99.0}})
+    assert refined.parameters["a"].value == 99.0
+    assert len(refined.parameters) > 1, "siblings from the entry were dropped"
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_definition_is_not_expanded(model):
+    """A record stating its own ``name`` is a definition; its ``iri`` only grounds it.
+
+    Fifty curated files are written that way. Expanding them would re-derive a definition
+    from a name lookup — and ``ReducedWongWangFunc.yml`` declares ``name: ReducedWongWang``,
+    so it would be overwritten by the different, canonical ``ReducedWongWang.yaml``.
+    """
+    coupling = model.Coupling(iri="tvbo:FastLinearCoupling", name="MyOwnCoupling")
+
+    assert coupling.name == "MyOwnCoupling"
+    assert coupling.delayed is True, "a definition adopted the entry it merely grounds on"
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_an_iri_naming_nothing_is_left_alone(model):
+    """It may name an entity that exists only in the ontology, which this pass cannot reach.
+
+    Distinguishing that from a typo is `tvbo validate`'s job, and `enrich()`'s — which
+    raises, because there the caller asked.
+    """
+    coupling = model.Coupling(iri="tvbo:NoSuchCouplingAnywhere")
+    assert coupling.iri == "tvbo:NoSuchCouplingAnywhere"
+
+
+@pytest.mark.backend_core
+def test_the_curated_record_still_loads_as_itself():
+    """The regression the definition guard exists for, on the file that exposed it."""
+    from tvbo.classes.dynamics import Dynamics
+    from tvbo.data.registry import database_dir
+
+    path = next(
+        p for ext in ("yaml", "yml") for p in database_dir("Dynamics").rglob(f"ReducedWongWangFunc.{ext}")
+    )
+    dynamics = Dynamics.from_file(str(path))
+
+    assert "H" in dynamics.functions
+    assert list(dynamics.functions["H"].arguments) == ["x"]

--- a/tvbo/classes/dynamics.py
+++ b/tvbo/classes/dynamics.py
@@ -514,14 +514,6 @@ def sort_equations(model: Any, variable_type: str, graph=None):
     model[variable_type].update(sorted_variables_metadata)
 
 
-# Slot aliases: YAML keys that map to canonical slot names.
-# Keeps YAML files readable (e.g. ``components:`` instead of ``modes:``) while
-# the datamodel uses a single canonical attribute.
-_DYNAMICS_SLOT_ALIASES = {
-    "components": "modes",
-}
-
-
 def _clamp_domain(rng):
     """Mark a bounds Range as a hard clamp (``enforce='clamp'``) and return it.
 
@@ -557,49 +549,25 @@ def _fold_range_boundaries(rng, boundaries):
     return domain, distribution
 
 
-def _fold_component_alias(d: dict) -> None:
-    """Recursively rename the Dynamics-only ``components`` → ``modes`` slot alias.
-
-    ``components`` is a ``modes`` alias only inside a Dynamics, so it is folded here
-    (and by the class-scoped fold in the loader) rather than anywhere a ``components``
-    key appears. Mutates ``d`` in place at every nesting level.
-    """
-    for alias, canonical in _DYNAMICS_SLOT_ALIASES.items():
-        if alias in d:
-            if canonical in d:
-                raise ValueError(
-                    f"Cannot specify both '{alias}' and '{canonical}' — "
-                    f"'{alias}' is an alias for '{canonical}'."
-                )
-            d[canonical] = d.pop(alias)
-    modes = d.get("modes")
-    if isinstance(modes, dict):
-        for v in modes.values():
-            if isinstance(v, dict):
-                _fold_component_alias(v)
-
-
 def _resolve_dynamics_aliases(d: dict) -> dict:
     """Normalize a Dynamics kwargs/metadata dict through the SINGLE shared route.
 
-    Every construction path — ``Dynamics(**dict)``, ``from_file``, ``from_string``,
-    the ``iri`` backfill, and the network/experiment coercion helpers — funnels
-    through here, so they apply identical conveniences and cannot drift:
+    Every construction path — ``Dynamics(**dict)``, ``from_file``, ``from_string`` and
+    the network/experiment coercion helpers — funnels through here, so they apply
+    identical conveniences and cannot drift.
 
-    * the Dynamics-specific ``components`` → ``modes`` alias (recursively), then
-    * :func:`tvbo.utils.yaml_loader._normalize_loaded` — the one implementation
-      shared with the LinkML ``load``/``loads``/``load_as_dict`` path: the aliases
-      ``Dynamics`` declares, the legacy ``boundaries``/``range`` → ``domain`` fold (``boundaries``
-      gaining ``enforce: clamp``; a co-existing descriptive ``domain`` preserved as
-      the IC-sampling ``distribution``), and the terse ``distribution: {lo, hi}``
-      lift. A bare ``domain`` is left untouched (``enforce`` defaults to ``none``),
-      so clamping stays opt-in.
+    It applies only what a class cannot: the legacy ``boundaries``/``range`` → ``domain``
+    fold (``boundaries`` gaining ``enforce: clamp``; a co-existing descriptive ``domain``
+    preserved as the IC-sampling ``distribution``), and the terse ``distribution: {lo, hi}``
+    lift. A bare ``domain`` is left untouched (``enforce`` defaults to ``none``), so
+    clamping stays opt-in. Declared slot aliases — ``components`` → ``modes`` among them —
+    are folded by the dialect at construction, at every nesting level, from the schema's
+    own ``aliases:``.
 
     ``_normalize_loaded`` rebuilds mappings, so the normalized content is written
     back into ``d`` in place (``clear`` + ``update``) to honour the in-place
     contract the coercion callers rely on; ``d`` is also returned for convenience.
     """
-    _fold_component_alias(d)
     normalized = yaml_loader._normalize_loaded(d)
     if normalized is not d:
         d.clear()
@@ -652,56 +620,34 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
     Most users should construct via [`Dynamics`](#tvbo.classes.dynamics.Dynamics)
     or `Dynamics.from_db(name)` — this class is the implementation base.
 
-    `_skip_ontology` says the model arrives fully specified — an `iri=` registry entry, a
-    PyRates import — so the slow ontology lookup is pointless. It does **not** mean the
-    record needs no normalising: every path runs `update_metadata`, which migrates the
-    deprecated `cases:` slot into conditionals and sorts derived variables into the
-    dependency order the straight-line JAX and NumPy emitters require. Returning early on
-    this flag left `cases:` models rendering with no branches at all.
+    An `iri=` is expanded by the dialect, before validation, so a model named by one
+    arrives already carrying the curated record — see
+    [`expand_iri`](../datamodel/dialect.qmd#expand_iri). Every path then runs
+    `update_metadata`, which migrates the deprecated `cases:` slot into conditionals and
+    sorts derived variables into the dependency order the straight-line JAX and NumPy
+    emitters require; a path that skipped it rendered `cases:` models with no branches.
     """
 
     def __init__(
         self,
-        name="Dynamics",
-        _skip_ontology: bool = False,
+        name=None,
         use_ontology: bool = False,
         **kwargs,
     ):
-        iri = kwargs.get("iri")
-        if iri and (name is None or name == "Dynamics"):
-            from tvbo.data.registry import resolve, local_name
-            from tvbo.utils import deep_merge
-
-            local = local_name(iri)
-            try:
-                loaded = yaml_loader.load_as_dict(str(resolve("Dynamics", local)))
-                _resolve_dynamics_aliases(loaded)
-                # Registry entry is the base; inline kwargs override at the leaf
-                # (e.g. parameters.a.value wins, siblings kept from the entry).
-                merged = deep_merge(loaded, kwargs)
-                kwargs.clear()
-                kwargs.update(merged)
-                name = kwargs.pop("name", local)
-                _skip_ontology = True
-            except (FileNotFoundError, RuntimeError):
-                pass
-
         if name is not None:
             kwargs["name"] = str(name)
 
         # Validate common schema mistakes before LinkML processing
         _validate_dynamics_kwargs(kwargs)
 
-        # Initialize datamodel (base class sets up empty containers)
+        # Initialize datamodel (the dialect expands `iri` and folds aliases here)
         super().__init__(**kwargs)
 
-        # Auto-populate only when a name was provided; keep default Dynamics() empty
-        if name != "Dynamics":
-            if use_ontology and not _skip_ontology:
-                self._populate_from_ontology_by_name()
+        if use_ontology:
+            self._populate_from_ontology_by_name()
 
-            self.update_metadata()
-            self.calculate_derived_parameters()
+        self.update_metadata()
+        self.calculate_derived_parameters()
 
     @property
     def components(self):
@@ -882,12 +828,7 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
         from tvbo.codegen.pyrates import from_pyrates_yaml
 
         data = from_pyrates_yaml(path, operator_key=operator_key)
-        # Skip ontology lookup - PyRates YAML provides complete model definition
-        inst = cls(_skip_ontology=True, **data)
-        # Only calculate derived parameters if needed
-        if inst.derived_parameters:
-            inst.calculate_derived_parameters()
-        return inst
+        return cls(**data)
 
     @classmethod
     def from_db(cls, name: str) -> "Dynamics":

--- a/tvbo/classes/experiment.py
+++ b/tvbo/classes/experiment.py
@@ -825,8 +825,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         # Convert dicts to Dynamics instances using lightweight construction
         dynamics = {}
         for name, dyn_dict in dynamics_dicts.items():
-            # Create instance with _skip_ontology=True to avoid slow lookups
-            dyn = Dynamics(_skip_ontology=True, **dyn_dict)
+            dyn = Dynamics(**dyn_dict)
             dynamics[name] = dyn
 
         # Use the first dynamics as the primary model

--- a/tvbo/datamodel/dialect.py
+++ b/tvbo/datamodel/dialect.py
@@ -1,10 +1,11 @@
 """The TVBO YAML dialect — one implementation, both construction paths.
 
 TVBO authors write a dialect the schema does not describe on its own: a slot may be
-written under a declared alias (``dt`` for ``step_size``), and an object with one
-obvious field may be written as a bare scalar (``omega: 0.0628`` for
-``omega: {value: 0.0628}``). Neither is something LinkML's loaders apply — ``aliases:``
-is documentation to them, and ``simple_dict_value`` is specified but unimplemented.
+written under a declared alias (``dt`` for ``step_size``), an object with one obvious
+field may be written as a bare scalar (``omega: 0.0628`` for ``omega: {value: 0.0628}``),
+and an entity may be named by ``iri`` instead of spelled out. None of the three is
+something LinkML's loaders apply — ``aliases:`` is documentation to them, and
+``simple_dict_value`` is specified but unimplemented.
 
 Both are therefore applied here, from tables read off the schema at build time
 (:mod:`tvbo.datamodel.dialect_tables`). The generated dataclasses install
@@ -22,12 +23,15 @@ belongs to the caller — Pydantic already descends into members, and the datacl
 from __future__ import annotations
 
 import warnings
+from functools import lru_cache
 
 from tvbo.datamodel.dialect_tables import SCALAR_SHORTCUTS, SLOT_ALIASES
 
 __all__ = [
     "SCALAR_SHORTCUTS",
     "SLOT_ALIASES",
+    "expand_iri",
+    "fold_aliases",
     "is_literal",
     "lift_scalar",
     "normalize",
@@ -71,18 +75,13 @@ def lift_scalar(value, target, multivalued, keyed=False):
     return value
 
 
-def normalize(cls_name: str, data: dict) -> dict:
-    """Fold *cls_name*'s scalar shortcuts and slot aliases into *data*, in place.
+def fold_aliases(cls_name: str, data: dict) -> dict:
+    """Rename *cls_name*'s declared aliases to their canonical slots, in place.
 
     Class-scoped on purpose: an alias is only an alias where its class declares it.
     ``target_variable`` is an ``Edge`` alias for ``target_var`` but the canonical slot on
     a stimulus ``Event``, so a table keyed by slot name alone would rename it in the one
     place it must not be.
-
-    Aliases fold first: the shortcut table is keyed by canonical slot, so a value written
-    under an alias is not yet under a name the shortcut pass can see. Lifting first left
-    ``BoundaryCondition(value="0")`` — the older spelling of ``equation`` — a bare string
-    where the generated ``__post_init__`` wanted a mapping, and it raised.
     """
     for alias, canonical in SLOT_ALIASES.get(cls_name, {}).items():
         if alias not in data:
@@ -92,10 +91,94 @@ def normalize(cls_name: str, data: dict) -> dict:
             warnings.warn(
                 f"{cls_name} got both {alias!r} and its canonical slot "
                 f"{canonical!r}; ignoring {alias!r}.",
-                stacklevel=3,
+                stacklevel=4,
             )
         else:
             data[canonical] = value
+    return data
+
+
+@lru_cache(maxsize=None)
+def _curated_entry(cls_name: str, iri: str) -> dict | None:
+    """The curated record *iri* names, alias-folded and ready to merge, or ``None``.
+
+    Cached because a recipe naming the same entity twice — every node of a homogeneous
+    network — would otherwise re-read and re-parse the same file per object. The result is
+    only ever fed to :func:`tvbo.utils.deep_merge`, which mutates neither side, so callers
+    share one instance safely.
+
+    The entry's own ``iri`` is dropped: keeping it would make the expanded record ask to be
+    expanded again on every later construction, and a self-referential entry would not
+    terminate.
+    """
+    import yaml
+
+    from tvbo.data.registry import local_name, resolve
+
+    try:
+        path = resolve(cls_name, local_name(iri))
+    except (FileNotFoundError, RuntimeError, ValueError):
+        return None
+    entry = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(entry, dict):
+        return None
+    entry.pop("iri", None)
+    return fold_aliases(cls_name, entry)
+
+
+def expand_iri(cls_name: str, data: dict) -> dict:
+    """Fill *data* from the curated record its ``iri`` names, letting the recipe win.
+
+    Naming an entity by ``iri`` instead of spelling it out is the same kind of dialect as
+    an alias or a bare scalar: a spelling the schema does not describe. It is resolved here,
+    before validation, because this is the only point that still knows which keys the recipe
+    actually wrote — after construction every slot carrying a schema default reads as though
+    it had been authored, and "the recipe did not say" becomes unanswerable. That is why a
+    curated ``delayed:`` was never applied, and why an explicit value equal to a default
+    could be overwritten by the entry.
+
+    Only the curated database is consulted. It is a local file read and its content is
+    ordered, whereas the ontology answers with an unordered set — a different parameter
+    order per process, which no frozen record can be written against. Reaching it is
+    :meth:`IriEnrichable.enrich`, which the caller asks for.
+
+    Only a *reference* expands. A record that also states its own ``name`` is a definition,
+    and its ``iri`` is grounding — "this model is a ReducedWongWang in the ontology" — not
+    an instruction to inherit. Fifty curated files are written that way, and expanding them
+    would re-derive a definition from a name lookup: ``ReducedWongWangFunc.yml`` declares
+    ``name: ReducedWongWang``, so it would be overwritten by the canonical
+    ``ReducedWongWang.yaml`` it merely relates to.
+
+    An ``iri`` naming nothing is left alone: it may point at an entity that exists only in
+    the ontology, and this pass cannot tell that from a typo. ``tvbo validate`` is where a
+    name that resolves nowhere is reported.
+    """
+    iri = data.get("iri")
+    if not isinstance(iri, str) or data.get("name") is not None:
+        return data
+    entry = _curated_entry(cls_name, iri)
+    if entry is None:
+        return data
+
+    from tvbo.utils import deep_merge
+
+    merged = deep_merge(entry, data)
+    data.clear()
+    data.update(merged)
+    return data
+
+
+def normalize(cls_name: str, data: dict) -> dict:
+    """Fold *cls_name*'s dialect into *data*, in place: aliases, ``iri``, shortcuts.
+
+    Aliases fold first, so the recipe and the curated record are keyed alike before they
+    are merged and the shortcut pass can see every value under the name it looks for.
+    Lifting first left ``BoundaryCondition(value="0")`` — the older spelling of
+    ``equation`` — a bare string where the generated ``__post_init__`` wanted a mapping,
+    and it raised.
+    """
+    fold_aliases(cls_name, data)
+    expand_iri(cls_name, data)
 
     for slot, (target, multivalued, keyed) in SCALAR_SHORTCUTS.get(cls_name, {}).items():
         if data.get(slot) is not None:


### PR DESCRIPTION
Part 1 of #95. Stacked on #93.

A recipe may name an entity by `iri` instead of spelling it out. That expansion moves from `DynamicalSystem.__init__` into `dialect.normalize()`, alongside the two spellings it belongs with — declared aliases and bare-scalar shortcuts.

## Why the dialect

`normalize` already runs **before validation, once per object, on both generated forms** (the dataclass `__init__` wrapper and the Pydantic `mode="before"` validator). Two things follow that nothing else can give:

1. **It reaches every model.** In `__init__` the expansion existed only on the runtime subclass, and only *could*, because a behaviour mixin cannot accept a constructor keyword — `@dataclass` writes `__init__` on the generated class.
2. **It can still see what the recipe wrote.** After construction, every slot carrying a schema default reads as though it had been authored, so *"the recipe did not say this"* stops being answerable.

That second point is not theoretical. It is why `CouplingBehaviour` needs `_schema_default()` to guess, why an explicit value equal to a default could be overwritten by the curated entry, and why **a curated `delayed:` has never been applied at all** (#34).

## #34, and an honest correction

`FastLinearCoupling` describes itself as *"Instantaneous linear coupling"*, declares `delayed: false`, and TVBO ran it delayed. It no longer does.

I expected this to move numbers and said so. It does not: the one curated experiment that uses it, `RWW_BOLD_FC_Optimization`, **spells `delayed: false` out in its own recipe**, so its coupling is a definition that never consulted the entry. Golden corpora are unchanged at **1545**. The fix is latent — it changes behaviour only for a recipe that references a curated coupling by `iri` alone and relies on the entry's value.

## Only a reference expands

A record that also states its own `name` is a *definition*; its `iri` grounds it — "this model is a ReducedWongWang in the ontology" — rather than asking to inherit.

**Fifty curated files are written that way.** Expanding them re-derives a definition from a name lookup, and one bites: `ReducedWongWangFunc.yml` declares `name: ReducedWongWang`, so it was overwritten by the different canonical `ReducedWongWang.yaml` and stopped parsing its own `H(x)`. A test pins that file.

## The ontology is deliberately not consulted

Measured: ~2.9 s cold, and it answers with an **unordered set** — a different parameter order per process, which no frozen record can be written against. So the rule this stack follows is:

> Construction resolves what is deterministic, local and cheap. Everything else is an act the caller asks for.

Only the curated database is read here: a local file, cached, with its own `iri` dropped so an expanded record cannot ask to be expanded again. Reaching the ontology becomes `enrich()` in part 2.

## Also removed

- `_skip_ontology` — it meant "this arrived fully specified, skip the lookup", and there is no lookup at construction to skip.
- `_fold_component_alias` + `_DYNAMICS_SLOT_ALIASES` — the dialect folds `components → modes` from the schema's own `aliases:`, at every nesting level, because each nested `Dynamics` goes through the same wrapped `__init__`. Verified three levels deep.
- `Dynamics(name=...)` defaults to `None`, not `"Dynamics"`. Forcing the default into the keywords made the recipe appear to have named itself, so an `iri` reference could never adopt the entry's name.

## Verification

| | |
|---|---|
| Golden corpora (codegen + database dump) | **1545 passed**, unchanged |
| Dialect, dynamics, symbolic layer, spec contract | 55 passed |
| `tests/test_iri_expansion.py` (new) | 11 passed |
| FastLinearCoupling users + heterogeneous adapter | 18 passed, 1 skipped |
| ruff blocking subset | clean |

An `iri` naming nothing is left alone — it may name an entity that exists only in the ontology, and this pass cannot tell that from a typo. `enrich()` raises there (part 2), and `tvbo validate` is where a typo should surface.
