### PR TITLE
feat(enrich): one verb for filling a record, and keyed collections that mean the same on both forms

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -51,7 +51,7 @@ def generate_datamodel(root: str | Path) -> None:
     out_dir = root / "tvbo" / "datamodel"
     out_dir.mkdir(parents=True, exist_ok=True)
     shortcuts, aliases, keyed = _dialect_tables(schema)
-    mixins = _behaviour_mixins(root, schema)
+    mixins = _mixins(root, schema)
     _write(out_dir / "dialect_tables.py", _render_dialect_tables(shortcuts, aliases, keyed))
     _write(
         out_dir / "schema.py",
@@ -196,6 +196,33 @@ from tvbo.datamodel.dialect import install_on_dataclasses as _install_dialect
 _install_dialect(globals())
 """
 
+#: Attached to every class the schema gives an ``iri``; see :mod:`tvbo.behaviour._enrich`.
+_ENRICHABLE_MIXIN = "tvbo.behaviour._enrich.IriEnrichable"
+
+
+def _mixins(root: Path, schema: Path) -> dict[str, list[str]]:
+    """``{class: dotted paths of the mixins it takes}``, most specific first.
+
+    Two rules, each derived rather than listed. A class takes its behaviour mixin because
+    one is named after it, and it takes :class:`IriEnrichable` because the schema gives it
+    an ``iri`` — a record that may name an entity elsewhere is a record that can be filled
+    from one. Only the classes that declare the slot *directly* are named: a subclass
+    inherits the base it was given, and naming it again would put the same mixin twice in
+    one class statement.
+
+    Behaviour comes first so a behaviour mixin can refine an enrichment method and reach
+    the generic one through ``super()``.
+    """
+    from linkml_runtime.utils.schemaview import SchemaView
+
+    view = SchemaView(str(schema))
+    mixins = {cls: [path] for cls, path in _behaviour_mixins(root, schema).items()}
+    for cls_name in view.all_classes():
+        if "iri" in view.class_slots(cls_name, direct=True):
+            mixins.setdefault(cls_name, []).append(_ENRICHABLE_MIXIN)
+    return mixins
+
+
 def _behaviour_mixins(root: Path, schema: Path) -> dict[str, str]:
     """``{class: dotted path of its behaviour mixin}``, discovered from ``tvbo/behaviour``.
 
@@ -282,18 +309,23 @@ class _DialectBase(BaseModel):
 '''
 
 
-def _mixin_imports(mixins: dict[str, str]) -> str:
-    """``from <module> import <Mixin>`` for each declared behaviour mixin."""
+def _mixin_imports(mixins: dict[str, list[str]]) -> str:
+    """``from <module> import <Mixin>`` for each declared mixin."""
     return "".join(
         f"from {path.rsplit('.', 1)[0]} import {path.rsplit('.', 1)[1]}\n"
-        for path in sorted(set(mixins.values()))
+        for path in sorted({path for paths in mixins.values() for path in paths})
     )
 
 
-def _with_behaviour(code: str, mixins: dict[str, str]) -> str:
-    """Give each annotated dataclass its behaviour mixin.
+def _mixin_bases(mixins: dict[str, list[str]]) -> dict[str, list[str]]:
+    """``{class: mixin class names}`` — the dotted paths reduced to what a base is written as."""
+    return {cls: [path.rsplit(".", 1)[1] for path in paths] for cls, paths in mixins.items()}
 
-    Both generated forms take the same mixin, so behaviour reaches an object whether it
+
+def _with_behaviour(code: str, mixins: dict[str, list[str]]) -> str:
+    """Give each annotated dataclass its mixins.
+
+    Both generated forms take the same mixins, so behaviour reaches an object whether it
     came from LinkML's loader (a dataclass) or from Pydantic validation. Without this the
     dataclasses would lose every helper the moment it moved out of a runtime subclass,
     since that is still what the loaders construct.
@@ -303,14 +335,14 @@ def _with_behaviour(code: str, mixins: dict[str, str]) -> str:
     code = code.replace(
         'metamodel_version = "', _mixin_imports(mixins) + '\nmetamodel_version = "', 1
     )
-    return _inject_bases(code, {cls: [path.rsplit(".", 1)[1]] for cls, path in mixins.items()})
+    return _inject_bases(code, _mixin_bases(mixins))
 
 
-def _with_dialect_and_behaviour(code: str, mixins: dict[str, str]) -> str:
-    """Give the generated models the dialect, and each annotated class its behaviour.
+def _with_dialect_and_behaviour(code: str, mixins: dict[str, list[str]]) -> str:
+    """Give the generated models the dialect, and each annotated class its mixins.
 
     The mixins are imported beside ``_DialectBase``, above every generated class, so a
-    behaviour module must not import the datamodel at module scope — the same discipline
+    mixin module must not import the datamodel at module scope — the same discipline
     :mod:`tvbo.datamodel.dialect` follows.
     """
     code = code.replace(
@@ -319,7 +351,7 @@ def _with_dialect_and_behaviour(code: str, mixins: dict[str, str]) -> str:
         1,
     )
     additions = {"ConfiguredBaseModel": ["_DialectBase"]}
-    additions.update({cls: [path.rsplit(".", 1)[1]] for cls, path in mixins.items()})
+    additions.update(_mixin_bases(mixins))
     return _inject_bases(code, additions)
 
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -50,9 +50,9 @@ def generate_datamodel(root: str | Path) -> None:
         )
     out_dir = root / "tvbo" / "datamodel"
     out_dir.mkdir(parents=True, exist_ok=True)
-    shortcuts, aliases = _dialect_tables(schema)
+    shortcuts, aliases, keyed = _dialect_tables(schema)
     mixins = _behaviour_mixins(root, schema)
-    _write(out_dir / "dialect_tables.py", _render_dialect_tables(shortcuts, aliases))
+    _write(out_dir / "dialect_tables.py", _render_dialect_tables(shortcuts, aliases, keyed))
     _write(
         out_dir / "schema.py",
         _with_behaviour(PythonGenerator(str(schema)).serialize(), mixins) + _INSTALL_DIALECT,
@@ -77,8 +77,8 @@ def generate_datamodel(root: str | Path) -> None:
 _SEMANTIC_ALIASES = ("range", "boundaries")
 
 
-def _dialect_tables(schema: Path) -> tuple[dict, dict]:
-    """``(scalar shortcuts, slot aliases)`` — the TVBO dialect, read once off the schema.
+def _dialect_tables(schema: Path) -> tuple[dict, dict, dict]:
+    """``(scalar shortcuts, slot aliases, keyed collections)`` — the dialect, read off the schema.
 
     LinkML treats ``aliases:`` as documentation — its loaders key on the canonical slot
     name, so a declared alias is inert and raises ``unexpected keyword argument``. Each
@@ -100,6 +100,12 @@ def _dialect_tables(schema: Path) -> tuple[dict, dict]:
     slot whose range has an identifier is a reference by default while leaving
     ``inlined`` unset — six such slots were being wrapped, and since the wrapper then had
     to fit a string-ranged slot it landed as the literal ``"JsonObj(value='x')"``.
+
+    Last, it records each keyed collection's identifier slot, so a member written under
+    its key can be given the name the key already states. The generated dataclasses do
+    that themselves in ``__post_init__``; the generated Pydantic models do not, and a
+    curated entry spelled the way this project requires — ``TR: {value: 720.0}``, no
+    redundant inner ``name`` — was accepted by one form and rejected by the other.
     """
     from linkml_runtime.utils.schemaview import SchemaView
 
@@ -130,6 +136,19 @@ def _dialect_tables(schema: Path) -> tuple[dict, dict]:
         if slot_lifts:
             lifts[cls_name] = slot_lifts
 
+    keyed: dict[str, dict[str, str]] = {}
+    for cls_name in view.all_classes():
+        members = {}
+        for slot in view.class_induced_slots(cls_name):
+            # `inlined_as_list` is a collection whose spelling IS a list; it has no keys.
+            if not slot.multivalued or slot.inlined_as_list or not view.is_inlined(slot):
+                continue
+            identifier = view.get_identifier_slot(str(slot.range), use_key=True)
+            if identifier is not None:
+                members[slot.name] = identifier.name
+        if members:
+            keyed[cls_name] = members
+
     table: dict[str, dict[str, str]] = {}
     for cls_name in view.all_classes():
         amap = {
@@ -143,11 +162,11 @@ def _dialect_tables(schema: Path) -> tuple[dict, dict]:
         amap = {a: c for a, c in amap.items() if a not in own}
         if amap:
             table[cls_name] = amap
-    return lifts, table
+    return lifts, table, keyed
 
 
-def _render_dialect_tables(shortcuts: dict, aliases: dict) -> str:
-    """The two dialect tables as their own module.
+def _render_dialect_tables(shortcuts: dict, aliases: dict, keyed: dict) -> str:
+    """The dialect tables as their own module.
 
     Kept apart from ``schema.py`` so the Pydantic models can read them without importing
     the dataclasses: that import is the coupling the migration exists to remove, and it
@@ -158,11 +177,14 @@ def _render_dialect_tables(shortcuts: dict, aliases: dict) -> str:
 ``SCALAR_SHORTCUTS`` maps ``{{class: {{slot: (slot the bare scalar stands for,
 multivalued, keyed)}}}}``, from ``annotations.simple_dict_value`` on each range class.
 ``SLOT_ALIASES`` maps ``{{class: {{alias: canonical slot}}}}`` from the schema's ``aliases:``.
+``KEYED_COLLECTIONS`` maps ``{{class: {{slot: the member slot its key states}}}}``.
 """
 
 SCALAR_SHORTCUTS = {shortcuts!r}
 
 SLOT_ALIASES = {aliases!r}
+
+KEYED_COLLECTIONS = {keyed!r}
 '''
 
 

--- a/schema/tvbo_datamodel.yaml
+++ b/schema/tvbo_datamodel.yaml
@@ -1451,8 +1451,15 @@ classes:
             coupling:
                 multivalued: true
                 range: Coupling
-                description: "Reusable coupling configurations referenced by edges (e.g., 'instant', 'delayed', 'inhibitory')"
                 inlined: true
+                description: >-
+                    How activity travels along this network's connections — the one
+                    place a coupling function is declared, because a coupling acts
+                    over a connectivity and has no meaning without one.
+                    Keyed by the role each plays in the network ('excitatory',
+                    'delayed', 'inhibitory'), so a network may carry several and an
+                    edge names the one it uses. A network with a single coupling
+                    applies it to every edge.
             graph_representation:
                 range: GraphRepresentation
                 ifabsent: string(auto)
@@ -1974,7 +1981,7 @@ classes:
             coupling:
                 range: Coupling
                 required: false
-                description: "Coupling function for this edge. Can be a reference (by name) to coupling or inline definition. If not provided, uses experiment's default coupling."
+                description: "Coupling function for this edge, named by reference into 'network.coupling' or defined inline. If not provided, the edge takes the network's coupling."
                 inlined: false
             directed:
                 range: boolean
@@ -4565,6 +4572,15 @@ classes:
         slot_usage:
             name:
                 ifabsent: "Linear"
+            iri:
+                aliases:
+                    - type
+                description: >-
+                    The coupling function this record is an instance of. A
+                    ``network.coupling`` entry is keyed by its role in the network
+                    ('excitatory', 'delayed'), so naming the function it instantiates
+                    is what ``iri`` is for; ``type`` is accepted as the older spelling
+                    of the same thing.
         attributes:
             # Standard coupling attributes
             coupling_function:
@@ -5099,9 +5115,6 @@ classes:
                 deprecated: "Use 'network' instead. 'connectivity' is kept for backward compatibility only and will be removed in a future version."
             network:
                 range: Network
-                inlined: true
-            coupling:
-                range: Coupling
                 inlined: true
             observations:
                 multivalued: true

--- a/tests/reference_data/database/experiments__RateML_ReducedWongWang.yaml
+++ b/tests/reference_data/database/experiments__RateML_ReducedWongWang.yaml
@@ -152,6 +152,22 @@ integration:
   delayed: true
   coupling_evaluation: per_step
 network:
+  coupling:
+    LinearCoupling:
+      name: LinearCoupling
+      sparse: false
+      pre_expression:
+        rhs: V_j
+        latex: false
+      post_expression:
+        rhs: '1'
+        latex: false
+      incoming_states:
+      - V
+      delayed: true
+      interpolate_delays: false
+      vectorized: false
+      symmetry: directed
   graph_representation: auto
   dynamics:
     BalloonWindkessel:
@@ -305,21 +321,6 @@ network:
       compile: false
   number_of_nodes: 4
   distance_unit: mm
-coupling:
-  name: LinearCoupling
-  sparse: false
-  pre_expression:
-    rhs: V_j
-    latex: false
-  post_expression:
-    rhs: '1'
-    latex: false
-  incoming_states:
-  - V
-  delayed: true
-  interpolate_delays: false
-  vectorized: false
-  symmetry: directed
 observations:
   bold:
     name: bold

--- a/tests/reference_data/database/experiments__Stimulation_Bayesian_Inference.yaml
+++ b/tests/reference_data/database/experiments__Stimulation_Bayesian_Inference.yaml
@@ -101,22 +101,7 @@ network:
           name: G
           value: 0.0
           description: No inter-node coupling (single node)
-        b:
-          name: b
-          value: 0.0
-          description: Shifts the base of the connection strength while maintaining
-            the absolute difference between different values.
-        a:
-          name: a
-          value: 0.00390625
-          description: Linear scaling factor of the coupled (delayed) input.
       sparse: false
-      pre_expression:
-        rhs: x_j
-        latex: false
-      post_expression:
-        rhs: a*gx + b
-        latex: false
       incoming_states:
       - V
       delayed: false

--- a/tests/test_accelerator_platform.py
+++ b/tests/test_accelerator_platform.py
@@ -44,16 +44,16 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration:
   method: RungeKutta4thOrder
   duration: 20.0

--- a/tests/test_bounded_solver_codegen.py
+++ b/tests/test_bounded_solver_codegen.py
@@ -47,16 +47,16 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration:
   method: RungeKutta4thOrder
   duration: 20.0

--- a/tests/test_correlated_noise_codegen.py
+++ b/tests/test_correlated_noise_codegen.py
@@ -48,15 +48,15 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: LinearCoupling
-  label: LinearCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-  pre_expression: {rhs: "x_j"}
-  post_expression: {rhs: "a * gx"}
-  incoming_states: [x]
-  local_states: [x]
+  coupling:
+    LinearCoupling:
+      label: LinearCoupling
+      parameters:
+        a: {value: 0.01}
+      pre_expression: {rhs: "x_j"}
+      post_expression: {rhs: "a * gx"}
+      incoming_states: [x]
+      local_states: [x]
 integration:
   method: Heun
   duration: 20.0

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,0 +1,131 @@
+"""``enrich()`` — filling a record's gaps from the entity it names.
+
+Construction resolves what is deterministic, local and cheap: the dialect expands an
+``iri`` from one curated file. Everything past that is an act the caller asks for, and
+``enrich()`` is the verb. What these pin is that it is one verb with one contract, reached
+by a rule rather than a list — the schema says which classes carry it, and the class says
+which sources answer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tvbo.datamodel import pydantic as pyd
+from tvbo.datamodel import schema
+
+GENERATED_FORMS = pytest.mark.parametrize("model", (schema, pyd), ids=("dataclass", "pydantic"))
+
+
+@pytest.mark.backend_core
+def test_the_schema_says_which_classes_are_enrichable():
+    """A class that may name an entity elsewhere is one that can be filled from it.
+
+    Nothing lists them: declaring the slot is what makes a class's records enrichable, and
+    a subclass inherits the base its parent was given.
+    """
+    from tvbo.behaviour._enrich import IriEnrichable
+
+    for form in (schema, pyd):
+        for cls_name in ("Coupling", "Dynamics", "Observation", "Function", "LossFunction"):
+            assert issubclass(getattr(form, cls_name), IriEnrichable), f"{form.__name__}.{cls_name}"
+
+    assert "iri" not in schema.Integrator.__dataclass_fields__
+    assert not issubclass(schema.Integrator, IriEnrichable)
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_record_is_filled_from_what_it_names(model):
+    """By ``name`` when it has one; a self-contained record simply gains nothing."""
+    coupling = model.Coupling(name="KuramotoCoupling")
+    assert coupling.pre_expression is None
+
+    coupling.enrich()
+    assert coupling.pre_expression is not None
+    assert "a" in coupling.parameters
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_filling_never_overwrites(model):
+    """Gap-filling is the whole contract: what the record carries, it keeps."""
+    coupling = model.Coupling(
+        name="KuramotoCoupling",
+        pre_expression={"rhs": "sin(x_j - x_i)"},
+        parameters={"a": {"value": 99.0}},
+    )
+
+    coupling.enrich()
+
+    assert str(coupling.pre_expression.rhs) == "sin(x_j - x_i)"
+    assert coupling.parameters["a"].value == 99.0
+    assert len(coupling.parameters) > 1, "siblings from the entry were dropped"
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_pointer_that_resolves_nowhere_raises(model):
+    """An ``iri`` is a pointer, and one pointing at nothing is a typo worth hearing about."""
+    coupling = model.Coupling(iri="tvbo:NoSuchCouplingAnywhere")
+
+    with pytest.raises(LookupError, match="NoSuchCouplingAnywhere"):
+        coupling.enrich()
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_bare_name_that_resolves_nowhere_does_not(model):
+    """A self-contained record that happens to be called something is the normal case."""
+    coupling = model.Coupling(name="MyOwnPrivateCoupling")
+    assert coupling.enrich() is coupling
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_key_redirects_the_lookup(model):
+    """A record named for its role in a network still declares what it is an instance of."""
+    coupling = model.Coupling(name="ExcitatoryCoupling")
+    coupling.enrich(key="KuramotoCoupling")
+
+    assert coupling.name == "ExcitatoryCoupling"
+    assert coupling.pre_expression is not None
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_source_the_class_does_not_have_raises(model):
+    """Sources dispatch on the reader the class defines, so asking for a missing one is an error."""
+    with pytest.raises(ValueError, match="ontology"):
+        model.Function(name="f").enrich(source="ontology")
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_filling_leaves_the_class_its_own_containers(model):
+    """Assigning a plain container into a LinkML slot is what makes a ``JsonObj``.
+
+    A keyed collection is therefore mutated, never assigned — otherwise the setter wraps
+    what it is handed and the typed members inside stop reading as themselves.
+    """
+    from tvbo.utils import keyed_items
+
+    observation = model.Observation(name="mine", iri="tvbo:BOLD_TVB")
+    observation.enrich(source="database")
+
+    names = [name for name, _ in keyed_items(observation.parameters, "parameters")]
+    assert "TR" in names
+    for _, parameter in keyed_items(observation.parameters, "parameters"):
+        assert parameter.value is not None, "a member was flattened by the setter"
+
+
+@pytest.mark.backend_core
+def test_a_model_is_left_where_construction_would_have():
+    """Filling a model can add derived variables, which the emitters read in dependency order."""
+    from tvbo.classes.dynamics import Dynamics
+
+    model = Dynamics(name="Generic2dOscillator")
+    model.enrich()
+
+    assert model.state_variables
+    assert model.parameters

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -65,6 +65,46 @@ def test_filling_never_overwrites(model):
 
 @pytest.mark.backend_core
 @GENERATED_FORMS
+def test_the_first_source_that_resolves_answers_alone(monkeypatch, model):
+    """Ranked, not combined — otherwise one record enriches to two different things.
+
+    Topping a curated record up from the ontology adds whatever the curators left out,
+    and only where the ontology resolves the same names: ``Sigmoidal`` filled from both
+    came to 5 parameters locally and 10 in CI, from the same YAML.
+
+    Asserted on the mechanism rather than a count, so it holds wherever it runs.
+    """
+    reached = []
+    monkeypatch.setattr(
+        type(model.Coupling(name="probe")),
+        "_from_ontology",
+        lambda self, key: reached.append(key) or True,
+    )
+
+    coupling = model.Coupling(name="Mine", iri="tvbo:Sigmoidal").enrich()
+
+    assert coupling.parameters, "the database source did not answer"
+    assert reached == [], "the ontology was consulted after the database had answered"
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_later_source_answers_when_the_first_does_not(monkeypatch, model):
+    """Ranked means fallback, not exclusivity: the ontology still covers what is uncurated."""
+    reached = []
+    monkeypatch.setattr(
+        type(model.Coupling(name="probe")),
+        "_from_ontology",
+        lambda self, key: reached.append(key) or True,
+    )
+
+    model.Coupling(name="Mine", iri="tvbo:NotCuratedAnywhere").enrich()
+
+    assert reached == ["NotCuratedAnywhere"]
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
 def test_a_pointer_that_resolves_nowhere_raises(model):
     """An ``iri`` is a pointer, and one pointing at nothing is a typo worth hearing about."""
     coupling = model.Coupling(iri="tvbo:NoSuchCouplingAnywhere")

--- a/tests/test_event_weight_parameter.py
+++ b/tests/test_event_weight_parameter.py
@@ -54,16 +54,16 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration:
   method: RungeKutta4thOrder
   duration: 20.0

--- a/tests/test_initial_conditions_axis.py
+++ b/tests/test_initial_conditions_axis.py
@@ -86,16 +86,16 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration:
   method: RungeKutta4thOrder
   duration: 20.0

--- a/tests/test_keyed_collections.py
+++ b/tests/test_keyed_collections.py
@@ -1,0 +1,84 @@
+"""A keyed collection means the same thing in both generated forms, and in both spellings.
+
+``parameters: {TR: {value: 720.0}}`` says a Parameter *called* ``TR``, so writing the name
+a second time inside the member is a redundancy this project's records are written without.
+Only the generated dataclasses acted on that: they fill the identifier from the key, and
+the generated Pydantic models left it missing and rejected the member as incomplete. The
+list spelling of the same collection they rejected outright, as not a mapping.
+
+Both are the dialect's business — it is the one implementation both construction paths run
+— and what these pin is that neither the form nor the spelling changes what a record means.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tvbo.datamodel import pydantic as pyd
+from tvbo.datamodel import schema
+
+GENERATED_FORMS = pytest.mark.parametrize("model", (schema, pyd), ids=("dataclass", "pydantic"))
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_member_is_named_by_its_key(model):
+    """The mapping spelling, with no redundant inner name."""
+    coupling = model.Coupling(name="C", parameters={"a": {"value": 1.5}})
+
+    assert coupling.parameters["a"].name == "a"
+    assert coupling.parameters["a"].value == 1.5
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_the_list_spelling_means_the_same(model):
+    """A list of bare identifiers, and a list of whole members, both arrive keyed."""
+    bare = model.Function(name="f", arguments=["v", "w"])
+    assert [str(argument) for argument in bare.arguments] == ["v", "w"]
+
+    whole = model.Coupling(name="C", parameters=[{"name": "a", "value": 1.5}])
+    assert whole.parameters["a"].value == 1.5
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_member_may_still_state_its_own_name(model):
+    """Fifty curated files spell it; the key and the name agree, and the name is kept."""
+    coupling = model.Coupling(name="C", parameters={"a": {"name": "a", "value": 1.5}})
+    assert coupling.parameters["a"].name == "a"
+
+
+@pytest.mark.backend_core
+@GENERATED_FORMS
+def test_a_curated_record_loads_on_either_form(model):
+    """The regression: an ``iri`` reference to a record written without redundant names.
+
+    ``BOLD_TVB`` writes ``TR: {value: 720.0}``. The dataclass form took it and the Pydantic
+    form raised ``Field required: parameters.TR.name`` — the same YAML meaning two different
+    things depending on which generated class read it.
+    """
+    observation = model.Observation(iri="tvbo:BOLD_TVB")
+
+    assert observation.parameters["TR"].value == 720.0
+    assert observation.parameters["TR"].name == "TR"
+    assert observation.pipeline
+
+
+@pytest.mark.backend_core
+def test_an_unkeyable_list_is_left_to_fail():
+    """Members stating no identifier cannot be keyed, and guessing is worse than raising."""
+    from tvbo.datamodel.dialect import key_members
+
+    data = {"parameters": [{"value": 1.5}]}
+    key_members("Coupling", data)
+
+    assert data["parameters"] == [{"value": 1.5}]
+
+
+@pytest.mark.backend_core
+def test_a_list_valued_collection_is_not_keyed():
+    """``inlined_as_list`` is a collection whose spelling IS a list; it has no keys."""
+    from tvbo.datamodel.dialect import KEYED_COLLECTIONS
+
+    assert "constructor_args" not in KEYED_COLLECTIONS.get("ClassReference", {})

--- a/tests/test_metadata_resolution.py
+++ b/tests/test_metadata_resolution.py
@@ -68,8 +68,8 @@ def test_dynamics_from_db_backcompat():
 def _exp(**net):
     from tvbo import SimulationExperiment
 
+    net.setdefault("network", {}).setdefault("coupling", {"long_range": {"iri": "tvbo:Linear"}})
     return SimulationExperiment(
-        coupling={"iri": "tvbo:Linear"},
         integration={"method": "Heun", "noise": None},
         **net,
     )
@@ -113,11 +113,21 @@ def test_coupling_iri_resolves_by_local_name(curie, expected):
 
 
 def test_coupling_explicit_name_preserved():
+    """A named coupling keeps its name and is filled from the function its ``iri`` names.
+
+    Naming it makes the record a definition, so construction expands nothing — that stays
+    the cheap, local step. ``enrich()`` is where it draws on the function it says it is an
+    instance of, and a ``network.coupling`` entry gets that at experiment load.
+    """
     from tvbo.classes.coupling import Coupling
 
     c = Coupling(name="MyCustom", iri="tvbo:Sigmoidal")
-    assert c.name == "MyCustom"                  # explicit name wins
-    assert len(c.parameters) == 5                # but params from Sigmoidal
+    assert c.name == "MyCustom"
+    assert not c.parameters
+
+    c.enrich()
+    assert c.name == "MyCustom"                  # explicit name still wins
+    assert len(c.parameters) == 5                # params now from Sigmoidal
 
 
 @pytest.mark.parametrize("curie", ["tvbo:Linear", "tvbo:Sigmoidal", "tvbo:SigmoidalJansenRit"])

--- a/tests/test_run_models.py
+++ b/tests/test_run_models.py
@@ -13,8 +13,8 @@ def test_simulation_experiment(model):
 
     metadata = {
         "dynamics": model,
-        "coupling": "Linear",
         "network": {
+            "coupling": {"long_range": {"iri": "tvbo:Linear"}},
             "parcellation": {
                 "atlas": {
                     "name": "DesikanKilliany",

--- a/tests/test_tvboptim_byte_identity.py
+++ b/tests/test_tvboptim_byte_identity.py
@@ -229,16 +229,16 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration:
   method: RungeKutta4thOrder
   duration: 200.0
@@ -338,17 +338,17 @@ network:
       parameters:
         weight: {value: 0.5}
         distance: {value: 30.0}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  delayed: true
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      delayed: true
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration:
   method: RungeKutta4thOrder
   duration: 200.0
@@ -1190,14 +1190,14 @@ network:
   edges:
     - {source: 0, target: 1, parameters: {weight: {value: 0.5}, delay: {value: 12.0}}}
     - {source: 1, target: 0, parameters: {weight: {value: 0.5}, delay: {value: 12.0}}}
-coupling:
-  name: KuramotoCoupling
-  delayed: true
-  parameters: {a: {value: 0.05}, N: {value: 1.0}}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      delayed: true
+      parameters: {a: {value: 0.05}, N: {value: 1.0}}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration: {method: Heun, duration: 100.0, step_size: 0.5, transient_time: 0.0}
 """
 

--- a/tests/test_warmstart_resolve.py
+++ b/tests/test_warmstart_resolve.py
@@ -47,17 +47,17 @@ network:
   edges:
     - {source: 0, target: 1, weight: 0.5}
     - {source: 1, target: 0, weight: 0.5}
-coupling:
-  name: KuramotoCoupling
-  label: KuramotoCoupling
-  parameters:
-    a: {name: a, value: 0.01}
-    N: {name: N, value: 1.0}
-    wLRE: {name: wLRE, value: 1.0, free: true, heterogeneous: true, shape: "(n_nodes, n_nodes)", measure: wLRE}
-  pre_expression: {rhs: "sin(theta_j - theta_i)"}
-  post_expression: {rhs: "a * gx / N"}
-  incoming_states: [theta]
-  local_states: [theta]
+  coupling:
+    KuramotoCoupling:
+      label: KuramotoCoupling
+      parameters:
+        a: {value: 0.01}
+        N: {value: 1.0}
+        wLRE: {value: 1.0, free: true, heterogeneous: true, shape: "(n_nodes, n_nodes)", measure: wLRE}
+      pre_expression: {rhs: "sin(theta_j - theta_i)"}
+      post_expression: {rhs: "a * gx / N"}
+      incoming_states: [theta]
+      local_states: [theta]
 integration: {method: RungeKutta4thOrder, duration: 10.0, step_size: 1.0, transient_time: 0.0}
 """
 

--- a/todo.md
+++ b/todo.md
@@ -35,19 +35,19 @@ statements**, then retire the isolated world (inverting the Phase-A
 `api.world is not owl.onto.world` invariant). Full file-by-file spec, impact map,
 and verification: **see `dev/runtime_ontology_migration.md` §3.0–§5**.
 
-**Design principle: three explicit load routes; YAML supervenes (from PR #43).**
+**Design principle: three explicit load routes; YAML supervenes (from PR #43). DONE — #95.**
 A model / experiment / class spec can be obtained three ways, all supported:
 1. **From ontology** — explicit (`Dynamics.from_ontology`).
 2. **From YAML / string / metadata** — the default
-   (`from_file`/`from_string`/`from_datamodel`/`from_db`, `use_ontology=False`).
-3. **From YAML enriched by ontology** — explicit opt-in (`use_ontology=True` /
-   `enrich_from_ontology()`).
+   (`from_file`/`from_string`/`from_datamodel`/`from_db`).
+3. **From YAML enriched by another source** — explicit (`enrich()`).
 
-Rules: **YAML supervenes** — by default the ontology is not touched; **enrichment
-is NOT the default** and, when requested, only **fills missing pieces** (never
-overrides a value present in the YAML). The load side already honours this
-(default `use_ontology=False`); TODO: verify `enrich_from_ontology` /
-`_populate_from_ontology` are strictly gap-fill and never clobber YAML.
+Rules: **YAML supervenes** — the ontology is never touched at construction, and
+enrichment only **fills missing pieces**. Construction resolves what is
+deterministic, local and cheap: `dialect.expand_iri` reads the one curated file an
+`iri` reference names. `enrich()` is the verb for everything past that; it is
+carried by every class the schema declares an `iri` on, and its sources dispatch on
+the reader the class defines.
 
 Concrete route-3 example — a component referenced by `iri` draws its spec from
 the ontology, with inline metadata overriding on top (YAML supervenes):
@@ -1170,19 +1170,17 @@ Depends on:
   need new DB entries.
 
 
-## Drop `use_ontology` / `_skip_ontology` flags once IRI handling is canonical
-- Today there are ~37 occurrences across `tvbo/` of `use_ontology`, `_skip_ontology`, `_populate_from_ontology*` runtime flags that gate ontology backfill.
-- Once IRI is the canonical way to declare a sourced component, the flag becomes redundant: **iri present → use ontology/DB data; iri absent → fully self-contained spec.**
-- Override semantics should follow YAML/dict merge: ontology defaults are the base, user-provided fields override key by key. Example target:
-    ```python
+## Drop `use_ontology` / `_skip_ontology` flags once IRI handling is canonical — DONE (#95)
+`use_ontology`, `_skip_ontology`, `_populate_from_ontology*` and `enrich_from_ontology`
+are gone, along with the three hand-rolled `iri`-expansions (dynamics, coupling,
+observation). What replaced them:
+
     Dynamics(iri='tvbo:ReducedWongWang', parameters={'a': {'value': 2}})
-    # → loads all parameters/state_variables from ontology, then overrides only a.value
-    ```
-- Cleanup steps:
-    1. Remove `use_ontology` / `_skip_ontology` parameters from `DynamicalSystem.__init__`, `Dynamics.from_*`, `Coupling.*` and any other class constructors.
-    2. Remove the explicit `_populate_from_ontology_by_name()` / `_populate_from_ontology()` call sites — they become unconditional inside the single `_resolve_iri` step from the previous TODO.
-    3. Ensure parameter/state-variable merging is non-destructive: user dict values overwrite at the leaf level (e.g. `parameters.a.value`), not the whole `parameters` slot.
-    4. Update tests that pass `use_ontology=True/False` explicitly.
+
+expands in the dialect, before validation — the only point that still knows which keys the
+recipe wrote — merging leaf by leaf so `a.value` supervenes and its siblings are inherited.
+Reaching the ontology is `enrich()`, one verb across Dynamics, Coupling, Observation,
+Function and Integrator.
 
 
 ## Experimental / parked

--- a/tvbo/adapters/base.py
+++ b/tvbo/adapters/base.py
@@ -96,23 +96,23 @@ class BaseAdapter:
     # ── Coupling ─────────────────────────────────────────────────────────
 
     def resolve_couplings(self) -> OrderedDict:
-        """Collect all unique coupling models as an OrderedDict."""
-        exp = self.experiment
-        nw_couplings = getattr(exp.network, "coupling", None) or {}
-        if isinstance(nw_couplings, dict) and nw_couplings:
-            return OrderedDict(nw_couplings)
-        coupling = exp.coupling
-        if coupling:
-            return OrderedDict({coupling.name: coupling})
-        return OrderedDict()
+        """The network's couplings, keyed by the role each plays in it.
+
+        The one place a backend asks what couplings an experiment has, so that a template
+        never derives it: a template that reads the model itself is a second answer to a
+        question this class already answers, and the two drift. A backend needing them
+        keyed differently overrides this and calls up — see ``TvboptimAdapter``.
+        """
+        from tvbo.utils import keyed_items
+
+        network = getattr(self.experiment, "network", None)
+        return OrderedDict(keyed_items(getattr(network, "coupling", None), "coupling"))
 
     def get_default_coupling(self, all_couplings: OrderedDict | None = None):
-        """Return the default (first) coupling model."""
+        """The coupling a backend applies where an edge names none — the first declared."""
         if all_couplings is None:
             all_couplings = self.resolve_couplings()
-        if all_couplings:
-            return next(iter(all_couplings.values()))
-        return self.experiment.coupling
+        return next(iter(all_couplings.values()), None)
 
     # ── Coupling dimension ───────────────────────────────────────────────
 

--- a/tvbo/adapters/tvb.py
+++ b/tvbo/adapters/tvb.py
@@ -975,12 +975,13 @@ def from_tvb_simulator(
 
     dynamics = _extract_dynamics(sim)
     network = from_tvb(sim.connectivity)
+    coupling = _extract_coupling(sim)
+    network.coupling[str(coupling.name)] = coupling
 
     exp = tvbo_datamodel.SimulationExperiment(
         id=experiment_id,
         model=dynamics.name,
         dynamics=dynamics,
-        coupling=_extract_coupling(sim),
         integration=_extract_integration(sim, dynamics),
         network=network,
         stimulation=_extract_stimulus(sim),

--- a/tvbo/adapters/tvboptim.py
+++ b/tvbo/adapters/tvboptim.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from tvbo.adapters.base import BaseAdapter
 from tvbo.adapters.smallscale.lowering import node_dynamics_name
 from tvbo.utils import as_list, noise_sigma, normalize_params
 
@@ -31,6 +32,23 @@ SOLVER_MAP = {
     "rungekutta4": "RungeKutta4",
     "rungekutta4thorder": "RungeKutta4",
 }
+
+
+class TvboptimAdapter(BaseAdapter):
+    """What the tvboptim templates need, resolved in Python before they emit anything."""
+
+    def resolve_couplings(self):
+        """The network's couplings, one key per distinct coupling.
+
+        tvbo can reach the same coupling under more than one name — the function's, a
+        coupling-input key, an explicit ``CouplingInput.source`` — and tvboptim wants one
+        key per object, so the aliases are collapsed against the model that names them.
+        """
+        from tvbo.templates.tvboptim.utils import normalize_coupling_aliases
+
+        return normalize_coupling_aliases(
+            dict(super().resolve_couplings()), getattr(self.experiment, "dynamics", None)
+        )
 
 
 def _build_graph(network: "Network", delays: bool = True, max_delay: float | None = None):

--- a/tvbo/api/ontology_api.py
+++ b/tvbo/api/ontology_api.py
@@ -446,14 +446,16 @@ class OntologyAPI:
         Accepts either legacy ``model``/``connectivity`` keys or the current
         ``dynamics``/``network`` keys.  Model and coupling names are resolved
         via ``Dynamics.from_db`` / ``Coupling.from_db`` so that equations,
-        parameters, and state variables are fully populated.
+        parameters, and state variables are fully populated. A coupling named at
+        the top level is placed on the network it acts over, which is where the
+        schema declares one.
 
         Example metadata::
 
             {
                 "dynamics": "Generic2dOscillator",
-                "coupling": "Linear",
                 "network": {
+                    "coupling": {"long_range": {"iri": "tvbo:Linear"}},
                     "parcellation": {"atlas": {"name": "DesikanKilliany"}},
                     "tractogram": {"name": "dTOR"},
                 },
@@ -476,7 +478,7 @@ class OntologyAPI:
                 dyn_name = str(dyn_raw)
             md["dynamics"] = Dynamics.from_db(dyn_name)
 
-        # --- Resolve coupling name → full Coupling object ---
+        # --- Resolve a coupling named at the top level onto the network it acts over ---
         coup_raw = md.pop("coupling", None)
         if coup_raw is not None:
             if isinstance(coup_raw, str):
@@ -485,7 +487,8 @@ class OntologyAPI:
                 coup_name = coup_raw.get("name") or coup_raw.get("label", "Linear")
             else:
                 coup_name = str(coup_raw)
-            md["coupling"] = Coupling.from_db(coup_name)
+            network = md.setdefault("network", {})
+            network.setdefault("coupling", {})[coup_name] = Coupling.from_db(coup_name)
 
         # --- Normalise legacy connectivity → network ---
         if "connectivity" in md and "network" not in md:

--- a/tvbo/behaviour/__init__.py
+++ b/tvbo/behaviour/__init__.py
@@ -29,4 +29,11 @@ Three rules keep this working:
   method that needs it.
 * A mixin's name must end in ``Behaviour`` and its stem must name a class the schema
   defines, or the build fails — otherwise it would attach to nothing, silently.
+
+One mixin attaches by a schema rule instead of by its name: :class:`IriEnrichable`, which
+``hatch_build`` gives to every class the schema declares an ``iri`` on. It lives in
+:mod:`tvbo.behaviour._enrich`, under a leading underscore, because the name rule above
+would otherwise look for a class called ``Enrich``. A behaviour mixin may refine what it
+provides — ``DynamicsBehaviour._from_ontology`` is how a model reaches the ontology — and
+reach the generic implementation through ``super()``, since behaviour is listed first.
 """

--- a/tvbo/behaviour/_enrich.py
+++ b/tvbo/behaviour/_enrich.py
@@ -1,0 +1,158 @@
+"""Filling a record's gaps from the entity it names.
+
+An entity written by ``iri`` — or by a name the curated database knows — is expanded at
+construction by :func:`tvbo.datamodel.dialect.expand_iri`, which reads one local file and
+nothing else. Everything beyond that is an act the caller asks for, and this is the verb
+for it: ``enrich()``.
+
+Which classes carry it is read off the schema. A class the schema gives an ``iri`` slot is
+a class whose records may name an entity elsewhere, so ``hatch_build`` makes this a base
+of it in both generated forms; subclasses inherit. Nothing lists them, and adding the slot
+to a class is what makes its records enrichable.
+
+Which sources answer is read off the class. ``database`` is implemented here and applies to
+every enrichable record; ``ontology`` is a ``_from_ontology`` a behaviour mixin defines,
+so a class reaches the ontology by knowing how to, rather than by being named in a table
+here. The two are ordered rather than equal: the database is a local file whose content is
+ordered, while the ontology answers with an unordered set — a different parameter order per
+process — so it is consulted only for what the database did not have.
+
+The mixin is deliberately not named ``*Behaviour``: that name attaches a class by its stem
+(``EventBehaviour`` -> ``Event``), and this one attaches by a schema rule instead.
+"""
+
+from __future__ import annotations
+
+from jsonasobj2 import JsonObj
+
+#: Consulted in order; each names a ``_from_<source>(key) -> bool`` reader.
+SOURCES = ("database", "ontology")
+
+#: The container types a slot may hold; anything else is a value, array included.
+#: ``JsonObj`` is the LinkML dataclasses' own container and goes when they do.
+_CONTAINERS = (dict, list, tuple, JsonObj)
+
+
+def _unset(value) -> bool:
+    """Whether *value* is a gap: nothing, or a container holding nothing."""
+    return value is None or (isinstance(value, _CONTAINERS) and not value)
+
+
+def _schema_class(cls) -> str:
+    """The schema class *cls* is, which is not always what Python calls it.
+
+    Every table read here is keyed by the schema — the curated database's categories, the
+    keyed collections — and a runtime subclass is still the schema class it extends:
+    ``DynamicalSystem`` is a ``Dynamics``. The dataclasses state it outright; for the
+    Pydantic models the generated class is the one that names it.
+    """
+    declared = getattr(cls, "class_name", None)
+    if declared:
+        return str(declared)
+    for base in cls.__mro__:
+        if base.__module__.startswith("tvbo.datamodel."):
+            return base.__name__
+    return cls.__name__
+
+
+class IriEnrichable:
+    """Gap-filling from the entity this record names."""
+
+    def enrich(self, source: str | None = None, key: str | None = None):
+        """Fill this record's gaps from the entity it names, and return it.
+
+        Gap-filling only: a slot this record already carries is never overwritten, and a
+        keyed collection gains the members it lacks while keeping the ones it has. That is
+        the whole contract, and it is why this can run after construction — unlike the
+        ``iri`` expansion in the dialect, which has to distinguish an authored value from a
+        schema default and so must run before one is applied.
+
+        Args:
+            source: Consult only this source. By default every source the class has is
+                tried, in :data:`SOURCES` order, and each fills what the ones before left.
+            key: The entity to enrich *from*, when this record does not name it itself —
+                a ``network.coupling`` entry named for its role in the network, say,
+                declaring the coupling function it is an instance of. Defaults to what
+                this record names: its ``iri``'s local name, else its ``name``.
+
+        Raises:
+            ValueError: *source* is not a source this class has.
+            LookupError: the entity was named by a pointer — an explicit *key*, or this
+                record's ``iri`` — and no source resolves it. Falling back to a bare
+                ``name`` that resolves nowhere is not an error: a self-contained record
+                that happens to be called something is the normal case.
+        """
+        wanted = SOURCES if source is None else (source,)
+        pointer = key or getattr(self, "iri", None)
+        key = key or self._named_entity()
+        cls_name = _schema_class(type(self))
+        found = False
+        for name in wanted:
+            reader = getattr(self, f"_from_{name}", None)
+            if reader is None:
+                if source is not None:
+                    raise ValueError(f"{cls_name} has no {name!r} to enrich from.")
+                continue
+            found |= bool(key and reader(key))
+        if not found and pointer:
+            raise LookupError(f"{cls_name} names {pointer!r}, which no source resolves.")
+        return self
+
+    def _named_entity(self) -> str | None:
+        """The entity this record names: its ``iri``'s local name, else its ``name``."""
+        from tvbo.data.registry import local_name
+
+        iri = getattr(self, "iri", None)
+        return local_name(iri) if iri else getattr(self, "name", None)
+
+    def _from_database(self, key: str) -> bool:
+        """Gap-fill from the curated record *key* names. True when one was found.
+
+        The entry is raw YAML, so it is handed to this class's own constructor rather than
+        read slot by slot: that types every member, in this object's own generated form,
+        and applies the dialect the entry itself is written in.
+        """
+        from tvbo.datamodel.dialect import curated_entry
+
+        entry = curated_entry(_schema_class(type(self)), key)
+        if entry is None:
+            return False
+        self._gap_fill(type(self)(**entry))
+        return True
+
+    def _gap_fill(self, other) -> None:
+        """Take from *other* every slot this record leaves unset.
+
+        A keyed collection is never assigned, only mutated member by member — so a record
+        declaring one parameter of ten gains the other nine and keeps its own, and, just as
+        importantly, the container the class built is the one that stays. Assigning a plain
+        Python container into a LinkML slot is what produces a ``JsonObj``: the setter wraps
+        whatever it is handed, and the typed members inside it stop reading as themselves.
+        Which slots are keyed collections is read off the schema rather than sniffed from
+        the value, so this holds for both generated forms and for an empty collection too.
+        """
+        from tvbo.datamodel.dialect import KEYED_COLLECTIONS
+        from tvbo.utils import keyed_items
+
+        collections = KEYED_COLLECTIONS.get(_schema_class(type(self)), {})
+        for slot in _slots(type(self)):
+            theirs = getattr(other, slot, None)
+            if _unset(theirs):
+                continue
+            mine = getattr(self, slot, None)
+            if slot not in collections:
+                if _unset(mine):
+                    setattr(self, slot, theirs)
+                continue
+            if mine is None:
+                setattr(self, slot, {})
+                mine = getattr(self, slot)
+            for member, value in keyed_items(theirs, slot):
+                if member not in mine:
+                    mine[member] = value
+
+
+def _slots(cls) -> tuple[str, ...]:
+    """*cls*'s schema slots, whichever generated form it is."""
+    fields = getattr(cls, "__dataclass_fields__", None)
+    return tuple(fields) if fields is not None else tuple(cls.model_fields)

--- a/tvbo/behaviour/_enrich.py
+++ b/tvbo/behaviour/_enrich.py
@@ -13,9 +13,11 @@ to a class is what makes its records enrichable.
 Which sources answer is read off the class. ``database`` is implemented here and applies to
 every enrichable record; ``ontology`` is a ``_from_ontology`` a behaviour mixin defines,
 so a class reaches the ontology by knowing how to, rather than by being named in a table
-here. The two are ordered rather than equal: the database is a local file whose content is
-ordered, while the ontology answers with an unordered set — a different parameter order per
-process — so it is consulted only for what the database did not have.
+here. They are ranked rather than combined: the first that resolves the entity answers
+alone. The database is a local file whose content is curated and ordered, and the ontology
+answers with an unordered set, so a curated record topped up from the ontology would gain
+whatever the curators left out — and only in a process where the ontology happens to be
+loaded, which is one record enriching to two different things.
 
 The mixin is deliberately not named ``*Behaviour``: that name attaches a class by its stem
 (``EventBehaviour`` -> ``Event``), and this one attaches by a schema rule instead.
@@ -68,8 +70,12 @@ class IriEnrichable:
         schema default and so must run before one is applied.
 
         Args:
-            source: Consult only this source. By default every source the class has is
-                tried, in :data:`SOURCES` order, and each fills what the ones before left.
+            source: Consult only this source. By default the sources are tried in
+                :data:`SOURCES` order and the FIRST that resolves the entity answers
+                alone. Topping a curated record up from the ontology would add whatever
+                the curators left out and make the result depend on whether the ontology
+                happens to be loaded — the same record enriching to a different thing in
+                two processes.
             key: The entity to enrich *from*, when this record does not name it itself —
                 a ``network.coupling`` entry named for its role in the network, say,
                 declaring the coupling function it is an instance of. Defaults to what
@@ -93,7 +99,9 @@ class IriEnrichable:
                 if source is not None:
                     raise ValueError(f"{cls_name} has no {name!r} to enrich from.")
                 continue
-            found |= bool(key and reader(key))
+            if key and reader(key):
+                found = True
+                break
         if not found and pointer:
             raise LookupError(f"{cls_name} names {pointer!r}, which no source resolves.")
         return self

--- a/tvbo/behaviour/coupling.py
+++ b/tvbo/behaviour/coupling.py
@@ -33,45 +33,6 @@ class CouplingBehaviour:
         coupling_class2metadata(hits[0], self, overwrite=False)
         return True
 
-    def populate_from_type(self, type_ref):
-        """Fill this coupling from the coupling function *type_ref* names.
-
-        A ``network.coupling`` entry is keyed by its role in the network, so its ``type``
-        is what says which function it is an instance of — the entity to enrich from,
-        rather than the one this record names.
-
-        Parameters
-        ----------
-        type_ref : str
-            Coupling function name or CURIE (e.g. ``"KuramotoCoupling"``
-            or ``"tvbo:KuramotoCoupling"``).
-        """
-        from tvbo.data.registry import local_name
-
-        self._coupling_type = type_ref
-        self.enrich(key=local_name(type_ref))
-        self._resolve_xi_xj()
-
-    def _resolve_xi_xj(self):
-        """Auto-populate local_states/incoming_states from x_i/x_j in expression.
-
-        Coupling database equations use generic placeholders ``x_i`` (local
-        node state) and ``x_j`` (source node state).  When the user has
-        declared ``incoming_states`` (the actual state variable names to
-        pull from connected nodes) but not ``local_states``, and the
-        expression references ``x_i``, we mirror ``incoming_states`` into
-        ``local_states`` so the template can generate correct assignments.
-        """
-        pre_rhs = str(self.pre_expression.rhs) if getattr(self, "pre_expression", None) else ""
-        incoming = getattr(self, "incoming_states", None) or []
-        local = getattr(self, "local_states", None) or []
-
-        if "x_i" in pre_rhs and not local and incoming:
-            self.local_states = list(incoming)
-
-        if "x_j" in pre_rhs and not incoming and local:
-            self.incoming_states = list(local)
-
     @classmethod
     def from_ontology(cls, ontoclass):
         """Create a Coupling instance from an ontology Coupling class or name.

--- a/tvbo/behaviour/coupling.py
+++ b/tvbo/behaviour/coupling.py
@@ -6,11 +6,9 @@ coupling carries these however it was built. The experiment loader used to reass
 any other way — ``network.coupling`` entries, an inner coupling, a hand-built one — as
 plain records.
 
-Unlike the other mixins this one hooks construction. It can: the generated
-``__post_init__`` ends in ``super().__post_init__(**kwargs)``, and the mixin sits directly
-before ``YAMLRoot`` in the MRO, so the hook runs once the generated normalization is done,
-whichever path built the object. That is where a coupling given only an ``iri`` adopts the
-name and the expressions that ``iri`` points at, as the wrapper's ``__init__`` used to.
+A coupling named solely by ``iri`` is expanded before validation, by the dialect; filling
+one that names its function any other way is :meth:`IriEnrichable.enrich`, whose ontology
+source is :meth:`CouplingBehaviour._from_ontology` below.
 """
 
 from __future__ import annotations
@@ -18,96 +16,29 @@ from __future__ import annotations
 import numpy as np
 
 
-def _schema_default(cls, slot: str):
-    """The default the schema gives *slot*, whichever generated form *cls* is.
-
-    A post-init hook cannot see the keywords as they were passed — the defaults are
-    already applied — so "the recipe did not name this" is read as "the value still equals
-    the schema default", and the two forms keep that default in different places.
-    """
-    fields = getattr(cls, "__dataclass_fields__", None)
-    if fields is not None:
-        return fields[slot].default
-    return cls.model_fields[slot].default
-
-
 class CouplingBehaviour:
     """Population, rendering and symbolic reading for a coupling function."""
 
-    def __post_init__(self, *args, **kwargs):
-        """The LinkML dataclasses' construction hook."""
-        super().__post_init__(*args, **kwargs)
-        self._adopt_iri_entry()
-
-    def model_post_init(self, context, /):
-        """The Pydantic models' construction hook.
-
-        The two generated forms do not share one. Without this the same YAML produced two
-        different couplings — the dataclass populated from its ``iri``, the Pydantic model
-        left as a bare default ``Linear`` — which is the divergence
-        ``tests/test_schema_aliases.py`` exists to prevent.
-        """
-        super().model_post_init(context)
-        self._adopt_iri_entry()
-
-    def _adopt_iri_entry(self):
-        """Adopt the ontology entry an ``iri``-only coupling points at.
-
-        A recipe that names the coupling solely by ``iri`` gets that entry's local name and
-        its expressions; an explicitly named one keeps its own name and is only filled in.
-        `name` carries a schema default, so "explicitly named" is read as differing from
-        that default — the one thing ``__init__`` could see that a post-init hook cannot.
-        """
-        if not getattr(self, "iri", None) or getattr(self, "pre_expression", None):
-            return
-
-        from tvbo.data.registry import local_name
-
-        local = local_name(self.iri)
-        if self.name == _schema_default(type(self), "name"):
-            self.name = local
-        self._populate_from_ontology(lookup_name=local)
-
-    def _populate_from_ontology(self, lookup_name=None):
-        """Fill missing metadata fields from ontology/database.
-
-        Parameters
-        ----------
-        lookup_name : str, optional
-            Name or CURIE to look up. If None, uses ``self.name``.
-            Supports plain names (``KuramotoCoupling``) and CURIEs
-            (``tvbo:KuramotoCoupling``).
-        """
-        from tvbo.classes.coupling import _load_coupling_from_database, coupling_class2metadata
+    def _from_ontology(self, key: str) -> bool:
+        """Gap-fill from the ontology coupling function *key* labels. True when found."""
+        from tvbo.classes.coupling import coupling_class2metadata
         from tvbo.ontology import query
 
-        if lookup_name:
-            lookup = lookup_name.split(":", 1)[-1] if ":" in lookup_name else lookup_name
-        else:
-            lookup = getattr(self, "name", None)
-
-        if lookup and _load_coupling_from_database(lookup, self):
-            return
-
         try:
-            if lookup:
-                hits = query.label_search(lookup, root_class="Coupling")
-                oc = hits[0] if hits else None
-            else:
-                oc = self.ontoclass
+            hits = query.label_search(key, root_class="Coupling")
         except Exception:
-            oc = None
-        if not oc:
-            return
-
-        coupling_class2metadata(oc, self, overwrite=False)
+            return False
+        if not hits:
+            return False
+        coupling_class2metadata(hits[0], self, overwrite=False)
+        return True
 
     def populate_from_type(self, type_ref):
-        """Fill missing pre/post expressions and parameters from a type reference.
+        """Fill this coupling from the coupling function *type_ref* names.
 
-        This is used when ``network.coupling`` entries specify a ``type`` field
-        to reference a known coupling function (e.g. ``KuramotoCoupling`` or
-        ``tvbo:KuramotoCoupling``).
+        A ``network.coupling`` entry is keyed by its role in the network, so its ``type``
+        is what says which function it is an instance of — the entity to enrich from,
+        rather than the one this record names.
 
         Parameters
         ----------
@@ -115,8 +46,10 @@ class CouplingBehaviour:
             Coupling function name or CURIE (e.g. ``"KuramotoCoupling"``
             or ``"tvbo:KuramotoCoupling"``).
         """
+        from tvbo.data.registry import local_name
+
         self._coupling_type = type_ref
-        self._populate_from_ontology(lookup_name=type_ref)
+        self.enrich(key=local_name(type_ref))
         self._resolve_xi_xj()
 
     def _resolve_xi_xj(self):
@@ -149,14 +82,15 @@ class CouplingBehaviour:
         """
         import owlready2
 
-        from tvbo.classes.coupling import _load_coupling_from_database, coupling_class2metadata
+        from tvbo.classes.coupling import coupling_class2metadata
+        from tvbo.data.registry import local_name
         from tvbo.datamodel import schema as tvbo_datamodel
         from tvbo.ontology import query
 
         if isinstance(ontoclass, str):
-            lookup = ontoclass.split(":", 1)[-1] if ":" in ontoclass else ontoclass
+            lookup = local_name(ontoclass)
             coup = cls(name=lookup)
-            if _load_coupling_from_database(lookup, coup):
+            if coup._from_database(lookup):
                 return coup
             hits = query.label_search(lookup, root_class="Coupling", exact_match=["label"])
             if not hits:

--- a/tvbo/behaviour/dynamics.py
+++ b/tvbo/behaviour/dynamics.py
@@ -19,6 +19,16 @@ from __future__ import annotations
 class DynamicsBehaviour:
     """A model's SymPy view of itself: one symbol table, one parse of each equation."""
 
+    def _from_ontology(self, key: str) -> bool:
+        """Gap-fill from the ontology neural mass model *key* labels. True when found."""
+        from tvbo.classes.dynamics import ontology_class, populate_from_ontology
+
+        ontoclass = ontology_class(key)
+        if ontoclass is None:
+            return False
+        populate_from_ontology(self, ontoclass)
+        return True
+
     @property
     def symbolic_system(self):
         """This model's [`SymbolicSystem`](../parse/system.qmd), built once and kept.

--- a/tvbo/behaviour/integrator.py
+++ b/tvbo/behaviour/integrator.py
@@ -5,11 +5,11 @@ Only schema fields are ever stored; everything derived from the ontology is a pr
 so an integrator can be serialized at any point without carrying runtime state.
 
 Population from the ontology is NOT done at construction. It is
-:meth:`IntegratorBehaviour._populate_from_ontology`, called explicitly and idempotent, so
-that resolving an integrator against the ontology stays an act the caller asks for rather
-than the cost of naming one. The wrapper this replaces called it from ``__init__``, which
-meant it ran for a directly constructed integrator and not for a loaded one; the loaded
-path compensated with its own call, and that call is now the only one.
+:meth:`IntegratorBehaviour.enrich`, called explicitly and idempotent, so that resolving an
+integrator against the ontology stays an act the caller asks for rather than the cost of
+naming one. The wrapper this replaces called it from ``__init__``, which meant it ran for
+a directly constructed integrator and not for a loaded one; the loaded path compensated
+with its own call, and that call is now the only one.
 
 A mixin *can* hook construction — see :mod:`tvbo.behaviour` on ``__post_init__``, which
 :class:`CouplingBehaviour` uses. This one deliberately does not.
@@ -109,14 +109,23 @@ class IntegratorBehaviour:
         """The current integration step, a stateless default of `0`."""
         return 0
 
-    def _populate_from_ontology(self):
-        """Fill the ontology-derived fields that are still unset. Idempotent."""
+    def enrich(self, source: str | None = None):
+        """Fill the ontology-derived fields that are still unset. Idempotent.
+
+        The same verb as :meth:`IriEnrichable.enrich`, and the same gap-filling contract,
+        but its own implementation and no *key*: an integrator names an ontology method
+        rather than a curated entity, so there is nothing for the database to answer and
+        nothing to redirect the lookup at.
+        """
         from tvbo.datamodel.schema import DerivedVariable, Equation
         from tvbo.ontology.owl import onto
 
+        if source not in (None, "ontology"):
+            raise ValueError(f"Integrator has no {source!r} to enrich from.")
+
         oc = self.ontoclass
         if not oc:
-            return
+            return self
         info = self.info
         try:
             if hasattr(self, "scipy_ode_base"):
@@ -140,6 +149,7 @@ class IntegratorBehaviour:
             self.update_expression = DerivedVariable(
                 name="dX", equation=Equation(lhs="X_{t+1}", rhs=info["dX_expr"])
             )
+        return self
 
     def render_code(self, format="tvb", **kwargs):
         """Render the integrator as source code for the requested backend.

--- a/tvbo/classes/coupling.py
+++ b/tvbo/classes/coupling.py
@@ -56,62 +56,6 @@ def _ensure_parameters(coupling) -> None:
         coupling.parameters = {}
 
 
-def _load_coupling_from_database(name, coupling):
-    """Fill coupling metadata from a curated database YAML file.
-
-    Resolves ``name`` through the database registry — the one component that knows where
-    the database lives — and fills the ``pre_expression``, ``post_expression`` and
-    ``parameters`` the coupling does not already carry.
-
-    Reading the curated entry is what makes population deterministic: the ontology answers
-    with an unordered set, so the parameters it yields come back in a different order in
-    every process, which no frozen record can be written against.
-
-    A curated ``delayed:`` is NOT applied. The slot carries a schema default of ``True``,
-    so it is never unset by the time this runs and the guard that read it could not fire.
-    Only ``FastLinearCoupling`` declares anything else, and honouring it would change that
-    coupling's delays — a measured change of its own, not a side effect of this one.
-
-    Parameters
-    ----------
-    name : str
-        Coupling function name (e.g. ``"KuramotoCoupling"``).
-    coupling : Coupling
-        Coupling instance to fill (modified in-place), in either generated form.
-
-    Returns
-    -------
-    bool
-        True if a database file was found and applied.
-    """
-    import yaml as _yaml
-
-    from tvbo.data.registry import resolve
-
-    try:
-        db_file = resolve("Coupling", name)
-    except (FileNotFoundError, RuntimeError, ValueError):
-        return False
-
-    data = _yaml.safe_load(db_file.read_text(encoding="utf-8"))
-    peer = peer_module(coupling)
-    _ensure_parameters(coupling)
-
-    for slot in ("pre_expression", "post_expression"):
-        if slot in data and not getattr(coupling, slot, None):
-            written = data[slot]
-            setattr(coupling, slot, peer.Equation(**(written if isinstance(written, dict) else {"rhs": written})))
-    for pname, pval in (data.get("parameters") or {}).items():
-        if pname in coupling.parameters:
-            continue
-        coupling.parameters[pname] = (
-            peer.Parameter(**{"name": pname, **pval}) if isinstance(pval, dict)
-            else peer.Parameter(name=pname, value=pval)
-        )
-
-    return True
-
-
 def get_parameters(CF):
     """Extract parameter metadata from a coupling function ontology class.
 

--- a/tvbo/classes/dynamics.py
+++ b/tvbo/classes/dynamics.py
@@ -71,6 +71,30 @@ def __getattr__(name):  # PEP 562: keep ``available_neural_mass_models`` importa
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def ontology_class(name):
+    """The ontology neural mass model labelled *name*, or ``None``.
+
+    Restricted to that branch on purpose: the ontology holds classes of every kind under
+    one label space, and a model must not be filled from a coupling function or an
+    integrator that happens to share its name.
+    """
+    if not name:
+        return None
+    found = ontology.onto.search_one(label=str(name))
+    return found if found in _available_neural_mass_models() else None
+
+
+def populate_from_ontology(model, ontoclass, **kwargs):
+    """Fill *model*'s unset schema fields from *ontoclass*.
+
+    The one implementation behind both ways in: `Dynamics.from_ontology`, which is handed
+    the class, and `enrich(source="ontology")`, which resolves it from what the model
+    names. Nothing runtime-only is written, so the model stays serializable.
+    """
+    class2metadata(ontoclass, model)
+    update_parameters(model, ontoclass, **kwargs)
+
+
 ## BifurcationResult moved to tvbo.analysis.bifurcation
 
 
@@ -612,28 +636,24 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
     """Enhanced base class for `Dynamics` adding Python-side behaviour.
 
     Wraps the generated LinkML `Dynamics` datamodel with the methods that
-    make a model usable: ontology resolution (`use_ontology=True`), equation
-    reordering, backend code generation, YAML / JSON / Pydantic round-tripping,
-    and matplotlib plotting hooks. The symbolic view comes from
-    [`DynamicsBehaviour`](../behaviour/dynamics.qmd), which every `Dynamics` carries.
+    make a model usable: equation reordering, backend code generation,
+    YAML / JSON / Pydantic round-tripping, and matplotlib plotting hooks. The symbolic
+    view comes from [`DynamicsBehaviour`](../behaviour/dynamics.qmd), which every
+    `Dynamics` carries.
 
     Most users should construct via [`Dynamics`](#tvbo.classes.dynamics.Dynamics)
     or `Dynamics.from_db(name)` — this class is the implementation base.
 
     An `iri=` is expanded by the dialect, before validation, so a model named by one
     arrives already carrying the curated record — see
-    [`expand_iri`](../datamodel/dialect.qmd#expand_iri). Every path then runs
-    `update_metadata`, which migrates the deprecated `cases:` slot into conditionals and
-    sorts derived variables into the dependency order the straight-line JAX and NumPy
-    emitters require; a path that skipped it rendered `cases:` models with no branches.
+    [`expand_iri`](../datamodel/dialect.qmd#expand_iri). Reaching further, to the ontology,
+    is `enrich()`. Every path then runs `update_metadata`, which migrates the deprecated
+    `cases:` slot into conditionals and sorts derived variables into the dependency order
+    the straight-line JAX and NumPy emitters require; a path that skipped it rendered
+    `cases:` models with no branches.
     """
 
-    def __init__(
-        self,
-        name=None,
-        use_ontology: bool = False,
-        **kwargs,
-    ):
+    def __init__(self, name=None, **kwargs):
         if name is not None:
             kwargs["name"] = str(name)
 
@@ -643,11 +663,20 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
         # Initialize datamodel (the dialect expands `iri` and folds aliases here)
         super().__init__(**kwargs)
 
-        if use_ontology:
-            self._populate_from_ontology_by_name()
-
         self.update_metadata()
         self.calculate_derived_parameters()
+
+    def enrich(self, source: str | None = None, key: str | None = None):
+        """Fill this model's gaps, then leave it where construction would have.
+
+        A model that has just gained state variables, derived variables or a ``cases:``
+        block is not yet in the shape the emitters read, so filling one ends in the same
+        two calls every construction path ends in.
+        """
+        super().enrich(source=source, key=key)
+        self.update_metadata()
+        self.calculate_derived_parameters()
+        return self
 
     @property
     def components(self):
@@ -661,16 +690,12 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
 
     # Factory constructors
     @classmethod
-    def from_datamodel(
-        cls, model_meta: tvbo_datamodel.Dynamics, use_ontology: bool = False
-    ):
+    def from_datamodel(cls, model_meta: tvbo_datamodel.Dynamics):
         """Create from a datamodel Dynamics instance by copying its
         already-normalized state (avoids ``_as_dict`` re-init crash on
         ``inlined_as_dict`` fields)."""
         inst = cls.__new__(cls)
         inst.__dict__.update(model_meta.__dict__)
-        if use_ontology:
-            inst._populate_from_ontology_by_name()
         inst.update_metadata()
         inst.calculate_derived_parameters()
         return inst
@@ -689,60 +714,43 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
             A populated instance with metadata and derived parameters
             finalized.
         """
-        # Construct with name and then populate from ontology
         if isinstance(ontoclass, str):
             ontoclass = query.label_search(
                 ontoclass, root_class="NeuralMassModel", exact_match=["label"]
             )[0]
         inst = cls(name=ontoclass.name, **kwargs)
-        inst._populate_from_ontology(ontoclass, **kwargs)
+        populate_from_ontology(inst, ontoclass, **kwargs)
         inst.update_metadata()
         inst.calculate_derived_parameters()
         return inst
 
     @classmethod
-    def from_file(
-        cls, path: str | os.PathLike, use_ontology: bool = False
-    ) -> "Dynamics":
+    def from_file(cls, path: str | os.PathLike) -> "Dynamics":
         """Load a model from a YAML/JSON specification file on disk.
 
         Args:
             path: Path to a TVBO model specification file.
-            use_ontology: If `True`, backfill missing fields from the
-                ontology after loading.
 
         Returns:
             The instance parsed from the file.
         """
         data = yaml_loader.load_as_dict(str(path))
         _resolve_dynamics_aliases(data)
-        inst = cls(**data)
-        if use_ontology:
-            inst._populate_from_ontology_by_name()
-        inst.update_metadata()
-        inst.calculate_derived_parameters()
-        return inst
+        return cls(**data)
 
     @classmethod
-    def from_string(cls, str: str, use_ontology: bool = False) -> "Dynamics":
+    def from_string(cls, str: str) -> "Dynamics":
         """Load a model from a YAML specification string.
 
         Args:
             str: A YAML document describing the model.
-            use_ontology: If `True`, backfill missing fields from the
-                ontology after parsing.
 
         Returns:
             The instance parsed from the string.
         """
         data = yaml_loader.load_as_dict(str) or {}
         _resolve_dynamics_aliases(data)
-        inst = cls(**data)
-        if use_ontology:
-            inst._populate_from_ontology_by_name()
-        inst.update_metadata()
-        inst.calculate_derived_parameters()
-        return inst
+        return cls(**data)
 
     # ── Platform retrieval ────────────────────────────────────────
 
@@ -901,38 +909,6 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
         )
         return df
 
-    # -------  Ontology enrichment  -------
-
-    def enrich_from_ontology(self):
-        """Explicitly enrich this model from the ontology by name.
-
-        Looks up the model name in the TVB ontology and backfills missing
-        parameter values, descriptions, ranges, state-variable metadata, and
-        derived variables.  Useful when you define a partial model spec and
-        want the ontology to fill in the gaps.
-
-        Example
-        -------
-        >>> d = Dynamics.from_string(partial_spec)
-        >>> d.enrich_from_ontology()  # fill in defaults from the knowledge base
-        """
-        self._populate_from_ontology_by_name()
-        self.update_metadata()
-        self.calculate_derived_parameters()
-        return self
-
-    # Internal helpers
-    def _populate_from_ontology_by_name(self):
-        """Resolve the ontology class by name and populate fields from it."""
-        oc = self.ontology  # auto-discover by name (read-only property)
-        if oc is not None:
-            self._populate_from_ontology(oc)
-
-    def _populate_from_ontology(self, oc, **kwargs):
-        # Fill schema fields from ontology, without persisting runtime-only state
-        class2metadata(oc, self)
-        update_parameters(self, oc, **kwargs)
-
     def __repr__(self) -> str:
         return f"{self.name} - {len(self.parameters)} parameters and {len(self.state_variables)} state variables"
 
@@ -976,11 +952,7 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
     @property
     def ontology(self):
         """The ontology class matching this model's name, or `None` if it is not a known neural mass model."""
-        name = getattr(self, "name", None)
-        if not name:
-            return None
-        cl = ontology.onto.search_one(label=str(name))
-        return cl if cl in _available_neural_mass_models() else None
+        return ontology_class(getattr(self, "name", None))
 
     def search_ontology(self, search_str: str, **kwargs):
         """Search this model's ontology subtree for a term.
@@ -1067,11 +1039,10 @@ class DynamicalSystem(tvbo_datamodel.Dynamics):
         return _pdm.Dynamics.model_validate(self._as_dict)
 
     @classmethod
-    def from_pydantic(cls, pyd_obj, use_ontology: bool = False):
+    def from_pydantic(cls, pyd_obj):
         """Create a Dynamics from a tvbopydantic.Dynamics (or dict-like)."""
         data = pyd_obj.model_dump() if hasattr(pyd_obj, "model_dump") else dict(pyd_obj)
-        inst = cls(use_ontology=use_ontology, **data)
-        return inst
+        return cls(**data)
 
     # Parameters
     def add_parameter(

--- a/tvbo/classes/experiment.py
+++ b/tvbo/classes/experiment.py
@@ -256,27 +256,14 @@ def _reject_unnamed(kind: str, entries) -> None:
     ``target_variable`` when one is given, so checking the key alone let a recipe keyed
     ``drive`` reach codegen carrying the name ``flash burst``.
 
-    Both shapes the schema allows are read — the keyed mapping and the list — and a
-    third would raise rather than pass. A guard that answers "nothing wrong" for input
-    it never looked at is worse than no guard: LinkML hands these over as ``JsonObj``,
-    which has no ``.items``, so skipping the unrecognised shape meant every
-    ``from_datamodel`` load — that is, every load from a file — went unchecked.
+    Every shape the schema allows is read, and a shape it does not allow raises rather
+    than passing — see :func:`tvbo.utils.keyed_items`.
     """
-    from jsonasobj2 import JsonObj, items as _json_items
-
     from tvbo.templates.base.utils import is_name
-
-    if isinstance(entries, JsonObj):
-        items = list(_json_items(entries))
-    elif hasattr(entries, "items"):
-        items = list(entries.items())
-    elif isinstance(entries, (list, tuple)):
-        items = [(getattr(entry, "name", None), entry) for entry in entries]
-    else:
-        raise TypeError(f"cannot read {kind} names from {type(entries).__name__}")
+    from tvbo.utils import keyed_items
 
     lines = []
-    for key, entry in items:
+    for key, entry in keyed_items(entries, kind):
         spellings = dict.fromkeys(
             str(value)
             for value in (key, getattr(entry, "name", None), getattr(entry, "target_variable", None))

--- a/tvbo/classes/experiment.py
+++ b/tvbo/classes/experiment.py
@@ -129,83 +129,60 @@ def _sync_network_node_count(net):
         net.nodes = [tvbo_datamodel.Node(id=i, label=f"node_{i}") for i in range(net.number_of_nodes)]
 
 
-def _upgrade_network_couplings(network, coupling_types=None):
-    """Upgrade network.coupling entries to runtime Coupling instances and
-    apply ``type``-based database/ontology fill.
+def _hoist_coupling_parameters(parameters) -> None:
+    """Address a coupling's parameters as ``coupling.*``, whatever holds the coupling.
 
-    Parameters
-    ----------
-    network : Network
-        The network whose coupling entries should be upgraded.
-    coupling_types : dict, optional
-        Mapping ``{coupling_key: type_ref}`` extracted from the raw YAML
-        before LinkML deserialization.  ``type_ref`` is a coupling function
-        name or CURIE (e.g. ``"KuramotoCoupling"`` or
-        ``"tvbo:KuramotoCoupling"``).
+    The parameter collection is the flat namespace generated code addresses — the JAX
+    backend emits ``state.parameters.coupling`` — so it is a view for codegen, not the
+    record's shape. A coupling is declared on the network, and this is what keeps that
+    from being something every backend has to know: one coupling flattens to
+    ``coupling.<param>``, several stay keyed by role as ``coupling.<role>.<param>``.
     """
-    coupling_types = coupling_types or {}
-    coup_raw = getattr(network, "coupling", None)
-    if not coup_raw:
-        return
+    network = parameters.get("network")
+    couplings = network.pop("coupling", None) if isinstance(network, dict) else None
+    if couplings:
+        parameters["coupling"] = (
+            next(iter(couplings.values())) if len(couplings) == 1 else couplings
+        )
 
-    # Schema allows dict (keyed by name), list, or a single Coupling object.
-    if isinstance(coup_raw, dict):
-        items = coup_raw.items()
-    elif isinstance(coup_raw, list):
-        items = enumerate(coup_raw)
-    else:
-        return
 
-    for key, coup in items:
+def _fill_network_couplings(network):
+    """Fill each of *network*'s couplings from the function it names.
+
+    An entry is keyed by its role in the network ('excitatory', 'delayed'), so the
+    function it instantiates is what its ``iri`` states — written ``iri:`` or under the
+    older spelling ``type:``, which the schema declares as an alias of it. One that
+    already carries its expressions names nothing to fill.
+    """
+    from tvbo.utils import keyed_items
+
+    for _key, coup in keyed_items(getattr(network, "coupling", None), "coupling"):
         if not getattr(coup, "pre_expression", None):
             coup.enrich()
-        if key in coupling_types:
-            coup.populate_from_type(coupling_types[key])
 
 
 def _resolve_coupling(experiment):
-    """Reconcile coupling declarations across experiment / network / dynamics.
+    """Give a network that needs a coupling one, and tell each coupling what it reads.
 
     Single source of truth for both ``__init__`` and ``from_datamodel`` paths.
 
-    Rules:
-      1. If ``network.coupling`` is populated, mirror its first entry to
-         ``experiment.coupling``.
-      2. Else, if ``dynamics.coupling_inputs`` declares coupling targets,
-         seed ``network.coupling`` from ``experiment.coupling`` (or a default
-         ``Linear`` if absent) so a single canonical container exists.
-      3. Auto-populate ``incoming_states`` on each coupling from the dynamics'
-         ``state_variables[*].coupling_variable == True`` flag — but only when
-         the coupling declares neither incoming nor local states. Couplings
-         that explicitly declare ``local_states`` (e.g. vectorized matmul
-         flavors) are left untouched.
+    A coupling acts over a connectivity, so ``network.coupling`` is the only place one is
+    declared and there is nothing to reconcile it against. What is left is supplying the
+    default: a model whose ``coupling_inputs`` declare coupling targets needs a coupling
+    to compute them, and a network that names none gets ``Linear``.
+
+    Each coupling is then told which states it reads, from the dynamics'
+    ``state_variables[*].coupling_variable`` flag — but only when it declares neither
+    incoming nor local states, so a vectorized flavour that states its own is left alone.
     """
     dyn = getattr(experiment, "dynamics", None)
     network = getattr(experiment, "network", None)
     if network is None:
         return
 
-    dyn_ci = getattr(dyn, "coupling_inputs", None)
-    has_coupling_inputs = bool(dyn_ci)
-    net_coup = getattr(network, "coupling", None)
-    exp_coup = getattr(experiment, "coupling", None)
-
-    if net_coup:
-        if isinstance(net_coup, dict) and net_coup:
-            experiment.coupling = next(iter(net_coup.values()))
-    elif has_coupling_inputs:
-        func = exp_coup
-        if not func or not isinstance(func, Coupling):
-            func = Coupling(name="Linear", iri="tvbo:Linear")
-            experiment.coupling = func
-        elif not getattr(func, "iri", None):
-            func.iri = "tvbo:Linear"
-        # Ensure ontology-derived fields (pre/post expressions, parameters)
-        # are populated — backends require them at codegen time.
-        if not getattr(func, "pre_expression", None):
-            func.enrich()
-        coup_name = str(getattr(func, "name", "Linear"))
-        network.coupling[coup_name] = func
+    if getattr(dyn, "coupling_inputs", None) and not getattr(network, "coupling", None):
+        # Backends need the expressions and parameters at codegen time, not just the name.
+        network.coupling["Linear"] = Coupling(iri="tvbo:Linear").enrich()
 
     if dyn:
         cvars = [
@@ -346,9 +323,9 @@ def _merge_from_registry(d, category: str):
 class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
     """The central runnable object in TVBO: a complete brain-network simulation spec.
 
-    Bundles `dynamics`, `coupling`, `network`, `integration`, `observations`,
-    and any analysis layers (stimulation, algorithms, explorations, …) into
-    one declarative specification. The same instance can be:
+    Bundles `dynamics`, `network` (with its `coupling`), `integration`,
+    `observations`, and any analysis layers (stimulation, algorithms, explorations, …)
+    into one declarative specification. The same instance can be:
 
     - **executed** in any registered backend (`run("jax")`, `run("tvb")`, …)
     - **serialized** to YAML, BIDS, openMINDS, or LEMS
@@ -368,9 +345,9 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         # Or fully declarative
         exp = SimulationExperiment(
             dynamics={"iri": "tvbo:ReducedWongWangExcInh"},
-            coupling={"iri": "tvbo:Linear"},
             network={"parcellation": {"atlas": {"iri": "tvbo:DesikanKilliany"}},
-                     "tractogram":   {"iri": "tvbo:dTOR"}},
+                     "tractogram":   {"iri": "tvbo:dTOR"},
+                     "coupling":     {"long_range": {"iri": "tvbo:Linear"}}},
             integration={"method": "Heun", "duration": 10_000, "noise": None},
         )
         ```
@@ -411,25 +388,6 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
             elif hasattr(net, "dict") and not isinstance(net, dict):
                 # Pydantic v1
                 kwargs["network"] = net.dict(exclude_none=True)
-
-        # Extract non-schema fields from network sub-dicts before parent init.
-        # These are popped so the datamodel __init__ doesn't reject unknown kwargs.
-        _coupling_types = {}
-        net_kw = kwargs.get("network")
-        if isinstance(net_kw, dict):
-            # Extract `type` from network.coupling entries.
-            # `type` references a coupling function name/CURIE.
-            coup_dict = net_kw.get("coupling")
-            if isinstance(coup_dict, dict):
-                for key, val in coup_dict.items():
-                    if isinstance(val, dict) and "type" in val:
-                        _coupling_types[key] = val.pop("type")
-
-        # Allow coupling to be specified as a plain string name (e.g. "SigmoidalJansenRit")
-        # Set iri to trigger ontology population
-        if "coupling" in kwargs and isinstance(kwargs["coupling"], str):
-            _cname = kwargs["coupling"]
-            kwargs["coupling"] = {"name": _cname, "iri": f"tvbo:{_cname}"}
 
         # Resolve Dynamics slot aliases (e.g. components → modes) before
         # the parent __post_init__ constructs the base-class Dynamics.
@@ -526,9 +484,6 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         if getattr(self, "dynamics", None):
             self.model = self.dynamics.name
 
-        if getattr(self, "coupling", None) and not isinstance(self.coupling, Coupling):
-            self.coupling = _coerce(Coupling, self.coupling)
-
         if getattr(self, "integration", None) and not isinstance(self.integration, Integrator):
             self.integration = _coerce(Integrator, self.integration)
 
@@ -581,7 +536,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
                 )
 
         # Upgrade network.coupling entries to runtime Coupling + apply type fills
-        _upgrade_network_couplings(self.network, _coupling_types)
+        _fill_network_couplings(self.network)
         # NOTE: coupling resolution (incoming_states / network.coupling seeding)
         # is intentionally deferred to ``configure()`` so it runs lazily at the
         # execution boundary across all backends and so the resolved state is
@@ -755,7 +710,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
             obj.__dict__["network"] = Network()
 
         # Upgrade network coupling entries (no type refs in from_datamodel path)
-        _upgrade_network_couplings(obj.network)
+        _fill_network_couplings(obj.network)
         # Coupling resolution deferred to ``configure()`` (see __post_init__).
 
         obj.__dict__["_source_file"] = getattr(cls, "_pending_source_file", None)
@@ -1187,13 +1142,13 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         # =====================================================================
         # 5. Create SimulationExperiment
         # =====================================================================
+        network.coupling["Linear"] = Coupling.from_ontology("Linear")
         experiment = cls(
             label=f"Loaded from BIDS: sub-{subject}",
             description=f"Experiment reconstructed from BIDS dataset at {bids_dir}",
             dynamics=dynamics,
             network=network,
             integration=integration,
-            coupling=Coupling.from_ontology("Linear"),
         )
 
         # Store BIDS source info
@@ -1234,6 +1189,24 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
     def metadata(self):
         """The experiment itself, exposed as its own metadata container."""
         return self
+
+    @property
+    def coupling(self):
+        """The network's default coupling — the first it declares. Read-only.
+
+        A coupling acts over a connectivity, so ``network.coupling`` is where one is
+        declared and an experiment has none of its own; this is a read of the network's,
+        not a second place to put one.
+
+        *Default* is what a backend that expresses a single coupling asks for — JAX,
+        LEMS, RateML and the pure-Python network each render one. A network declaring
+        several is written for a backend that routes per coupling, and reading it through
+        here silently answers with one of them; those backends read ``network.coupling``
+        directly and should be the ones to say a network they cannot express is one they
+        cannot express.
+        """
+        couplings = getattr(self.network, "coupling", None) if self.network else None
+        return next(iter((couplings or {}).values()), None)
 
     def symbolic(self, integrate=False, indexed=False, delays=False):
         """Symbolic representation of the full experiment equations.
@@ -1297,12 +1270,13 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         net_coup = getattr(self.network, "coupling", {}) or {}
         dyn_ci = getattr(self.dynamics, "coupling_inputs", {}) or {}
 
+        # A network's one coupling serves every input; several must be named to be used.
+        only = next(iter(net_coup.values())) if len(net_coup) == 1 else None
         for ci_name in dyn_ci:
             if ci_name in net_coup:
                 coupling_map[ci_name] = net_coup[ci_name]
-            elif self.coupling and str(getattr(self.coupling, "name", "")) != "Linear":
-                # Fallback: single experiment-level coupling for any input
-                coupling_map[ci_name] = self.coupling
+            elif only is not None and str(getattr(only, "name", "")) != "Linear":
+                coupling_map[ci_name] = only
 
         # If no coupling to resolve, return dynamics as-is
         if not coupling_map:
@@ -1581,8 +1555,9 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
             if delays is None or np.allclose(np.nan_to_num(delays, nan=0.0), 0):
                 if getattr(self, "integration", None) is not None:
                     self.integration.delayed = False
-                if getattr(self, "coupling", None) is not None:
-                    self.coupling.delayed = False
+                # A network with no delays has none for any of its couplings.
+                for coup in (getattr(self.network, "coupling", None) or {}).values():
+                    coup.delayed = False
         except Exception as e:
             # Best-effort; keep defaults if anything goes wrong
             import warnings
@@ -1664,13 +1639,16 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
         N = self.network.number_of_nodes
         coupling_params = parameters.coupling
 
-        # Get the coupling parameter definitions with shape info
-        if self.coupling is None:
-            return
-
-        for param_name, param_obj in (self.coupling.parameters or {}).items():
+        # Every coupling the network declares, not just the first: each states its own shapes.
+        declared = {
+            name: param
+            for coup in (getattr(self.network, "coupling", None) or {}).values()
+            for name, param in (getattr(coup, "parameters", None) or {}).items()
+        }
+        for param_name, param_obj in declared.items():
             if param_name not in coupling_params:
                 continue
+
 
             shape_str = getattr(param_obj, "shape", None)
             if not shape_str:
@@ -2307,7 +2285,12 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
             # Build node labels from network.nodes (used as xarray 'node' coord)
             node_labels = [n.label for n in self.network.nodes] if self.network.nodes else None
 
-            delay_matrix = self.network.calculate_delays() if getattr(self.coupling, "delayed", False) else None
+            # One delayed coupling is enough to need the matrix, however many there are.
+            any_delayed = any(
+                getattr(coup, "delayed", False)
+                for coup in (getattr(self.network, "coupling", None) or {}).values()
+            )
+            delay_matrix = self.network.calculate_delays() if any_delayed else None
 
             # Resolve network-sourced observations (e.g. fc_target <- empirical
             # FC) to matrices and pass them alongside weights/distances. Only
@@ -3923,6 +3906,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
             callback_kwargs={"parameters": parameters},
             keys_to_exclude=keys_to_exclude,
         )
+        _hoist_coupling_parameters(parameters)
         return parameters
 
     @property

--- a/tvbo/classes/experiment.py
+++ b/tvbo/classes/experiment.py
@@ -158,7 +158,7 @@ def _upgrade_network_couplings(network, coupling_types=None):
 
     for key, coup in items:
         if not getattr(coup, "pre_expression", None):
-            coup._populate_from_ontology()
+            coup.enrich()
         if key in coupling_types:
             coup.populate_from_type(coupling_types[key])
 
@@ -203,7 +203,7 @@ def _resolve_coupling(experiment):
         # Ensure ontology-derived fields (pre/post expressions, parameters)
         # are populated — backends require them at codegen time.
         if not getattr(func, "pre_expression", None):
-            func._populate_from_ontology()
+            func.enrich()
         coup_name = str(getattr(func, "name", "Linear"))
         network.coupling[coup_name] = func
 
@@ -600,7 +600,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
 
         if not getattr(self, "integration", None):
             self.integration = Integrator(method="Heun")
-        self.integration._populate_from_ontology()
+        self.integration.enrich()
 
     def _load_network_from_data_file(self):
         """Load network matrices from a companion data file (h5/zarr/yaml sidecar).
@@ -712,7 +712,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
                 if isinstance(v, tvbo_datamodel.Dynamics) and not isinstance(v, Dynamics):
                     v.__class__ = Dynamics
                     if getattr(v, "iri", None):
-                        v.enrich_from_ontology()
+                        v.enrich()
             first = next(iter(dyn.values()))
             obj.__dict__["dynamics"] = first
             obj.__dict__["model"] = first.name
@@ -720,13 +720,13 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
             if not isinstance(dyn, Dynamics):
                 dyn.__class__ = Dynamics
                 if getattr(dyn, "iri", None):
-                    dyn.enrich_from_ontology()
+                    dyn.enrich()
             obj.__dict__["model"] = dyn.name
         else:
             obj.__dict__.setdefault("dynamics", None)
 
         integ = getattr(obj, "integration", None) or Integrator(method="Heun")
-        integ._populate_from_ontology()
+        integ.enrich()
         obj.__dict__["integration"] = integ
 
         stim = getattr(obj, "stimulation", None)
@@ -735,7 +735,7 @@ class SimulationExperiment(tvbo_datamodel.SimulationExperiment):
 
         coup = getattr(obj, "coupling", None)
         if coup is not None and not getattr(coup, "pre_expression", None):
-            coup._populate_from_ontology()
+            coup.enrich()
         if not getattr(obj, "coupling", None):
             obj.__dict__["coupling"] = Coupling(name="Linear")
 

--- a/tvbo/classes/observation.py
+++ b/tvbo/classes/observation.py
@@ -973,109 +973,33 @@ class ObservationModel:
 
 
 def populate_observation_from_iri(obs, functions_sink=None) -> bool:
-    """Fill an observation's missing fields from the curated model its ``iri`` names.
+    """Fill an observation from the curated model its ``iri`` names, and collect its functions.
 
-    When an observation declares ``iri: tvbo:BOLD_TVB`` (or any curated entry under
-    ``tvbo/database/observation_models/``), its metadata — ``pipeline``, ``parameters``,
-    ``class_reference``, ``imaging_modality``, ``label``/``description`` — is loaded from
-    that model and merged **non-destructively**: a field the recipe set locally always
-    wins, so ``source``/``period`` overrides stay in force while the curated hemodynamic
-    pipeline fills in. Mirrors :func:`tvbo.classes.coupling._load_coupling_from_database`.
+    The filling itself is :meth:`IriEnrichable.enrich`, which every class the schema gives
+    an ``iri`` carries: the curated record supervenes nowhere, so ``source``/``period``
+    overrides stay in force while the curated hemodynamic pipeline fills in.
 
-    When ``functions_sink`` (a mutable name→Function mapping) is given, the model's
-    ``functions`` block is merged into it too — the helper functions a functional
-    pipeline calls by name, which codegen reads from ``experiment.functions``.
+    What is specific to an observation is where its ``functions`` go. A curated model ships
+    the helper functions its pipeline calls by name — an HRF kernel, a downsample, a
+    convolution — and codegen reads those from ``experiment.functions``, not from the
+    observation. Given a ``functions_sink`` (a mutable name -> Function mapping) they are
+    merged there instead, a function the experiment already declares winning.
 
-    Returns True if a curated model was found and merged, False otherwise.
+    Returns True if a curated model was found, False otherwise.
     """
-    iri = getattr(obs, "iri", None)
-    if not iri:
+    if not getattr(obs, "iri", None):
         return False
-    from tvbo.data.registry import local_name, resolve
-
-    name = local_name(iri) if ":" in str(iri) else str(iri)
     try:
-        path = resolve("Observation", name)
-    except Exception:
-        return False
-    if path is None or not path.exists():
+        obs.enrich(source="database")
+    except LookupError:
         return False
 
-    import yaml as _yaml
+    if functions_sink is not None:
+        from tvbo.utils import keyed_items
 
-    data = _yaml.safe_load(path.read_text()) or {}
-
-    # Scalar fields: adopt the curated value only where the recipe left it empty.
-    for field in ("label", "description", "imaging_modality", "period",
-                  "downsample_period", "time_unit"):
-        if data.get(field) is not None and not getattr(obs, field, None):
-            setattr(obs, field, data[field])
-
-    # source: a list — take the curated one only if the recipe declared none.
-    if data.get("source") and not getattr(obs, "source", None):
-        obs.source = list(data["source"])
-
-    # pipeline: the heart of a curated observation model. Fill only if absent so a
-    # recipe that hand-declares its own pipeline is never silently overridden.
-    if data.get("pipeline") and not getattr(obs, "pipeline", None):
-        # A pipeline step is a FunctionCall (it may reference a function by name,
-        # inline a callable, or carry its own equation/source_code) — not a bare
-        # Function. Building it as Function drops `function:`/`callable:` steps.
-        obs.pipeline = [
-            step if isinstance(step, tvbo_datamodel.FunctionCall)
-            else tvbo_datamodel.FunctionCall(**step)
-            for step in data["pipeline"]
-        ]
-
-    # dynamics: a co-integrated observer (the alternative to a pipeline — the observation
-    # computed online as a recurrence). Fill if absent, exactly as the pipeline is; without
-    # this an `iri`-referenced observer arrives with no dynamics and codegen emits a
-    # pass-through monitor.
-    if data.get("dynamics") is not None and not getattr(obs, "dynamics", None):
-        dyn = data["dynamics"]
-        obs.dynamics = (
-            dyn if isinstance(dyn, tvbo_datamodel.Dynamics)
-            else tvbo_datamodel.Dynamics(**dyn)
-        )
-
-    # class_reference: a monitor/class handle (e.g. tvb Bold). Fill if absent.
-    if data.get("class_reference") is not None and not getattr(obs, "class_reference", None):
-        cr = data["class_reference"]
-        obs.class_reference = (
-            cr if isinstance(cr, tvbo_datamodel.ClassReference)
-            else tvbo_datamodel.ClassReference(**cr)
-        )
-
-    # parameters: keyed collection — fill each missing key, keep recipe overrides.
-    if data.get("parameters"):
-        params = obs.parameters if getattr(obs, "parameters", None) else {}
-        for pname, pval in data["parameters"].items():
-            if pname in params:
-                continue
-            if isinstance(pval, dict):
-                pval = {"name": pname, **pval}
-                params[pname] = tvbo_datamodel.Parameter(**pval)
-            else:
-                params[pname] = tvbo_datamodel.Parameter(name=pname, value=pval)
-        obs.parameters = params
-
-    # functions: a curated model may ship the helper functions its pipeline calls
-    # by name (an HRF kernel, a downsample, a convolution). Observation carries no
-    # `functions` slot — codegen reads them from the experiment — so hand them to the
-    # caller's sink to merge into `experiment.functions` (non-destructively: a
-    # function the experiment already declares wins).
-    if data.get("functions") and functions_sink is not None:
-        for fname, fdef in data["functions"].items():
-            if fname in functions_sink:
-                continue
-            if isinstance(fdef, tvbo_datamodel.Function):
-                functions_sink[fname] = fdef
-            else:
-                # The dict key is the function's name; a redundant inner ``name``
-                # (against the keyed-collection convention) must not double the
-                # keyword. Merge with the key winning.
-                functions_sink[fname] = tvbo_datamodel.Function(**{**fdef, "name": fname})
-
+        for name, function in keyed_items(getattr(obs, "functions", None), "functions"):
+            if name not in functions_sink:
+                functions_sink[name] = function
     return True
 
 

--- a/tvbo/database/experiments/RateML_ReducedWongWang.yaml
+++ b/tvbo/database/experiments/RateML_ReducedWongWang.yaml
@@ -9,17 +9,16 @@
 id: 1
 label: "RateML rwongwang ground truth"
 
-# Linear coupling: c_glob = sum(wij * V_j) * global_coupling
-coupling:
-  name: LinearCoupling
-  parameters: {}
-  incoming_states: [V]
-  pre_expression: {rhs: "V_j"}
-  post_expression: {rhs: "1"}
-
 # Network (small test network)
 network:
   number_of_nodes: 4
+  # Linear coupling: c_glob = sum(wij * V_j) * global_coupling
+  coupling:
+    LinearCoupling:
+      parameters: {}
+      incoming_states: [V]
+      pre_expression: {rhs: "V_j"}
+      post_expression: {rhs: "1"}
   dynamics:
     BalloonWindkessel:
       name: BalloonWindkessel

--- a/tvbo/datamodel/dialect.py
+++ b/tvbo/datamodel/dialect.py
@@ -31,6 +31,7 @@ __all__ = [
     "KEYED_COLLECTIONS",
     "SCALAR_SHORTCUTS",
     "SLOT_ALIASES",
+    "curated_entry",
     "expand_iri",
     "fold_aliases",
     "is_literal",
@@ -101,13 +102,17 @@ def fold_aliases(cls_name: str, data: dict) -> dict:
 
 
 @lru_cache(maxsize=None)
-def _curated_entry(cls_name: str, iri: str) -> dict | None:
-    """The curated record *iri* names, alias-folded and ready to merge, or ``None``.
+def curated_entry(cls_name: str, name: str) -> dict | None:
+    """The curated *cls_name* record called *name*, alias-folded and ready to merge.
+
+    ``None`` when the database holds no such record — including when *cls_name* is not a
+    category it keeps at all.
 
     Cached because a recipe naming the same entity twice — every node of a homogeneous
-    network — would otherwise re-read and re-parse the same file per object. The result is
-    only ever fed to :func:`tvbo.utils.deep_merge`, which mutates neither side, so callers
-    share one instance safely.
+    network — would otherwise re-read and re-parse the same file per object. Callers must
+    not mutate the result: :func:`expand_iri` only feeds it to
+    :func:`tvbo.utils.deep_merge`, which mutates neither side, and
+    :meth:`IriEnrichable._from_database` only reads it into a constructor.
 
     The entry's own ``iri`` is dropped: keeping it would make the expanded record ask to be
     expanded again on every later construction, and a self-referential entry would not
@@ -115,10 +120,10 @@ def _curated_entry(cls_name: str, iri: str) -> dict | None:
     """
     import yaml
 
-    from tvbo.data.registry import local_name, resolve
+    from tvbo.data.registry import resolve
 
     try:
-        path = resolve(cls_name, local_name(iri))
+        path = resolve(cls_name, name)
     except (FileNotFoundError, RuntimeError, ValueError):
         return None
     entry = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -142,7 +147,7 @@ def expand_iri(cls_name: str, data: dict) -> dict:
     Only the curated database is consulted. It is a local file read and its content is
     ordered, whereas the ontology answers with an unordered set — a different parameter
     order per process, which no frozen record can be written against. Reaching it is
-    :meth:`IriEnrichable.enrich`, which the caller asks for.
+    :meth:`tvbo.behaviour._enrich.IriEnrichable.enrich`, which the caller asks for.
 
     Only a *reference* expands. A record that also states its own ``name`` is a definition,
     and its ``iri`` is grounding — "this model is a ReducedWongWang in the ontology" — not
@@ -155,10 +160,12 @@ def expand_iri(cls_name: str, data: dict) -> dict:
     the ontology, and this pass cannot tell that from a typo. ``tvbo validate`` is where a
     name that resolves nowhere is reported.
     """
+    from tvbo.data.registry import local_name
+
     iri = data.get("iri")
     if not isinstance(iri, str) or data.get("name") is not None:
         return data
-    entry = _curated_entry(cls_name, iri)
+    entry = curated_entry(cls_name, local_name(iri))
     if entry is None:
         return data
 

--- a/tvbo/datamodel/dialect.py
+++ b/tvbo/datamodel/dialect.py
@@ -25,14 +25,16 @@ from __future__ import annotations
 import warnings
 from functools import lru_cache
 
-from tvbo.datamodel.dialect_tables import SCALAR_SHORTCUTS, SLOT_ALIASES
+from tvbo.datamodel.dialect_tables import KEYED_COLLECTIONS, SCALAR_SHORTCUTS, SLOT_ALIASES
 
 __all__ = [
+    "KEYED_COLLECTIONS",
     "SCALAR_SHORTCUTS",
     "SLOT_ALIASES",
     "expand_iri",
     "fold_aliases",
     "is_literal",
+    "key_members",
     "lift_scalar",
     "normalize",
     "install_on_dataclasses",
@@ -168,14 +170,59 @@ def expand_iri(cls_name: str, data: dict) -> dict:
     return data
 
 
+def key_members(cls_name: str, data: dict) -> dict:
+    """Give a keyed collection the mapping spelling, each member named by its key.
+
+    ``parameters: {TR: {value: 720.0}}`` means a Parameter *called* ``TR``, so writing the
+    name a second time inside the member is the redundancy this project's records are
+    written without. The generated dataclasses fill it from the key in ``__post_init__``;
+    the generated Pydantic models leave it missing and reject the member as incomplete, so
+    a record that loaded on one form failed on the other.
+
+    The same collection may equally be written as a LIST — of bare identifiers
+    (``arguments: [v]``) or of whole members — which the dataclasses key and the Pydantic
+    models reject outright as not a mapping. Both spellings arrive as the mapping here, so
+    which one a record uses stops being a question of which form is loading it. A list
+    whose members state no identifier is left alone: there is nothing to key it by, and
+    that is a record to reject rather than to guess at.
+
+    Members are rebuilt rather than mutated: the mapping may be a cached curated entry,
+    shared by every object that names it.
+    """
+    for slot, identifier in KEYED_COLLECTIONS.get(cls_name, {}).items():
+        members = data.get(slot)
+        if isinstance(members, list):
+            members = _as_mapping(members, identifier)
+        if not isinstance(members, dict):
+            continue
+        data[slot] = {
+            key: ({identifier: key, **member} if isinstance(member, dict) and identifier not in member else member)
+            for key, member in members.items()
+        }
+    return data
+
+
+def _as_mapping(members: list, identifier: str) -> list | dict:
+    """A list-spelled keyed collection as its mapping, or unchanged if it cannot be keyed."""
+    keyed = {}
+    for member in members:
+        if isinstance(member, str):
+            keyed[member] = {identifier: member}
+        elif isinstance(member, dict) and isinstance(member.get(identifier), str):
+            keyed[member[identifier]] = member
+        else:
+            return members
+    return keyed
+
+
 def normalize(cls_name: str, data: dict) -> dict:
-    """Fold *cls_name*'s dialect into *data*, in place: aliases, ``iri``, shortcuts.
+    """Fold *cls_name*'s dialect into *data*, in place: aliases, ``iri``, shortcuts, keys.
 
     Aliases fold first, so the recipe and the curated record are keyed alike before they
     are merged and the shortcut pass can see every value under the name it looks for.
     Lifting first left ``BoundaryCondition(value="0")`` — the older spelling of
     ``equation`` — a bare string where the generated ``__post_init__`` wanted a mapping,
-    and it raised.
+    and it raised. Keying comes last, once every member is a mapping that can carry a name.
     """
     fold_aliases(cls_name, data)
     expand_iri(cls_name, data)
@@ -183,7 +230,7 @@ def normalize(cls_name: str, data: dict) -> dict:
     for slot, (target, multivalued, keyed) in SCALAR_SHORTCUTS.get(cls_name, {}).items():
         if data.get(slot) is not None:
             data[slot] = lift_scalar(data[slot], target, multivalued, keyed)
-    return data
+    return key_members(cls_name, data)
 
 
 def install_on_dataclasses(namespace: dict) -> None:

--- a/tvbo/export/formats.py
+++ b/tvbo/export/formats.py
@@ -73,8 +73,11 @@ def _render_jax(exp, **kw):
 
 
 def _render_tvboptim(exp, **kw):
+    from tvbo.adapters.tvboptim import TvboptimAdapter
     from tvbo.classes.experiment import templates
     template = templates.lookup.get_template("tvboptim/tvbo-tvboptim-experiment.py.mako")
+    # Which couplings this experiment has is the adapter's answer, not the template's.
+    kw.setdefault("all_couplings", TvboptimAdapter(exp).resolve_couplings())
     # Resolve network- and dataset-sourced observation pointers once, in Python,
     # and hand the {obs_name: measure} mapping to the template (which only emits
     # code). Both bind at run_experiment time via _bind_network_observations.

--- a/tvbo/templates/tvboptim/tvbo-tvboptim-cfun.py.mako
+++ b/tvbo/templates/tvboptim/tvbo-tvboptim-cfun.py.mako
@@ -30,20 +30,10 @@ if 'experiment' in context.keys():
             keys = getattr(ci, 'keys', None)
             coupling_inputs_info[ci_key] = {'dimension': dim, 'keys': list(keys) if keys else None}
 
-    # Get all couplings from network.coupling, fall back to experiment-level coupling
-    all_couplings = {}
-    if hasattr(network, 'coupling') and network.coupling:
-        if hasattr(network.coupling, 'items'):
-            all_couplings = dict(network.coupling.items())
-        elif hasattr(network.coupling, 'keys'):
-            all_couplings = {k: network.coupling[k] for k in network.coupling.keys()}
-    if not all_couplings and getattr(experiment, 'coupling', None):
-        _exp_c = experiment.coupling
-        if hasattr(_exp_c, 'items'):
-            all_couplings = dict(_exp_c.items())
-        else:
-            all_couplings = {_exp_c.name or 'coupling': _exp_c}
-    all_couplings = normalize_coupling_aliases(all_couplings, model)
+    # Resolved by TvboptimAdapter.resolve_couplings — see tvbo/adapters/tvboptim.py.
+    from tvbo.adapters.tvboptim import TvboptimAdapter
+
+    all_couplings = context.get('all_couplings') or TvboptimAdapter(experiment).resolve_couplings()
 
 elif 'coupling' in context.keys():
     _standalone_coupling = context['coupling']

--- a/tvbo/templates/tvboptim/tvbo-tvboptim-experiment.py.mako
+++ b/tvbo/templates/tvboptim/tvbo-tvboptim-experiment.py.mako
@@ -116,16 +116,8 @@ elif model.coupling_terms:
 first_coupling_key = list(coupling_inputs_dict.keys())[0] if coupling_inputs_dict else None
 has_coupling = bool(coupling_inputs_dict)
 
-# Build all_couplings dict from network.coupling (keyed by function name — schema convention)
-# Fall back to experiment-level coupling if network.coupling is empty.
-all_couplings = dict(network.coupling.items()) if network.coupling else {}
-if not all_couplings and getattr(experiment, 'coupling', None):
-    _exp_c = experiment.coupling
-    if hasattr(_exp_c, 'items'):
-        all_couplings = dict(_exp_c.items())
-    else:
-        all_couplings = {_exp_c.name or 'coupling': _exp_c}
-all_couplings = normalize_coupling_aliases(all_couplings, model)
+# Resolved by TvboptimAdapter.resolve_couplings, in Python — see tvbo/adapters/tvboptim.py.
+all_couplings = context['all_couplings']
 
 # Coupling-input → coupling-function mapping (+ local-term drop) resolved in the
 # tvboptim Python layer, not here — see resolve_coupling_input_map.

--- a/tvbo/utils/__init__.py
+++ b/tvbo/utils/__init__.py
@@ -216,6 +216,29 @@ def as_list(obj) -> list:
         return [obj]
 
 
+def keyed_items(collection, kind: str = "collection") -> list:
+    """A keyed collection's ``(key, member)`` pairs, whichever shape holds it.
+
+    The generated dataclasses wrap a keyed collection in a ``JsonObj`` when it is assigned,
+    and a ``JsonObj`` has no ``.items``; the Pydantic models keep a plain dict. The schema
+    also allows the list spelling, whose members carry their own ``name``. Anything else
+    raises: a reader that answers "nothing here" for a shape it did not recognise reports
+    an empty collection as an empty *result*, which is how an unchecked ``from_datamodel``
+    load went unchecked.
+    """
+    from jsonasobj2 import JsonObj, items as _json_items
+
+    if collection is None:
+        return []
+    if isinstance(collection, JsonObj):
+        return list(_json_items(collection))
+    if hasattr(collection, "items"):
+        return list(collection.items())
+    if isinstance(collection, (list, tuple)):
+        return [(getattr(member, "name", None), member) for member in collection]
+    raise TypeError(f"cannot read {kind} names from {type(collection).__name__}")
+
+
 def normalize_params(params) -> dict:
     """Normalize a ``parameters`` collection to a flat ``{name: param}`` dict.
 


### PR DESCRIPTION
Part 2 of #95. Stacked on #97.

Two commits, separately reviewable and separately revertable. The first is a defect #97 exposed; the second is the feature that needed it fixed.

---

# 1 — `fix(dialect)`: a keyed collection means the same thing on both generated forms

`parameters: {TR: {value: 720.0}}` says a Parameter **called** `TR`. Writing the name a second time inside the member is the redundancy this project's records are deliberately written without — and only the generated dataclasses acted on that.

| spelling | dataclass form | Pydantic form |
|---|---|---|
| `parameters: {TR: {value: 720.0}}` | keyed in `__post_init__` | **`Field required: parameters.TR.name`** |
| `arguments: [v]` | keyed | **`Input should be a valid dictionary`** |

`Observation(iri="tvbo:BOLD_TVB")` therefore returned a populated observation on one form and raised on the other, because `BOLD_TVB.yaml` is written correctly. `FastLinearCoupling.yaml` masked the same defect by spelling `name: G` redundantly inside each parameter — which is why the `iri` expansion in #97 landed without it surfacing.

Keying belongs in the dialect for the reason the declared aliases and the bare-scalar shortcuts do: it is the **one implementation both construction paths run**, before validation, once per object. Both spellings now arrive as the mapping on either form. A list whose members state no identifier is left alone — there is nothing to key it by, and that is a record to reject rather than to guess at.

`KEYED_COLLECTIONS` joins the two tables `hatch_build` already derives — 36 classes, 66 slots. `inlined_as_list` is excluded: that is a collection whose spelling *is* a list and has no keys, so keying `ClassReference.constructor_args` would have turned a list the Pydantic models require into a mapping they refuse. Pinned by a test.

Closes the `pydantic_loader` keyed-collection gap recorded as a known limitation while #97 was being built.

---

# 2 — `feat(enrich)`: one verb for filling a record from the entity it names

Construction resolves what is deterministic, local and cheap — the dialect expands an `iri` reference from one curated file (#97). Everything past that is an act the caller asks for, and it was asked for **four different ways**:

- `use_ontology=` on three constructors
- `enrich_from_ontology()`
- `_populate_from_ontology()`, in three unrelated implementations
- `populate_observation_from_iri`, **90 lines** filling an Observation slot by slot — and hardcoding the dataclass form, so a Pydantic Observation got dataclass members

They are one act. Now they are one verb.

## `enrich()`

Gap-fills, and only gap-fills: a slot the record already carries is never overwritten, and a keyed collection gains the members it lacks while keeping its own. That contract is what lets it run *after* construction — unlike the `iri` expansion, which must tell an authored value from a schema default and so has to run before one is applied.

## Two rules, replacing two lists

**Which classes carry it is read off the schema.** A class the schema gives an `iri` slot is a class whose records may name an entity elsewhere, so `hatch_build` makes `IriEnrichable` a base of it in both generated forms. Eleven classes; `LossFunction` inherits it. Nothing enumerates them — adding the slot is what makes a class's records enrichable.

**Which sources answer is read off the class.** `database` is generic; `ontology` is a `_from_ontology` a behaviour mixin defines, so a class reaches the ontology by *knowing how to*, not by being named in a table. The two are ordered rather than equal: the database is a local file whose content is ordered, and the ontology answers with an unordered set — a different parameter order per process.

```python
Coupling(iri="tvbo:NoSuchThing").enrich()   # LookupError — a pointer at nothing is a typo
Coupling(name="MyOwnCoupling").enrich()     # no-op — self-contained is the normal case
coupling.enrich(key="KuramotoCoupling")     # a network entry named for its role
```

## Never assign a container into a slot

`_gap_fill` mutates the container the class built, member by member. That is what a `JsonObj` is: the LinkML setter wrapping a plain Python container it was handed, after which the typed members inside stop reading as themselves. `experiment.py` already carried a five-line comment about it and an `object.__setattr__` to dodge the setter.

Which slots are keyed collections is read off the schema rather than sniffed from the value, so this holds on both generated forms and for an empty collection too. `JsonObj` is now read in exactly one place — `tvbo.utils.keyed_items` — and that arm goes when the dataclasses do.

## Removed

`use_ontology=`, `enrich_from_ontology`, `_populate_from_ontology` ×3, `_adopt_iri_entry`, `_schema_default`, `_load_coupling_from_database`, 90 lines of `populate_observation_from_iri`, and Coupling's `__post_init__` / `model_post_init` pair — which existed to guess after construction what only the dialect can still see. `from_file` / `from_string` also stop running `update_metadata` and `calculate_derived_parameters` a second time, after `cls(**data)` has already run them.

## One re-baselined record — the point, not a side effect

`Stimulation_Bayesian_Inference`'s `network.coupling.c_lin` grounds on `iri: tvbo:Linear` and declares `G: {value: 0.0}`. TVBO was serializing it back as a **copy of Linear** — `pre_expression`, `post_expression`, parameters `a`/`b` the author never wrote. A named record grounding on an `iri` is a definition, not a reference; that is the #97 rule, now reaching the generated class.

Nothing it computes changes: the runtime still fills it at experiment load (`pre=x_j`, params `G,b,a`), and the 1500-test codegen corpus is unchanged.

---

## Verification

| | |
|---|---|
| Golden corpora (codegen + database dump) | **1545 passed**, one reviewed re-baseline |
| Core-backend suite | 292 passed, 1 skipped |
| `tests/test_enrich.py` (new) | 17 passed |
| `tests/test_keyed_collections.py` (new) | 10 passed |
| ruff blocking subset | clean |

## Not in scope

- `network.coupling`'s `type:` field still goes through `populate_from_type`. It is really an alias for `iri`, but the loader keys the member as its `name` first, so the definition guard would block expansion — a schema-side fix.
- `SimulationExperiment.coupling` is `None` for `Stimulation_Bayesian_Inference` while `network.coupling` holds `c_lin`. Pre-existing, and codegen reads `network.coupling`; flagged rather than chased.

Parts 3 (one derived-parameter route) and 4 (the remaining `DynamicalSystem` methods) of #95 follow.
