### PR TITLE
ci: check the stacked-comment rule at the dev boundary only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,9 @@ jobs:
             - name: Prose — comments and docstrings (reporting)
               run: python scripts/check_prose.py || true
 
-            # Blocking: templates and config keep their backlog, but no PR may add to it.
+            # Blocking, and only at the dev boundary: every commit reaching main passed this check on its way into dev, so re-running it against main measures the whole accumulated backlog instead of what the PR adds.
             - name: Prose — no stacked '#' blocks added
+              if: github.base_ref != 'main'
               run: python scripts/check_prose.py --diff "origin/${{ github.base_ref || 'dev' }}"
 
             # mypy: type-check the source tree, non-blocking.


### PR DESCRIPTION
`Lint` fails on #62 (dev → main) with **611 stacked comment blocks added**, blocking the release PR.

## What went wrong

The blocking check compares against the PR's base branch. That is correct for a PR into `dev` and wrong for the release PR into `main`.

`dev` deliberately carries a backlog of stacked `#` blocks in templates and configuration — the rule reads *added lines* precisely so that new code cannot add one while the existing ones stay put, no clearing campaign required. Against `main`, everything `dev` has accumulated since the last release reads as "added by this PR", so #62 was effectively asked to clear the entire backlog before it could merge.

Measured both ways on the current `dev`:

| base | violations |
|---|---|
| `origin/dev` | **0** |
| `origin/main` | **611** (108 in `tvbo-tvboptim-experiment.py.mako` alone) |

## The fix

Skip the blocking check when the base is `main`. Every commit that reaches `main` has already passed it on the way into `dev`, so the second reading measures a backlog rather than a change, and cannot be satisfied by the PR being judged. The rule is enforced once, at the boundary where work actually enters.

The non-blocking whole-file prose report is untouched and still runs everywhere.

## Note

This is a defect in #98, which I wrote — the diff gate was designed against PRs into `dev` and never considered the integration PR.
